### PR TITLE
feat: add op-erigon

### DIFF
--- a/network_params.yaml
+++ b/network_params.yaml
@@ -2,6 +2,7 @@ optimism_package:
   participants:
     - el_type: op-geth
     - el_type: op-reth
+    - el_type: op-erigon
   additional_services:
    - blockscout
 ethereum_package:

--- a/src/el/op-erigon/op_erigon_launcher.star
+++ b/src/el/op-erigon/op_erigon_launcher.star
@@ -1,0 +1,230 @@
+shared_utils = import_module(
+    "github.com/ethpandaops/ethereum-package/src/shared_utils/shared_utils.star"
+)
+# input_parser = import_module("../../package_io/input_parser.star")
+el_context = import_module(
+    "github.com/ethpandaops/ethereum-package/src/el/el_context.star"
+)
+el_admin_node_info = import_module(
+    "github.com/ethpandaops/ethereum-package/src/el/el_admin_node_info.star"
+)
+
+node_metrics = import_module(
+    "github.com/ethpandaops/ethereum-package/src/node_metrics_info.star"
+)
+constants = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
+)
+
+RPC_PORT_NUM = 8545
+WS_PORT_NUM = 8546
+DISCOVERY_PORT_NUM = 30303
+ENGINE_RPC_PORT_NUM = 8551
+METRICS_PORT_NUM = 9001
+
+# The min/max CPU/memory that the execution node can use
+EXECUTION_MIN_CPU = 300
+EXECUTION_MIN_MEMORY = 512
+
+# Port IDs
+RPC_PORT_ID = "rpc"
+WS_PORT_ID = "ws"
+TCP_DISCOVERY_PORT_ID = "tcp-discovery"
+UDP_DISCOVERY_PORT_ID = "udp-discovery"
+ENGINE_RPC_PORT_ID = "engine-rpc"
+ENGINE_WS_PORT_ID = "engineWs"
+METRICS_PORT_ID = "metrics"
+
+METRICS_PATH = "/debug/metrics/prometheus"
+
+# The dirpath of the execution data directory on the client container
+EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER = "/data/op-erigon/execution-data"
+
+
+def get_used_ports(discovery_port=DISCOVERY_PORT_NUM):
+    used_ports = {
+        RPC_PORT_ID: shared_utils.new_port_spec(
+            RPC_PORT_NUM,
+            shared_utils.TCP_PROTOCOL,
+            shared_utils.HTTP_APPLICATION_PROTOCOL,
+        ),
+        WS_PORT_ID: shared_utils.new_port_spec(WS_PORT_NUM, shared_utils.TCP_PROTOCOL),
+        TCP_DISCOVERY_PORT_ID: shared_utils.new_port_spec(
+            discovery_port, shared_utils.TCP_PROTOCOL
+        ),
+        UDP_DISCOVERY_PORT_ID: shared_utils.new_port_spec(
+            discovery_port, shared_utils.UDP_PROTOCOL
+        ),
+        ENGINE_RPC_PORT_ID: shared_utils.new_port_spec(
+            ENGINE_RPC_PORT_NUM,
+            shared_utils.TCP_PROTOCOL,
+        ),
+        METRICS_PORT_ID: shared_utils.new_port_spec(
+            METRICS_PORT_NUM, shared_utils.TCP_PROTOCOL
+        ),
+    }
+    return used_ports
+
+
+ENTRYPOINT_ARGS = ["sh", "-c"]
+
+VERBOSITY_LEVELS = {
+    constants.GLOBAL_LOG_LEVEL.error: "1",
+    constants.GLOBAL_LOG_LEVEL.warn: "2",
+    constants.GLOBAL_LOG_LEVEL.info: "3",
+    constants.GLOBAL_LOG_LEVEL.debug: "4",
+    constants.GLOBAL_LOG_LEVEL.trace: "5",
+}
+
+def launch(
+    plan,
+    launcher,
+    service_name,
+    image,
+    existing_el_clients,
+    sequencer_enabled,
+    sequencer_context,
+):
+    network_name = shared_utils.get_network_name(launcher.network)
+
+    config = get_config(
+        plan,
+        launcher.el_cl_genesis_data,
+        launcher.jwt_file,
+        launcher.network,
+        launcher.network_id,
+        image,
+        service_name,
+        existing_el_clients,
+        sequencer_enabled,
+        sequencer_context,
+    )
+
+    service = plan.add_service(service_name, config)
+
+    enode, enr = el_admin_node_info.get_enode_enr_for_node(
+        plan, service_name, RPC_PORT_ID
+    )
+
+    metrics_url = "{0}:{1}".format(service.ip_address, METRICS_PORT_NUM)
+    erigon_metrics_info = node_metrics.new_node_metrics_info(
+        service_name, METRICS_PATH, metrics_url
+    )
+
+    http_url = "http://{0}:{1}".format(service.ip_address, RPC_PORT_NUM)
+
+    return el_context.new_el_context(
+        "op-erigon",
+        enr,
+        enode,
+        service.ip_address,
+        RPC_PORT_NUM,
+        WS_PORT_NUM,
+        ENGINE_RPC_PORT_NUM,
+        http_url,
+        service_name,
+        [erigon_metrics_info],
+    )
+
+
+def get_config(
+    plan,
+    el_cl_genesis_data,
+    jwt_file,
+    network,
+    network_id,
+    image,
+    service_name,
+    existing_el_clients,
+    sequencer_enabled,
+    sequencer_context,
+):
+    init_datadir_cmd_str = "erigon init --datadir={0} {1}".format(
+        EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER,
+        constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER + "/genesis.json",
+    )
+
+    discovery_port = DISCOVERY_PORT_NUM
+    used_ports = get_used_ports(discovery_port)
+
+    cmd = [
+        "erigon",
+        "--datadir=" + EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER,
+        "--networkid={0}".format(network_id),
+        "--http",
+        "--http.addr=0.0.0.0",
+        "--http.vhosts=*",
+        "--http.corsdomain=*",
+        "--http.api=admin,engine,net,eth,web3,debug",
+        "--ws",
+        "--ws.addr=0.0.0.0",
+        "--ws.port={0}".format(WS_PORT_NUM),
+        "--ws.api=admin,engine,net,eth,web3,debug",
+        "--ws.origins=*",
+        "--allow-insecure-unlock",
+        "--authrpc.port={0}".format(ENGINE_RPC_PORT_NUM),
+        "--authrpc.addr=0.0.0.0",
+        "--authrpc.vhosts=*",
+        "--authrpc.jwtsecret=" + constants.JWT_MOUNT_PATH_ON_CONTAINER,
+        "--nat=extip:" + constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+        "--rpc.allow-unprotected-txs",
+        "--metrics",
+        "--metrics.addr=0.0.0.0",
+        "--metrics.port={0}".format(METRICS_PORT_NUM),
+        "--discovery.port={0}".format(discovery_port),
+        "--port={0}".format(discovery_port),
+    ]
+
+    if not sequencer_enabled:
+        cmd.append(
+            "--rollup.sequencerhttp={0}".format(sequencer_context.beacon_http_url)
+        )
+
+    if len(existing_el_clients) > 0:
+        cmd.append(
+            "--bootnodes="
+            + ",".join(
+                [
+                    ctx.enode
+                    for ctx in existing_el_clients[: constants.MAX_ENODE_ENTRIES]
+                ]
+            )
+        )
+
+    cmd_str = " ".join(cmd)
+    if network not in constants.PUBLIC_NETWORKS:
+        subcommand_strs = [
+            init_datadir_cmd_str,
+            cmd_str,
+        ]
+        command_str = " && ".join(subcommand_strs)
+    else:
+        command_str = cmd_str
+
+    files = {
+        constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: el_cl_genesis_data,
+        constants.JWT_MOUNTPOINT_ON_CLIENTS: jwt_file,
+    }
+
+    return ServiceConfig(
+        image=image,
+        ports=used_ports,
+        cmd=[command_str],
+        files=files,
+        entrypoint=ENTRYPOINT_ARGS,
+        private_ip_address_placeholder=constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+    )
+
+
+def new_op_erigon_launcher(
+    el_cl_genesis_data,
+    jwt_file,
+    network,
+    network_id,
+):
+    return struct(
+        el_cl_genesis_data=el_cl_genesis_data,
+        jwt_file=jwt_file,
+        network=network,
+        network_id=network_id,
+    )

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -7,6 +7,7 @@ shared_utils = import_module(
 # EL
 op_geth = import_module("./el/op-geth/op_geth_launcher.star")
 op_reth = import_module("./el/op-reth/op_reth_launcher.star")
+op_erigon = import_module("./el/op-erigon/op_erigon_launcher.star")
 # CL
 op_node = import_module("./cl/op-node/op_node_launcher.star")
 
@@ -39,6 +40,15 @@ def launch(
                 network_params.network_id,
             ),
             "launch_method": op_reth.launch,
+        },
+        "op-erigon": {
+            "launcher": op_erigon.new_op_erigon_launcher(
+                el_cl_data,
+                jwt_file,
+                network_params.network,
+                network_params.network_id,
+            ),
+            "launch_method": op_erigon.launch,
         },
     }
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -5,6 +5,7 @@ ethereum_package_input_parser = import_module(
 DEFAULT_EL_IMAGES = {
     "op-geth": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:latest",
     "op-reth": "parithoshj/op-reth:latest",
+    "op-erigon": "testinprod/op-erigon:latest",
 }
 
 DEFAULT_CL_IMAGES = {


### PR DESCRIPTION
Resolves https://github.com/ethpandaops/optimism-package/issues/12

This PR adds op-erigon to the list of execution clients for optimism protocol.
Most of the configuration is same as op-geth and op-reth, except for erigon run flags and op-erigon's docker image. 