### PR TITLE
fix: ChainID Overflow for Uint64 values

### DIFF
--- a/static_files/scripts/fund.sh
+++ b/static_files/scripts/fund.sh
@@ -29,7 +29,7 @@ for chain_id in "${chain_ids[@]}"; do
     role_idx=$((index+1))
     chain_id_mnemonic=$(perl -e "print $chain_id % 4294967296")
 
-    private_key=$(cast wallet private-key "$mnemonic" "m/44'/60'/2'/$chain_id/$role_idx")
+    private_key=$(cast wallet private-key "$mnemonic" "m/44'/60'/2'/$chain_id_mnemonic/$role_idx")
     address=$(cast wallet address "${private_key}")
     write_keyfile "${address}" "${private_key}" "${role}-$chain_id"
     send "${address}"

--- a/static_files/scripts/fund.sh
+++ b/static_files/scripts/fund.sh
@@ -27,6 +27,7 @@ for chain_id in "${chain_ids[@]}"; do
   for index in "${!roles[@]}"; do
     role="${roles[$index]}"
     role_idx=$((index+1))
+    chain_id_mnemonic=$(perl -e "print $chain_id % 4294967296")
 
     private_key=$(cast wallet private-key "$mnemonic" "m/44'/60'/2'/$chain_id/$role_idx")
     address=$(cast wallet address "${private_key}")


### PR DESCRIPTION
Op-program currently uses a CustomChainIDIndicator to boot l2ChainConfig and rollupConfig information for custom chains (e.g local networks using [Kurtosis](https://github.com/ethpandaops/optimism-package)) ([code](https://github.com/ethereum-optimism/optimism/blob/develop/op-program/client/boot/boot.go#L15)). This value is set at `18446744073709551615` which is the highest uint64 value.

The current private key generation script includes the `chain_id` as a parameter into the derivation path for the mnemonic. This results in an error when the `chain_id` is set to `18446744073709551615` because cast only supports `u32` values in the derivation path ([code](https://github.com/summa-tx/coins/blob/6838848770409722c63956f9295497f92fcb1236/crates/bip32/src/path.rs#L23))

The proposed solution is to `mod` the chain_id by 4294967296 which guarantees it fits in a u32

Seen error:
```
Collect keys, and fund addresses
Command returned with exit code '0' and the following output:
--------------------
Error: Malformatted index during derivation: m/44'/60'/2'/18446744073709551615/1
```