### PR TITLE
fix: handling of config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,13 @@ optimism_package:
         # Offset is in seconds
         interop_time_offset: ""
 
+        # Whether to fund dev accounts on L2
+        # Defaults to True
+        fund_dev_accounts: true
+
+        # The Docker image that should be used for the batcher; leave blank to use the default op-batcher image
+        batcher_image: ""
+
 
       # Additional services to run alongside the network
       # Defaults to []

--- a/README.md
+++ b/README.md
@@ -237,9 +237,13 @@ optimism_package:
         # Defaults to True
         fund_dev_accounts: true
 
+      # Default batcher configuration
+      batcher_params:
         # The Docker image that should be used for the batcher; leave blank to use the default op-batcher image
-        batcher_image: ""
+        image: ""
 
+        # A list of optional extra params that will be passed to the batcher container for modifying its behaviour
+        extra_params: []
 
       # Additional services to run alongside the network
       # Defaults to []

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -38,7 +38,9 @@ optimism_package:
         holocene_time_offset: ""
         interop_time_offset: ""
         fund_dev_accounts: true
-        batcher_image: ""
+      batcher_params:
+        image: ""
+        extra_params: []
       additional_services: []
   op_contract_deployer_params:
     image: mslipper/op-deployer:latest

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -37,6 +37,8 @@ optimism_package:
         granite_time_offset: ""
         holocene_time_offset: ""
         interop_time_offset: ""
+        fund_dev_accounts: true
+        batcher_image: ""
       additional_services: []
   op_contract_deployer_params:
     image: mslipper/op-deployer:latest

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -40,6 +40,7 @@ def launch(
     cl_context,
     l1_config_env_vars,
     gs_batcher_private_key,
+    batcher_params,
 ):
     batcher_service_name = "{0}".format(service_name)
 
@@ -51,6 +52,7 @@ def launch(
         cl_context,
         l1_config_env_vars,
         gs_batcher_private_key,
+        batcher_params,
     )
 
     batcher_service = plan.add_service(service_name, config)
@@ -71,6 +73,7 @@ def get_batcher_config(
     cl_context,
     l1_config_env_vars,
     gs_batcher_private_key,
+    batcher_params,
 ):
     cmd = [
         "op-batcher",
@@ -89,6 +92,8 @@ def get_batcher_config(
         "--private-key=" + gs_batcher_private_key,
         "--data-availability-type=blobs",
     ]
+
+    cmd += batcher_params.extra_params
 
     ports = get_used_ports()
     return ServiceConfig(

--- a/src/cl/hildr/hildr_launcher.star
+++ b/src/cl/hildr/hildr_launcher.star
@@ -196,6 +196,8 @@ def get_beacon_config(
             )
         )
 
+    cmd += participant.cl_extra_params
+
     files = {
         ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: launcher.deployment_output,
         ethereum_package_constants.JWT_MOUNTPOINT_ON_CLIENTS: launcher.jwt_file,

--- a/src/cl/op-node/op_node_launcher.star
+++ b/src/cl/op-node/op_node_launcher.star
@@ -205,6 +205,8 @@ def get_beacon_config(
             )
         )
 
+    cmd += participant.cl_extra_params
+
     files = {
         ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: launcher.deployment_output,
         ethereum_package_constants.JWT_MOUNTPOINT_ON_CLIENTS: launcher.jwt_file,

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -40,15 +40,31 @@ def deploy_contracts(
         ),
     )
 
-    intent_updates = [
-        ("string", "contractArtifactsURL", optimism_args.op_contract_deployer_params.artifacts_url),
-    ] + [
-        ("int", "chains.[{0}].deployOverrides.l2BlockTime".format(index), str(chain.network_params.seconds_per_slot))
-        for index, chain in enumerate(optimism_args.chains)
-    ] + [
-        ("bool", "chains.[{0}].deployOverrides.fundDevAccounts".format(index), "true" if chain.network_params.fund_dev_accounts else "false")
-        for index, chain in enumerate(optimism_args.chains)
-    ]
+    intent_updates = (
+        [
+            (
+                "string",
+                "contractArtifactsURL",
+                optimism_args.op_contract_deployer_params.artifacts_url,
+            ),
+        ]
+        + [
+            (
+                "int",
+                "chains.[{0}].deployOverrides.l2BlockTime".format(index),
+                str(chain.network_params.seconds_per_slot),
+            )
+            for index, chain in enumerate(optimism_args.chains)
+        ]
+        + [
+            (
+                "bool",
+                "chains.[{0}].deployOverrides.fundDevAccounts".format(index),
+                "true" if chain.network_params.fund_dev_accounts else "false",
+            )
+            for index, chain in enumerate(optimism_args.chains)
+        ]
+    )
 
     op_deployer_configure = plan.run_sh(
         name="op-deployer-configure",

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -40,6 +40,16 @@ def deploy_contracts(
         ),
     )
 
+    intent_updates = [
+        ("string", "contractArtifactsURL", optimism_args.op_contract_deployer_params.artifacts_url),
+    ] + [
+        ("int", "chains.[{0}].deployOverrides.l2BlockTime".format(index), str(chain.network_params.seconds_per_slot))
+        for index, chain in enumerate(optimism_args.chains)
+    ] + [
+        ("bool", "chains.[{0}].deployOverrides.fundDevAccounts".format(index), "true" if chain.network_params.fund_dev_accounts else "false")
+        for index, chain in enumerate(optimism_args.chains)
+    ]
+
     op_deployer_configure = plan.run_sh(
         name="op-deployer-configure",
         description="Configure L2 contract deployments",
@@ -55,10 +65,10 @@ def deploy_contracts(
         },
         run=" && ".join(
             [
-                "cat /network-data/intent.toml | dasel put -r toml -t string -v '{0}' 'contractArtifactsURL' > /network-data/.intent.toml".format(
-                    optimism_args.op_contract_deployer_params.artifacts_url
-                ),
-                "mv /network-data/.intent.toml /network-data/intent.toml",
+                "cat /network-data/intent.toml | dasel put -r toml -t {0} -v '{2}' '{1}' -o /network-data/intent.toml".format(
+                    t, k, v
+                )
+                for t, k, v in intent_updates
             ]
         ),
     )

--- a/src/el/op-besu/op_besu_launcher.star
+++ b/src/el/op-besu/op_besu_launcher.star
@@ -222,6 +222,7 @@ def get_config(
             )
         )
 
+    cmd += participant.el_extra_params
     cmd_str = " ".join(cmd)
 
     files = {

--- a/src/el/op-erigon/op_erigon_launcher.star
+++ b/src/el/op-erigon/op_erigon_launcher.star
@@ -211,6 +211,7 @@ def get_config(
             )
         )
 
+    cmd += participant.el_extra_params
     cmd_str = " ".join(cmd)
     if launcher.network not in ethereum_package_constants.PUBLIC_NETWORKS:
         subcommand_strs = [

--- a/src/el/op-geth/op_geth_launcher.star
+++ b/src/el/op-geth/op_geth_launcher.star
@@ -226,6 +226,7 @@ def get_config(
             )
         )
 
+    cmd += participant.el_extra_params
     cmd_str = " ".join(cmd)
     if launcher.network not in ethereum_package_constants.PUBLIC_NETWORKS:
         subcommand_strs = [

--- a/src/el/op-nethermind/op_nethermind_launcher.star
+++ b/src/el/op-nethermind/op_nethermind_launcher.star
@@ -225,6 +225,8 @@ def get_config(
                 constants.EL_TYPE.op_nethermind + "_volume_size"
             ],
         )
+
+    cmd += participant.el_extra_params
     env_vars = participant.el_extra_env_vars
     config_args = {
         "image": participant.el_image,

--- a/src/el/op-reth/op_reth_launcher.star
+++ b/src/el/op-reth/op_reth_launcher.star
@@ -223,6 +223,7 @@ def get_config(
             ],
         )
 
+    cmd += participant.el_extra_params
     env_vars = participant.el_extra_env_vars
     config_args = {
         "image": participant.el_image,

--- a/src/l2.star
+++ b/src/l2.star
@@ -22,6 +22,7 @@ def launch_l2(
     persistent,
 ):
     network_params = l2_args.network_params
+    batcher_params = l2_args.batcher_params
 
     plan.print("Deploying L2 with name {0}".format(network_params.name))
     jwt_file = plan.upload_files(
@@ -34,6 +35,7 @@ def launch_l2(
         l2_args.participants,
         jwt_file,
         network_params,
+        batcher_params,
         deployment_output,
         l1_config,
         l2_services_suffix,

--- a/src/l2.star
+++ b/src/l2.star
@@ -23,10 +23,6 @@ def launch_l2(
 ):
     network_params = l2_args.network_params
 
-    l2_config_env_vars = {}
-    l2_config_env_vars["L2_CHAIN_ID"] = str(network_params.network_id)
-    l2_config_env_vars["L2_BLOCK_TIME"] = str(network_params.seconds_per_slot)
-
     plan.print("Deploying L2 with name {0}".format(network_params.name))
     jwt_file = plan.upload_files(
         src=ethereum_package_static_files.JWT_PATH_FILEPATH,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -86,6 +86,8 @@ def input_parser(plan, input_args):
                         "holocene_time_offset"
                     ],
                     interop_time_offset=result["network_params"]["interop_time_offset"],
+                    fund_dev_accounts=result["network_params"]["fund_dev_accounts"],
+                    batcher_image=result["network_params"]["batcher_image"],
                 ),
                 additional_services=result["additional_services"],
             )
@@ -202,6 +204,8 @@ def default_network_params():
         "granite_time_offset": None,
         "holocene_time_offset": None,
         "interop_time_offset": None,
+        "fund_dev_accounts": True,
+        "batcher_image": "",
     }
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -25,11 +25,6 @@ DEFAULT_PROPOSER_IMAGES = {
     "op-proposer": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:develop",
 }
 
-ATTR_TO_BE_SKIPPED_AT_ROOT = (
-    "network_params",
-    "participants",
-)
-
 DEFAULT_ADDITIONAL_SERVICES = []
 
 
@@ -87,7 +82,10 @@ def input_parser(plan, input_args):
                     ],
                     interop_time_offset=result["network_params"]["interop_time_offset"],
                     fund_dev_accounts=result["network_params"]["fund_dev_accounts"],
-                    batcher_image=result["network_params"]["batcher_image"],
+                ),
+                batcher_params=struct(
+                    image=result["batcher_params"]["image"],
+                    extra_params=result["batcher_params"]["extra_params"],
                 ),
                 additional_services=result["additional_services"],
             )
@@ -113,6 +111,9 @@ def parse_network_params(plan, input_args):
     for chain in input_args.get("chains", default_chains()):
         network_params = default_network_params()
         network_params.update(chain.get("network_params", {}))
+
+        batcher_params = default_batcher_params()
+        batcher_params.update(chain.get("batcher_params", {}))
 
         network_name = network_params["name"]
         network_id = network_params["network_id"]
@@ -157,6 +158,7 @@ def parse_network_params(plan, input_args):
         result = {
             "participants": participants,
             "network_params": network_params,
+            "batcher_params": batcher_params,
             "additional_services": chain.get(
                 "additional_services", DEFAULT_ADDITIONAL_SERVICES
             ),
@@ -189,6 +191,7 @@ def default_chains():
         {
             "participants": [default_participant()],
             "network_params": default_network_params(),
+            "batcher_params": default_batcher_params(),
             "additional_services": DEFAULT_ADDITIONAL_SERVICES,
         }
     ]
@@ -205,7 +208,12 @@ def default_network_params():
         "holocene_time_offset": None,
         "interop_time_offset": None,
         "fund_dev_accounts": True,
-        "batcher_image": "",
+    }
+
+def default_batcher_params():
+    return {
+        "image": "",
+        "extra_params": [],
     }
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -210,6 +210,7 @@ def default_network_params():
         "fund_dev_accounts": True,
     }
 
+
 def default_batcher_params():
     return {
         "image": "",

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -41,8 +41,8 @@ SUBCATEGORY_PARAMS = {
         "holocene_time_offset",
         "interop_time_offset",
         "fund_dev_accounts",
-        "batcher_image",
     ],
+    "batcher_params": ["image", "extra_params"],
 }
 
 OP_CONTRACT_DEPLOYER_PARAMS = [

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -40,6 +40,8 @@ SUBCATEGORY_PARAMS = {
         "granite_time_offset",
         "holocene_time_offset",
         "interop_time_offset",
+        "fund_dev_accounts",
+        "batcher_image",
     ],
 }
 

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -11,6 +11,7 @@ def launch_participant_network(
     participants,
     jwt_file,
     network_params,
+    batcher_params,
     deployment_output,
     l1_config_env_vars,
     l2_services_suffix,
@@ -66,7 +67,7 @@ def launch_participant_network(
         ".privateKey",
     )
 
-    op_batcher_image = network_params.batcher_image if network_params.batcher_image != "" else input_parser.DEFAULT_BATCHER_IMAGES["op-batcher"]
+    op_batcher_image = batcher_params.image if batcher_params.image != "" else input_parser.DEFAULT_BATCHER_IMAGES["op-batcher"]
 
     op_batcher_launcher.launch(
         plan,
@@ -76,6 +77,7 @@ def launch_participant_network(
         all_cl_contexts[0],
         l1_config_env_vars,
         batcher_key,
+        batcher_params,
     )
 
     # The OP Stack don't run the proposer anymore, it has been replaced with the challenger

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -66,10 +66,12 @@ def launch_participant_network(
         ".privateKey",
     )
 
+    op_batcher_image = network_params.batcher_image if network_params.batcher_image != "" else input_parser.DEFAULT_BATCHER_IMAGES["op-batcher"]
+
     op_batcher_launcher.launch(
         plan,
         "op-batcher-{0}".format(l2_services_suffix),
-        input_parser.DEFAULT_BATCHER_IMAGES["op-batcher"],
+        op_batcher_image,
         all_el_contexts[0],
         all_cl_contexts[0],
         l1_config_env_vars,

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -67,7 +67,11 @@ def launch_participant_network(
         ".privateKey",
     )
 
-    op_batcher_image = batcher_params.image if batcher_params.image != "" else input_parser.DEFAULT_BATCHER_IMAGES["op-batcher"]
+    op_batcher_image = (
+        batcher_params.image
+        if batcher_params.image != ""
+        else input_parser.DEFAULT_BATCHER_IMAGES["op-batcher"]
+    )
 
     op_batcher_launcher.launch(
         plan,


### PR DESCRIPTION
This PR adds 2 configuration options and fixes handling of existing ones:
- `fund_dev_accounts` option is added to `network_params`, allowing to configure whether dev accounts should be funded on L2. In one of recent updates they stopped being funded by default, this PR changes it, let me know if this is undesired
- adds `batcher_image` option allowing to configure custom op-batcher image
- fixes handling of `el_extra_params`, right now this argument is not respected
- fixes handling of `seconds_per_slot`, right now this argument is not respected

Also it seems that `count` key for participants is no more respected. Is this intentional?