### PR TITLE
fix: sequencer forwarding

### DIFF
--- a/src/el/op-besu/op_besu_launcher.star
+++ b/src/el/op-besu/op_besu_launcher.star
@@ -206,7 +206,7 @@ def get_config(
 
     # if not sequencer_enabled:
     #     cmd.append(
-    #         "--rollup.sequencerhttp={0}".format(sequencer_context.beacon_http_url)
+    #         "--rollup.sequencerhttp={0}".format(sequencer_context.rpc_http_url)
     #     )
 
     if len(existing_el_clients) > 0:

--- a/src/el/op-erigon/op_erigon_launcher.star
+++ b/src/el/op-erigon/op_erigon_launcher.star
@@ -194,9 +194,7 @@ def get_config(
     ]
 
     if not sequencer_enabled:
-        cmd.append(
-            "--rollup.sequencerhttp={0}".format(sequencer_context.beacon_http_url)
-        )
+        cmd.append("--rollup.sequencerhttp={0}".format(sequencer_context.rpc_http_url))
 
     if len(existing_el_clients) > 0:
         cmd.append(

--- a/src/el/op-geth/op_geth_launcher.star
+++ b/src/el/op-geth/op_geth_launcher.star
@@ -209,9 +209,7 @@ def get_config(
     ]
 
     if not sequencer_enabled:
-        cmd.append(
-            "--rollup.sequencerhttp={0}".format(sequencer_context.beacon_http_url)
-        )
+        cmd.append("--rollup.sequencerhttp={0}".format(sequencer_context.rpc_http_url))
 
     if len(existing_el_clients) > 0:
         cmd.append(

--- a/src/el/op-nethermind/op_nethermind_launcher.star
+++ b/src/el/op-nethermind/op_nethermind_launcher.star
@@ -187,9 +187,7 @@ def get_config(
         "--Metrics.ExposeHost=0.0.0.0",
     ]
     if not sequencer_enabled:
-        cmd.append(
-            "--Optimism.SequencerUrl={0}".format(sequencer_context.beacon_http_url)
-        )
+        cmd.append("--Optimism.SequencerUrl={0}".format(sequencer_context.rpc_http_url))
 
     if len(existing_el_clients) > 0:
         cmd.append(

--- a/src/el/op-reth/op_reth_launcher.star
+++ b/src/el/op-reth/op_reth_launcher.star
@@ -192,9 +192,7 @@ def get_config(
     ]
 
     if not sequencer_enabled:
-        cmd.append(
-            "--rollup.sequencer-http={0}".format(sequencer_context.beacon_http_url)
-        )
+        cmd.append("--rollup.sequencer-http={0}".format(sequencer_context.rpc_http_url))
 
     if len(existing_el_clients) > 0:
         cmd.append(

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -149,7 +149,7 @@ def launch(
             index_str, cl_type, el_type, l2_services_suffix
         )
 
-        sequencer_context = all_cl_contexts[0] if len(all_cl_contexts) > 0 else None
+        sequencer_context = all_el_contexts[0] if len(all_el_contexts) > 0 else None
         el_context = el_launch_method(
             plan,
             el_launcher,


### PR DESCRIPTION
## Description

Closes #86 

Configure sequencer forwarding to send transactions to the sequencer EL RPC endpoint instead of the CL RPC endpoint.

Nightly workflow: https://github.com/leovct/optimism-package/actions/runs/12199976016

## Test

```bash
kurtosis run --enclave op --args-file .github/tests/op-geth.yaml .

export ETH_RPC_URL=$(kurtosis port print op op-el-2-op-geth-hildr-op-kurtosis rpc)
curl \
  --request POST \
  --url $ETH_RPC_URL \
  --header 'accept: application/json' \
  --header 'content-type: application/json' \
  --data '{"id":0,"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0x02f8718320d5e480018476bb8201825208940000000000000000000000000000000000000000880de0b6b3a764000080c001a09322fe55a0a429fc26fc3703fea0e44298e28ac884afa448f1f9dd0ea6ac080ca07650448283d4afd481d7b690bb5251c75a7aca3a6e41d06cab49b0727218d074"]}'
```

Without the fix:

```bash
{"jsonrpc":"2.0","id":0,"error":{"code":-32601,"message":"the method eth_sendRawTransaction does not exist/is not available"}}
```

With the fix:

```bash
{"jsonrpc":"2.0","id":0,"result":"0x90dc459ccc7429d1cdef3c3e4e7caa069142312b65bfe45cd14b4ff8f6dcd803"}
```
