### PR TITLE
fix: Trust L1 RPC

### DIFF
--- a/src/cl/op-node/op_node_launcher.star
+++ b/src/cl/op-node/op_node_launcher.star
@@ -154,6 +154,7 @@ def get_beacon_config(
         "--l1={0}".format(l1_config_env_vars["L1_RPC_URL"]),
         "--l1.rpckind={0}".format(l1_config_env_vars["L1_RPC_KIND"]),
         "--l1.beacon={0}".format(l1_config_env_vars["CL_RPC_URL"]),
+        "--l1.trustrpc",
         "--p2p.advertise.ip=" + constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
         "--p2p.advertise.tcp={0}".format(BEACON_DISCOVERY_PORT_NUM),
         "--p2p.advertise.udp={0}".format(BEACON_DISCOVERY_PORT_NUM),


### PR DESCRIPTION
# What

This gets around the following error starting up `op-node`:
```
failed to fetch runtime config data" err="failed to fetch unsafe block signing address from system config: failed to fetch proof of storage slot 0x65a7ed542fb37fe237fdfbdd70b31598523fe5b32879e307bae27a0bd9581c08 at block 0x26af2a02dc48831d3d002bf3c064af37e769f05aa3a0dbfa70c4967ba7887ed8: eth_getProof is unimplemented for historical blocks
```

# Testing
A local l1, the neccassary deployments and config for an l2 and the l2 nodes starts with the following:

1. Checkout this branch and run 
```
kurtosis run path/to/optimism-package --args-file path/to/optimism-package/network_params.yaml
```
