### PR TITLE
feat(reproduicibility): pin ethereum-package dependency

### DIFF
--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -2,3 +2,5 @@ name: github.com/ethpandaops/optimism-package
 description: |
   # Optimism Package
   This is a Kurtosis package for deploying an Optimism Rollup
+replace:
+  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@4.4.0


### PR DESCRIPTION
This change makes consuming ethereum-package more predictable.
And more importantly, more reproducible.

Downside: obviously we'll need to bump that version every now and then.
