### PR TITLE
fix: repair supervisor->node cnx

### DIFF
--- a/src/interop/op-supervisor/op_supervisor_launcher.star
+++ b/src/interop/op-supervisor/op_supervisor_launcher.star
@@ -79,7 +79,7 @@ def get_supervisor_config(
             "OP_SUPERVISOR_L1_RPC": l1_config_env_vars["L1_RPC_URL"],
             "OP_SUPERVISOR_L2_CONSENSUS_NODES": ",".join(
                 [
-                    "http://{0}:{1}".format(
+                    "ws://{0}:{1}".format(
                         participant.cl_context.ip_addr,
                         interop_constants.INTEROP_WS_PORT_NUM,
                     )


### PR DESCRIPTION
This change is a workaround, considering that the http fallback should
work, but it's probably a better default anyway.

Main issue is tracked at:
https://github.com/ethereum-optimism/optimism/issues/13624
