### PR TITLE
Add Isthmus fork and set deployOverrides for hard fork activations

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,11 @@ optimism_package:
         # Offset is in seconds
         holocene_time_offset: ""
 
+        # Isthmus fork
+        # Defaults to None - not activated - decimal value
+        # Offset is in seconds
+        isthmus_time_offset: ""
+
         # Interop fork
         # Defaults to None - not activated - decimal value
         # Offset is in seconds

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -64,6 +64,38 @@ def deploy_contracts(
             )
             for index, chain in enumerate(optimism_args.chains)
         ]
+        + [
+            (
+                "int",
+                "chains.[{0}].deployOverrides.l2GenesisFjordTimeOffset".format(index),
+                str(chain.network_params.fjord_time_offset)
+            )
+            for index, chain in enumerate(optimism_args.chains)
+        ]
+        + [
+            (
+                "int",
+                "chains.[{0}].deployOverrides.l2GenesisGraniteTimeOffset".format(index),
+                str(chain.network_params.granite_time_offset)
+            )
+            for index, chain in enumerate(optimism_args.chains)
+        ]
+        + [
+            (
+                "int",
+                "chains.[{0}].deployOverrides.l2GenesisHoloceneTimeOffset".format(index),
+                str(chain.network_params.holocene_time_offset)
+            )
+            for index, chain in enumerate(optimism_args.chains)
+        ]
+        + [
+            (
+                "int",
+                "chains.[{0}].deployOverrides.l2GenesisIsthmusTimeOffset".format(index),
+                str(chain.network_params.isthmus_time_offset)
+            )
+            for index, chain in enumerate(optimism_args.chains)
+        ]
     )
 
     op_deployer_configure = plan.run_sh(

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -80,6 +80,9 @@ def input_parser(plan, input_args):
                     holocene_time_offset=result["network_params"][
                         "holocene_time_offset"
                     ],
+                    isthmus_time_offset=result["network_params"][
+                        "isthmus_time_offset"
+                    ],
                     interop_time_offset=result["network_params"]["interop_time_offset"],
                     fund_dev_accounts=result["network_params"]["fund_dev_accounts"],
                 ),
@@ -206,6 +209,7 @@ def default_network_params():
         "fjord_time_offset": 0,
         "granite_time_offset": None,
         "holocene_time_offset": None,
+        "isthmus_time_offset": None,
         "interop_time_offset": None,
         "fund_dev_accounts": True,
     }

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -39,6 +39,7 @@ SUBCATEGORY_PARAMS = {
         "fjord_time_offset",
         "granite_time_offset",
         "holocene_time_offset",
+        "isthmus_time_offset",
         "interop_time_offset",
         "fund_dev_accounts",
     ],


### PR DESCRIPTION
* Adds Isthmus hard fork activation
* Reads fork activation blocks from `chain.network_params` and sets `deployOverrides` for `op-deployer` to consume.