### PR TITLE
fix: set useInterop flag properly

### DIFF
--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -92,6 +92,11 @@ def deploy_contracts(plan, priv_key, l1_config_env_vars, optimism_args, l1_netwo
 
     intent_updates = [
         (
+            "bool",
+            "useInterop",
+            optimism_args.interop.enabled,
+        ),
+        (
             "string",
             "l1ContractsLocator",
             optimism_args.op_contract_deployer_params.l1_artifacts_locator,


### PR DESCRIPTION
Now that we have a top-level interop.enabled configuration flag, we
need to make sure op-deployer is configured accordingly.
