### PR TITLE
fix: restore semantics of empty strings in input

### DIFF
--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -74,11 +74,15 @@ def launch_participant_network(
         "batcher-{0}".format(network_params.network_id),
         ".privateKey",
     )
-
+    op_batcher_image = (
+        batcher_params.image
+        if batcher_params.image != ""
+        else input_parser.DEFAULT_BATCHER_IMAGES["op-batcher"]
+    )
     op_batcher_launcher.launch(
         plan,
         "op-batcher-{0}".format(l2_services_suffix),
-        batcher_params.image,
+        op_batcher_image,
         all_el_contexts[0],
         all_cl_contexts[0],
         l1_config_env_vars,
@@ -99,11 +103,15 @@ def launch_participant_network(
         "challenger-{0}".format(network_params.network_id),
         ".privateKey",
     )
-
+    op_challenger_image = (
+        challenger_params.image
+        if challenger_params.image != ""
+        else input_parser.DEFAULT_CHALLENGER_IMAGES["op-challenger"]
+    )
     op_challenger_launcher.launch(
         plan,
         "op-challenger-{0}".format(l2_services_suffix),
-        challenger_params.image,
+        op_challenger_image,
         all_el_contexts[0],
         all_cl_contexts[0],
         l1_config_env_vars,
@@ -121,11 +129,15 @@ def launch_participant_network(
         "proposer-{0}".format(network_params.network_id),
         ".privateKey",
     )
-
+    op_proposer_image = (
+        proposer_params.image
+        if proposer_params.image != ""
+        else input_parser.DEFAULT_PROPOSER_IMAGES["op-proposer"]
+    )
     op_proposer_launcher.launch(
         plan,
         "op-proposer-{0}".format(l2_services_suffix),
-        proposer_params.image,
+        op_proposer_image,
         all_cl_contexts[0],
         l1_config_env_vars,
         proposer_key,


### PR DESCRIPTION
https://github.com/ethpandaops/optimism-package/pull/134 accidentally
broke the convention that an explicit "" for images meant using the
default ones.
This restores that behavior for now.
