### PR TITLE
fix: sets op-node sequencer/verifier confs to 2/1

### DIFF
--- a/src/cl/hildr/hildr_launcher.star
+++ b/src/cl/hildr/hildr_launcher.star
@@ -251,7 +251,7 @@ def get_beacon_config(
         "labels": ethereum_package_shared_utils.label_maker(
             client=constants.CL_TYPE.op_node,
             client_type=constants.CLIENT_TYPES.cl,
-            image=participant.cl_image[-constants.MAX_LABEL_LENGTH :],
+            image=util.label_from_image(participant.cl_image),
             connected_client=el_context.client_name,
             extra_labels=participant.cl_extra_labels,
         ),

--- a/src/cl/op-node/op_node_launcher.star
+++ b/src/cl/op-node/op_node_launcher.star
@@ -170,7 +170,7 @@ def get_beacon_config(
         "op-node",
         "--l2={0}".format(EXECUTION_ENGINE_ENDPOINT),
         "--l2.jwt-secret=" + ethereum_package_constants.JWT_MOUNT_PATH_ON_CONTAINER,
-        "--verifier.l1-confs=4",
+        "--verifier.l1-confs=1",
         "--rollup.config="
         + "{0}/rollup-{1}.json".format(
             ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS,
@@ -252,7 +252,7 @@ def get_beacon_config(
         cmd += [
             "--p2p.sequencer.key=" + sequencer_private_key,
             "--sequencer.enabled",
-            "--sequencer.l1-confs=5",
+            "--sequencer.l1-confs=2",
         ]
 
     if len(existing_cl_clients) > 0:


### PR DESCRIPTION
* we removed the `l1.trustrpc` but now in some cases op-node times out waiting for enough confs to read the systemconfig (in particular when using pectra l1 geth test image?)
* fixes an unrelated bug in hildr causing nightlys to fail (note: they are will still fail for another upstream lighthouse package issue)