### PR TITLE
fix: don't truncate names too arbitrarily

### DIFF
--- a/src/cl/op-node/op_node_launcher.star
+++ b/src/cl/op-node/op_node_launcher.star
@@ -281,7 +281,7 @@ def get_beacon_config(
         "labels": ethereum_package_shared_utils.label_maker(
             client=constants.CL_TYPE.op_node,
             client_type=constants.CLIENT_TYPES.cl,
-            image=participant.cl_image[-constants.MAX_LABEL_LENGTH :],
+            image=util.label_from_image(participant.cl_image),
             connected_client=el_context.client_name,
             extra_labels=participant.cl_extra_labels,
         ),

--- a/src/el/op-besu/op_besu_launcher.star
+++ b/src/el/op-besu/op_besu_launcher.star
@@ -24,6 +24,7 @@ ethereum_package_constants = import_module(
 
 constants = import_module("../../package_io/constants.star")
 observability = import_module("../../observability/observability.star")
+util = import_module("../../util.star")
 
 RPC_PORT_NUM = 8545
 WS_PORT_NUM = 8546
@@ -261,7 +262,7 @@ def get_config(
         "labels": ethereum_package_shared_utils.label_maker(
             client=constants.EL_TYPE.op_besu,
             client_type=constants.CLIENT_TYPES.el,
-            image=participant.el_image[-constants.MAX_LABEL_LENGTH :],
+            image=util.label_from_image(participant.el_image),
             connected_client=cl_client_name,
             extra_labels=participant.el_extra_labels,
         ),

--- a/src/el/op-erigon/op_erigon_launcher.star
+++ b/src/el/op-erigon/op_erigon_launcher.star
@@ -22,6 +22,7 @@ ethereum_package_constants = import_module(
 
 constants = import_module("../../package_io/constants.star")
 observability = import_module("../../observability/observability.star")
+util = import_module("../../util.star")
 
 RPC_PORT_NUM = 8545
 WS_PORT_NUM = 8546
@@ -256,7 +257,7 @@ def get_config(
         "labels": ethereum_package_shared_utils.label_maker(
             client=constants.EL_TYPE.op_erigon,
             client_type=constants.CLIENT_TYPES.el,
-            image=participant.el_image[-constants.MAX_LABEL_LENGTH :],
+            image=util.label_from_image(participant.el_image),
             connected_client=cl_client_name,
             extra_labels=participant.el_extra_labels,
         ),

--- a/src/el/op-geth/op_geth_launcher.star
+++ b/src/el/op-geth/op_geth_launcher.star
@@ -24,6 +24,7 @@ ethereum_package_constants = import_module(
 constants = import_module("../../package_io/constants.star")
 observability = import_module("../../observability/observability.star")
 interop_constants = import_module("../../interop/constants.star")
+util = import_module("../../util.star")
 
 RPC_PORT_NUM = 8545
 WS_PORT_NUM = 8546
@@ -268,6 +269,9 @@ def get_config(
     subcommand_strs.append(" ".join(cmd))
     command_str = " && ".join(subcommand_strs)
 
+    plan.print(">>>", participant.el_image)
+    plan.print(">>>", util.label_from_image(participant.el_image))
+
     config_args = {
         "image": participant.el_image,
         "ports": ports,
@@ -279,7 +283,7 @@ def get_config(
         "labels": ethereum_package_shared_utils.label_maker(
             client=constants.EL_TYPE.op_geth,
             client_type=constants.CLIENT_TYPES.el,
-            image=participant.el_image[-constants.MAX_LABEL_LENGTH :],
+            image=util.label_from_image(participant.el_image),
             connected_client=cl_client_name,
             extra_labels=participant.el_extra_labels,
         ),

--- a/src/el/op-nethermind/op_nethermind_launcher.star
+++ b/src/el/op-nethermind/op_nethermind_launcher.star
@@ -23,6 +23,7 @@ ethereum_package_constants = import_module(
 
 constants = import_module("../../package_io/constants.star")
 observability = import_module("../../observability/observability.star")
+util = import_module("../../util.star")
 
 RPC_PORT_NUM = 8545
 WS_PORT_NUM = 8546
@@ -248,7 +249,7 @@ def get_config(
         "labels": ethereum_package_shared_utils.label_maker(
             client=constants.EL_TYPE.op_nethermind,
             client_type=constants.CLIENT_TYPES.el,
-            image=participant.el_image[-constants.MAX_LABEL_LENGTH :],
+            image=util.label_from_image(participant.el_image),
             connected_client=cl_client_name,
             extra_labels=participant.el_extra_labels,
         ),

--- a/src/el/op-reth/op_reth_launcher.star
+++ b/src/el/op-reth/op_reth_launcher.star
@@ -22,6 +22,7 @@ ethereum_package_input_parser = import_module(
 
 constants = import_module("../../package_io/constants.star")
 observability = import_module("../../observability/observability.star")
+util = import_module("../../util.star")
 
 RPC_PORT_NUM = 8545
 WS_PORT_NUM = 8546
@@ -243,7 +244,7 @@ def get_config(
         "labels": ethereum_package_shared_utils.label_maker(
             client=constants.EL_TYPE.op_reth,
             client_type=constants.CLIENT_TYPES.el,
-            image=participant.el_image[-constants.MAX_LABEL_LENGTH :],
+            image=util.label_from_image(participant.el_image),
             connected_client=cl_client_name,
             extra_labels=participant.el_extra_labels,
         ),

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -26,5 +26,3 @@ VOLUME_SIZE = {
         "hildr_volume_size": 1000,  # 1GB
     },
 }
-
-MAX_LABEL_LENGTH = 63

--- a/src/util.star
+++ b/src/util.star
@@ -37,3 +37,32 @@ def to_hex_chain_id(chain_id):
     out = "%x" % int(chain_id)
     pad = 64 - len(out)
     return "0x" + "0" * pad + out
+
+
+def label_from_image(image):
+    """Generate a label from an image name.
+
+    Truncate the image label to 63 characters max to comply with k8s label length limit.
+    The label is expected to be in the format of <registry>/<image>:<tag>.
+    But it case it's too long, we take the longest meaningful suffix
+    (so that it's still recognizable), breaking at slashes (so that it's valid).
+
+    Args:
+        image: The image to label.
+
+    Returns:
+        The potentially truncated label.
+    """
+    max_length = 63
+    if len(image) <= max_length:
+        return image
+    cpts = image.split("/")
+    label = cpts[-1]
+    for cpt in reversed(cpts[:-1]):
+        if len(label) + len(cpt) + 1 > max_length:
+            break
+        label = cpt + "/" + label
+    # just in case the last part is already too long
+    if len(label) > max_length:
+        label = label[-max_length:]
+    return label


### PR DESCRIPTION
The problem with selecting the last 63 characters of the image name
for a k8s label is that there's no guarantee that the result will
respect the other contraints.

In particular,
us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101411.4-rc.4
yields .pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101411.4-rc.4
which is invalid because it starts with a dot.
So the net outcome is that valid images fail to deploy because of an
invalid attached label.

This change select the longest prefix available while breaking only at /
So for the image above, the label would be
oplabs-tools-artifacts/images/op-geth:v1.101411.4-rc.4
