### PR TITLE
fix: remove some UUOC

### DIFF
--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -201,7 +201,7 @@ def deploy_contracts(plan, priv_key, l1_config_env_vars, optimism_args, l1_netwo
         },
         run=" && ".join(
             [
-                "cat /network-data/intent.toml | dasel put -r toml -t {0} -v {2} '{1}' -o /network-data/intent.toml".format(
+                "dasel put -r toml -t {0} -v {2} '{1}' -o /network-data/intent.toml < /network-data/intent.toml".format(
                     t, k, v
                 )
                 for t, k, v in intent_updates
@@ -258,7 +258,7 @@ def deploy_contracts(plan, priv_key, l1_config_env_vars, optimism_args, l1_netwo
                 "/network-data": op_deployer_output.files_artifacts[0],
                 "/fund-script": fund_script_artifact,
             },
-            run='cat "/network-data/genesis-$CHAIN_ID.json" | jq --from-file /fund-script/gen2spec.jq > "/network-data/chainspec-$CHAIN_ID.json"',
+            run='jq --from-file /fund-script/gen2spec.jq < "/network-data/genesis-$CHAIN_ID.json" > "/network-data/chainspec-$CHAIN_ID.json"',
         )
 
     return op_deployer_output.files_artifacts[0]

--- a/src/util.star
+++ b/src/util.star
@@ -13,7 +13,7 @@ def read_json_value(plan, json_file, json_path, mounts=None):
         description="Read JSON value",
         image=DEPLOYMENT_UTILS_IMAGE,
         files=mounts,
-        run="cat {0} | jq -j '{1}'".format(json_file, json_path),
+        run="jq -j '{1}' < {0}".format(json_file, json_path),
     )
     return run.output
 


### PR DESCRIPTION
given that run_sh uses /bin/sh, which doesn't support pipefail option,
the previous state allowed failures to not stop kurtosis execution
(the whole step itself didn't fail).

Beyond the inconvenience of having to scroll up to see the real
failure, it also potentially allowed kurtosis to *cache* the faulty
step, which would be very confusing at the next run.
