### PR TITLE
feat: adds op-proposer support

### DIFF
--- a/main.star
+++ b/main.star
@@ -82,9 +82,10 @@ def run(plan, args):
         l1_network,
     )
 
-    for chain in optimism_args_with_right_defaults.chains:
+    for l2_num, chain in enumerate(optimism_args_with_right_defaults.chains):
         l2_launcher.launch_l2(
             plan,
+            l2_num,
             chain.network_params.name,
             chain,
             deployment_output,
@@ -101,9 +102,11 @@ def run(plan, args):
     # Deploy L2s
     plan.print("Deploying a local L2")
     if type(optimism_args) == "dict":
+        l2_num = 0
         l2_services_suffix = ""  # no suffix if one l2
         l2_launcher.launch_l2(
             plan,
+            l2_num,
             l2_services_suffix,
             optimism_args,
             l1_config_env_vars,
@@ -138,6 +141,7 @@ def run(plan, args):
             l2_services_suffix = "-{0}".format(name)
             l2_launcher.launch_l2(
                 plan,
+                l2_num,
                 l2_services_suffix,
                 l2_args,
                 l1_config_env_vars,

--- a/src/l2.star
+++ b/src/l2.star
@@ -10,6 +10,7 @@ util = import_module("./util.star")
 
 def launch_l2(
     plan,
+    l2_num,
     l2_services_suffix,
     l2_args,
     deployment_output,
@@ -23,6 +24,7 @@ def launch_l2(
 ):
     network_params = l2_args.network_params
     batcher_params = l2_args.batcher_params
+    proposer_params = l2_args.proposer_params
     mev_params = l2_args.mev_params
 
     plan.print("Deploying L2 with name {0}".format(network_params.name))
@@ -37,9 +39,11 @@ def launch_l2(
         jwt_file,
         network_params,
         batcher_params,
+        proposer_params,
         mev_params,
         deployment_output,
         l1_config,
+        l2_num,
         l2_services_suffix,
         global_log_level,
         global_node_selectors,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -108,6 +108,12 @@ def input_parser(plan, input_args):
                     image=result["batcher_params"]["image"],
                     extra_params=result["batcher_params"]["extra_params"],
                 ),
+                proposer_params=struct(
+                    image=result["proposer_params"]["image"],
+                    extra_params=result["proposer_params"]["extra_params"],
+                    game_type=result["proposer_params"]["game_type"],
+                    proposal_interval=result["proposer_params"]["proposal_interval"],
+                ),
                 mev_params=struct(
                     rollup_boost_image=result["mev_params"]["rollup_boost_image"],
                     builder_host=result["mev_params"]["builder_host"],
@@ -145,6 +151,9 @@ def parse_network_params(plan, input_args):
 
         batcher_params = default_batcher_params()
         batcher_params.update(chain.get("batcher_params", {}))
+
+        proposer_params = default_proposer_params()
+        proposer_params.update(chain.get("proposer_params", {}))
 
         mev_params = default_mev_params()
         mev_params.update(chain.get("mev_params", {}))
@@ -221,6 +230,7 @@ def parse_network_params(plan, input_args):
             "participants": participants,
             "network_params": network_params,
             "batcher_params": batcher_params,
+            "proposer_params": proposer_params,
             "mev_params": mev_params,
             "additional_services": chain.get(
                 "additional_services", DEFAULT_ADDITIONAL_SERVICES
@@ -263,6 +273,7 @@ def default_chains():
             "participants": [default_participant()],
             "network_params": default_network_params(),
             "batcher_params": default_batcher_params(),
+            "proposer_params": default_proposer_params(),
             "mev_params": default_mev_params(),
             "additional_services": DEFAULT_ADDITIONAL_SERVICES,
         }
@@ -288,6 +299,15 @@ def default_batcher_params():
     return {
         "image": "",
         "extra_params": [],
+    }
+
+
+def default_proposer_params():
+    return {
+        "image": "",
+        "extra_params": [],
+        "game_type": 1,
+        "proposal_interval": "10m",
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -48,6 +48,7 @@ SUBCATEGORY_PARAMS = {
         "fund_dev_accounts",
     ],
     "batcher_params": ["image", "extra_params"],
+    "proposer_params": ["image", "extra_params", "game_type", "proposal_interval"],
     "mev_params": ["rollup_boost_image", "builder_host", "builder_port"],
 }
 

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -39,7 +39,8 @@ def launch(
     cl_context,
     l1_config_env_vars,
     gs_proposer_private_key,
-    l2oo_address,
+    game_factory_address,
+    proposer_params,
 ):
     proposer_service_name = "{0}".format(service_name)
 
@@ -50,7 +51,8 @@ def launch(
         cl_context,
         l1_config_env_vars,
         gs_proposer_private_key,
-        l2oo_address,
+        game_factory_address,
+        proposer_params,
     )
 
     proposer_service = plan.add_service(service_name, config)
@@ -70,17 +72,24 @@ def get_proposer_config(
     cl_context,
     l1_config_env_vars,
     gs_proposer_private_key,
-    l2oo_address,
+    game_factory_address,
+    proposer_params,
 ):
     cmd = [
         "op-proposer",
         "--poll-interval=12s",
         "--rpc.port=" + str(PROPOSER_HTTP_PORT_NUM),
         "--rollup-rpc=" + cl_context.beacon_http_url,
-        "--l2oo-address=" + str(l2oo_address),
+        "--game-factory-address=" + str(game_factory_address),
         "--private-key=" + gs_proposer_private_key,
         "--l1-eth-rpc=" + l1_config_env_vars["L1_RPC_URL"],
+        "--allow-non-finalized=true",
+        "--game-type={0}".format(proposer_params.game_type),
+        "--proposal-interval=" + proposer_params.proposal_interval,
+        "--wait-node-sync=true",
     ]
+
+    cmd += proposer_params.extra_params
 
     ports = get_used_ports()
     return ServiceConfig(


### PR DESCRIPTION
**Description**

Adds op-proposer support back in preparation for adding op-challenger support. We need proposer to make proposals to test challenger functionality.

The launcher supports a few config params:
```
{
  "image": "",
  "extra_params": [],
  "game_type": 1,
  "proposal_interval": "10m",
}
```

**Changes**
* Adds an l2_num param to l2, network participant launchers so we can index into the deployment state to get per-chain addresses
* Makes proposer parameters consistent with batcher
* Updates proposer to use dispute game factory