### PR TITLE
chore: set proof window

### DIFF
--- a/src/el/op-reth/op_reth_launcher.star
+++ b/src/el/op-reth/op_reth_launcher.star
@@ -167,6 +167,7 @@ def get_config(
         "--metrics=0.0.0.0:{0}".format(METRICS_PORT_NUM),
         "--discovery.port={0}".format(discovery_port),
         "--port={0}".format(discovery_port),
+        "--rpc.eth-proof-window=302400",
     ]
 
     if not sequencer_enabled:


### PR DESCRIPTION
Currently `optimism_outputAtBlock` fails on op-reth because the proof window size defaults to 0. This sets it to 302400, which is roughly 1 week on a 2 second block time.