### PR TITLE
handle op-deployer `--intent-config-type custom`

### DIFF
--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -104,6 +104,12 @@ def input_parser(plan, input_args):
                     interop_time_offset=result["network_params"]["interop_time_offset"],
                     fund_dev_accounts=result["network_params"]["fund_dev_accounts"],
                 ),
+                vaults_params=struct(
+                    base_fee_vault_recipient=result["vaults_params"]["base_fee_vault_recipient"],
+                    l1_fee_vault_recipient=result["vaults_params"]["l1_fee_vault_recipient"],
+                    sequencer_fee_vault_recipient=result["vaults_params"]["sequencer_fee_vault_recipient"],
+                    operator_fee_vault_recipient=result["vaults_params"]["operator_fee_vault_recipient"],
+                ),
                 batcher_params=struct(
                     image=result["batcher_params"]["image"],
                     extra_params=result["batcher_params"]["extra_params"],
@@ -112,6 +118,11 @@ def input_parser(plan, input_args):
                     rollup_boost_image=result["mev_params"]["rollup_boost_image"],
                     builder_host=result["mev_params"]["builder_host"],
                     builder_port=result["mev_params"]["builder_port"],
+                ),
+                eip1559_params=struct(
+                    denominator_canyon=result["eip1559_params"]["denominator_canyon"],
+                    denominator=result["eip1559_params"]["denominator"],
+                    elasticity=result["eip1559_params"]["elasticity"],
                 ),
                 additional_services=result["additional_services"],
             )
@@ -125,6 +136,11 @@ def input_parser(plan, input_args):
             l2_artifacts_locator=results["op_contract_deployer_params"][
                 "l2_artifacts_locator"
             ],
+            proxyAdminOwner=results["op_contract_deployer_params"]["proxyAdminOwner"],
+            protocolVersionsOwner=results["op_contract_deployer_params"][
+                "protocolVersionsOwner"
+            ],
+            guardian=results["op_contract_deployer_params"]["guardian"],
         ),
         global_log_level=results["global_log_level"],
         global_node_selectors=results["global_node_selectors"],
@@ -148,6 +164,12 @@ def parse_network_params(plan, input_args):
 
         mev_params = default_mev_params()
         mev_params.update(chain.get("mev_params", {}))
+
+        eip1559_params = default_eip1559_params()
+        eip1559_params.update(chain.get("eip1559_params", {}))
+
+        vaults_params = default_vaults_params()
+        vaults_params.update(chain.get("vaults_params", {}))
 
         network_name = network_params["name"]
         network_id = network_params["network_id"]
@@ -222,6 +244,8 @@ def parse_network_params(plan, input_args):
             "network_params": network_params,
             "batcher_params": batcher_params,
             "mev_params": mev_params,
+            "eip1559_params": eip1559_params,
+            "vaults_params": vaults_params,
             "additional_services": chain.get(
                 "additional_services", DEFAULT_ADDITIONAL_SERVICES
             ),
@@ -256,6 +280,20 @@ def default_mev_params():
         "builder_port": "",
     }
 
+def default_eip1559_params():
+    return {
+        "denominator_canyon": "",
+        "denominator": "",
+        "elasticity": "",
+    }
+
+def default_vaults_params():
+    return {
+        "base_fee_vault_recipient": "",
+        "l1_fee_vault_recipient": "",
+        "sequencer_fee_vault_recipient": "",
+        "operator_fee_vault_recipient": "",
+    }
 
 def default_chains():
     return [
@@ -264,6 +302,8 @@ def default_chains():
             "network_params": default_network_params(),
             "batcher_params": default_batcher_params(),
             "mev_params": default_mev_params(),
+            "eip1559_params": default_eip1559_params(),
+            "vaults_params": default_vaults_params(),
             "additional_services": DEFAULT_ADDITIONAL_SERVICES,
         }
     ]

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -49,12 +49,22 @@ SUBCATEGORY_PARAMS = {
     ],
     "batcher_params": ["image", "extra_params"],
     "mev_params": ["rollup_boost_image", "builder_host", "builder_port"],
+    "eip1559_params": ["denominator_canyon", "denominator", "elasticity"],
+    "vaults_params": [
+        "base_fee_vault_recipient",
+        "l1_fee_vault_recipient",
+        "sequencer_fee_vault_recipient",
+        "operator_fee_vault_recipient",
+    ],
 }
 
 OP_CONTRACT_DEPLOYER_PARAMS = [
     "image",
     "l1_artifacts_locator",
     "l2_artifacts_locator",
+    "proxyAdminOwner",
+    "protocolVersionsOwner",
+    "guardian",
 ]
 
 ADDITIONAL_SERVICES_PARAMS = [

--- a/static_files/scripts/fund.sh
+++ b/static_files/scripts/fund.sh
@@ -7,7 +7,7 @@ export ETH_RPC_URL="$L1_RPC_URL"
 addr=$(cast wallet address "$PRIVATE_KEY")
 nonce=$(cast nonce "$addr")
 mnemonic="test test test test test test test test test test test junk"
-roles=("proposer" "batcher" "sequencer" "challenger" "l2ProxyAdmin" "l1ProxyAdmin" "baseFeeVaultRecipient" "l1FeeVaultRecipient" "sequencerFeeVaultRecipient" "systemConfigOwner")
+roles=("proposer" "batcher" "sequencer" "challenger" "l2ProxyAdmin" "l1ProxyAdmin" "baseFeeVaultRecipient" "l1FeeVaultRecipient" "operatorFeeVaultRecipient" "sequencerFeeVaultRecipient" "systemConfigOwner" "unsafeBlockSigner")
 
 IFS=',';read -r -a chain_ids <<< "$1"
 


### PR DESCRIPTION
I wanted to deploy a devnet with my own `op-deployer` version that happen to have the `--intent-config-type` arg.

So, with this version, omitting `--intent-config-type` default to `standard` that work only for maimmet and sepolia, and adding `--intent-config-type custom` results with an incomplete `intent.toml`.

In this PR I moved the `fund.sh` execution at the beginning of contract deployment in order to have access to needed accounts addresses and use that to fill `intent.toml`.