### PR TITLE
fix: stop pointing op-node to op-supervisor

### DIFF
--- a/src/cl/op-node/op_node_launcher.star
+++ b/src/cl/op-node/op_node_launcher.star
@@ -241,7 +241,7 @@ def get_beacon_config(
 
         env_vars.update(
             {
-                "OP_NODE_INTEROP_SUPERVISOR": interop_constants.SUPERVISOR_ENDPOINT,
+                # "OP_NODE_INTEROP_SUPERVISOR": interop_constants.SUPERVISOR_ENDPOINT,
                 "OP_NODE_INTEROP_RPC_ADDR": "0.0.0.0",
                 "OP_NODE_INTEROP_RPC_PORT": str(interop_constants.INTEROP_WS_PORT_NUM),
                 "OP_NODE_INTEROP_JWT_SECRET": ethereum_package_constants.JWT_MOUNT_PATH_ON_CONTAINER,


### PR DESCRIPTION
op-node pointing to supervisor is now a configuration error, as per https://github.com/ethereum-optimism/optimism/pull/13406