### PR TITLE
feat: alt-da support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,29 @@ optimism_package:
 
       # A list of optional extra params that will be passed to the supervisor container for modifying its behaviour
       extra_params: []
+
+  # AltDA Deploy Configuration, which is passed to op-deployer.
+  #
+  # For simplicity we currently enforce chains to all be altda or all rollups.
+  # Adding a single altda chain to a cluster essentially makes all chains have altda levels of security.
+  #
+  # To setup an altda cluster, make sure to
+  # 1. Set altda_deploy_config.use_altda to true (and da_commitment_type to KeccakCommitment, see TODO below)
+  # 2. For each chain,
+  #    - Add "da_server" to the additional_services list if it should use alt-da
+  #    - For altda chains, set da_server_params to use an image and cmd of your choice (one could use da-server, another eigenda-proxy, another celestia proxy, etc). If unset, op's default da-server image will be used.
+  altda_deploy_config:
+    use_altda: false
+    # TODO: Is this field redundant? Afaiu setting it to GenericCommitment will not deploy the
+    # DAChallengeContract, and hence is equivalent to setting use_altda to false.
+    # Furthermore, altda rollups using generic commitments might anyways need to support failing over
+    # to keccak commitments if the altda layer is down.
+    da_commitment_type: KeccakCommitment
+    da_challenge_window: 100
+    da_resolve_window: 100
+    da_bond_size: 0
+    da_resolver_refund_percentage: 0
+
   # An array of L2 networks to run
   chains:
     # Specification of the optimism-participants in the network
@@ -391,7 +414,24 @@ optimism_package:
       # Available services:
       # - blockscout
       # - rollup-boost
+      # - da_server
       additional_services: []
+
+      # Configuration for da-server - https://specs.optimism.io/experimental/alt-da.html#da-server
+      # TODO: each op-node and op-batcher should potentially have their own da-server, instead of sharing one like we currently do. For eg batcher needs to write via its da-server, whereas op-nodes don't.
+      da_server_params:
+        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/da-server:latest
+        # Command to pass to the container.
+        # This is kept maximally generic to allow for any possible configuration, given that different
+        # da layer da-servers might have completely different flags.
+        # The below arguments are also the default, so can be omitted, and will work as long as the image
+        # is the da-server above (which is also the default, so can also be omitted).
+        cmd:
+          - "da-server"
+          - "--file.path=/home"
+          - "--addr=0.0.0.0"
+          - "--port=3100"
+          - "--log.level=debug"
 
   # L2 contract deployer configuration - used for all L2 networks
   # The docker image that should be used for the L2 contract deployer

--- a/main.star
+++ b/main.star
@@ -44,6 +44,7 @@ def run(plan, args):
     global_node_selectors = optimism_args_with_right_defaults.global_node_selectors
     global_log_level = optimism_args_with_right_defaults.global_log_level
     persistent = optimism_args_with_right_defaults.persistent
+    altda_deploy_config = optimism_args_with_right_defaults.altda_deploy_config
 
     observability_params = optimism_args_with_right_defaults.observability
     interop_params = optimism_args_with_right_defaults.interop
@@ -94,6 +95,7 @@ def run(plan, args):
         l1_config_env_vars,
         optimism_args_with_right_defaults,
         l1_network,
+        altda_deploy_config,
     )
 
     jwt_file = plan.upload_files(

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -1,4 +1,11 @@
 optimism_package:
+  altda_deploy_config:
+    use_altda: true
+    da_commitment_type: KeccakCommitment
+    da_challenge_window: 100
+    da_resolve_window: 100
+    da_bond_size: 0
+    da_resolver_refund_percentage: 0
   chains:
     - participants:
       - el_type: op-geth
@@ -39,7 +46,17 @@ optimism_package:
       mev_params:
         builder_host: ""
         builder_port: ""
-      additional_services: []
+      da_server_params:
+        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/da-server:latest
+        # A list of optional extra params that will be passed to the da-server container for modifying its behaviour
+        cmd:
+          - "da-server"
+          - "--file.path=/home"
+          - "--addr=0.0.0.0"
+          - "--port=3100"
+          - "--log.level=debug"
+      additional_services:
+        - da_server
   op_contract_deployer_params:
     image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11
     l1_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-c193a1863182092bc6cb723e523e8313a0f4b6e9c9636513927f1db74c047c15.tar.gz

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -1,11 +1,4 @@
 optimism_package:
-  altda_deploy_config:
-    use_altda: true
-    da_commitment_type: KeccakCommitment
-    da_challenge_window: 100
-    da_resolve_window: 100
-    da_bond_size: 0
-    da_resolver_refund_percentage: 0
   chains:
     - participants:
       - el_type: op-geth
@@ -46,17 +39,7 @@ optimism_package:
       mev_params:
         builder_host: ""
         builder_port: ""
-      da_server_params:
-        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/da-server:latest
-        # A list of optional extra params that will be passed to the da-server container for modifying its behaviour
-        cmd:
-          - "da-server"
-          - "--file.path=/home"
-          - "--addr=0.0.0.0"
-          - "--port=3100"
-          - "--log.level=debug"
-      additional_services:
-        - da_server
+      additional_services: []
   op_contract_deployer_params:
     image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11
     l1_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-c193a1863182092bc6cb723e523e8313a0f4b6e9c9636513927f1db74c047c15.tar.gz

--- a/src/alt-da/da-server/da_server_launcher.star
+++ b/src/alt-da/da-server/da_server_launcher.star
@@ -1,0 +1,76 @@
+shared_utils = import_module(
+    "github.com/ethpandaops/ethereum-package/src/shared_utils/shared_utils.star"
+)
+constants = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
+)
+
+# Port IDs
+DA_SERVER_HTTP_PORT_ID = "http"
+
+# Port nums
+DA_SERVER_HTTP_PORT_NUM = 3100
+
+
+def get_used_ports():
+    used_ports = {
+        DA_SERVER_HTTP_PORT_ID: shared_utils.new_port_spec(
+            DA_SERVER_HTTP_PORT_NUM,
+            shared_utils.TCP_PROTOCOL,
+            shared_utils.HTTP_APPLICATION_PROTOCOL,
+        ),
+    }
+    return used_ports
+
+
+def launch_da_server(
+    plan,
+    service_name,
+    image,
+    cmd,
+):
+    config = get_da_server_config(
+        plan,
+        service_name,
+        image,
+        cmd,
+    )
+
+    da_server_service = plan.add_service(service_name, config)
+
+    http_url = "http://{0}:{1}".format(
+        da_server_service.ip_address, DA_SERVER_HTTP_PORT_NUM
+    )
+    # da_server_context is passed as argument to op-batcher and op-node(s)
+    return new_da_server_context(
+        http_url=http_url,
+    )
+
+
+def get_da_server_config(
+    plan,
+    service_name,
+    image,
+    cmd,
+):
+    ports = get_used_ports()
+
+    return ServiceConfig(
+        image=image,
+        ports=ports,
+        cmd=cmd,
+        private_ip_address_placeholder=constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+    )
+
+
+def disabled_da_server_context():
+    return new_da_server_context(
+        http_url="",
+    )
+
+
+def new_da_server_context(http_url):
+    return struct(
+        enabled=http_url != "",
+        http_url=http_url,
+    )

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -45,6 +45,7 @@ def launch(
     gs_batcher_private_key,
     batcher_params,
     observability_helper,
+    da_server_context,
 ):
     batcher_service_name = "{0}".format(service_name)
 
@@ -58,6 +59,7 @@ def launch(
         gs_batcher_private_key,
         batcher_params,
         observability_helper,
+        da_server_context,
     )
 
     batcher_service = plan.add_service(service_name, config)
@@ -82,6 +84,7 @@ def get_batcher_config(
     gs_batcher_private_key,
     batcher_params,
     observability_helper,
+    da_server_context,
 ):
     ports = dict(get_used_ports())
 
@@ -100,7 +103,15 @@ def get_batcher_config(
         "--max-channel-duration=1",
         "--l1-eth-rpc=" + l1_config_env_vars["L1_RPC_URL"],
         "--private-key=" + gs_batcher_private_key,
-        "--data-availability-type=blobs",
+        # da commitments currently have to be sent as calldata to the batcher inbox
+        "--data-availability-type=" + "calldata"
+        if da_server_context.enabled
+        else "blobs",
+        "--altda.enabled=" + str(da_server_context.enabled),
+        "--altda.da-server=" + da_server_context.http_url,
+        # This flag is very badly named, but is needed in order to let the da-server compute the commitment.
+        # This leads to sending POST requests to /put instead of /put/<keccak256(data)>
+        "--altda.da-service",
     ]
 
     # apply customizations

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -104,9 +104,8 @@ def get_batcher_config(
         "--l1-eth-rpc=" + l1_config_env_vars["L1_RPC_URL"],
         "--private-key=" + gs_batcher_private_key,
         # da commitments currently have to be sent as calldata to the batcher inbox
-        "--data-availability-type=" + "calldata"
-        if da_server_context.enabled
-        else "blobs",
+        "--data-availability-type="
+        + ("calldata" if da_server_context.enabled else "blobs"),
         "--altda.enabled=" + str(da_server_context.enabled),
         "--altda.da-server=" + da_server_context.http_url,
         # This flag is very badly named, but is needed in order to let the da-server compute the commitment.

--- a/src/cl/hildr/hildr_launcher.star
+++ b/src/cl/hildr/hildr_launcher.star
@@ -78,6 +78,7 @@ def launch(
     sequencer_enabled,
     observability_helper,
     interop_params,
+    da_server_context,
 ):
     # beacon_node_identity_recipe = PostHttpRequestRecipe(
     #     endpoint="/",
@@ -109,6 +110,7 @@ def launch(
         l1_config_env_vars,
         sequencer_enabled,
         observability_helper,
+        da_server_context,
     )
 
     beacon_service = plan.add_service(service_name, config)
@@ -155,6 +157,7 @@ def get_beacon_config(
     l1_config_env_vars,
     sequencer_enabled,
     observability_helper,
+    da_server_context,
 ):
     EXECUTION_ENGINE_ENDPOINT = "http://{0}:{1}".format(
         el_context.ip_addr,
@@ -183,6 +186,9 @@ def get_beacon_config(
             ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS,
             launcher.network_params.network_id,
         ),
+        # TODO: support altda flags once they are implemented.
+        # See https://github.com/optimism-java/hildr/issues/134
+        # eg: "--altda.enabled=" + str(da_server_context.enabled),
     ]
 
     # configure files

--- a/src/cl/op-node/op_node_launcher.star
+++ b/src/cl/op-node/op_node_launcher.star
@@ -77,6 +77,7 @@ def launch(
     sequencer_enabled,
     observability_helper,
     interop_params,
+    da_server_context,
 ):
     beacon_node_identity_recipe = PostHttpRequestRecipe(
         endpoint="/",
@@ -110,6 +111,7 @@ def launch(
         sequencer_enabled,
         observability_helper,
         interop_params,
+        da_server_context,
     )
 
     beacon_service = plan.add_service(service_name, config)
@@ -158,6 +160,7 @@ def get_beacon_config(
     sequencer_enabled,
     observability_helper,
     interop_params,
+    da_server_context,
 ):
     ports = dict(get_used_ports(BEACON_DISCOVERY_PORT_NUM))
 
@@ -190,6 +193,8 @@ def get_beacon_config(
         "--p2p.listen.tcp={0}".format(BEACON_DISCOVERY_PORT_NUM),
         "--p2p.listen.udp={0}".format(BEACON_DISCOVERY_PORT_NUM),
         "--safedb.path={0}".format(BEACON_DATA_DIRPATH_ON_SERVICE_CONTAINER),
+        "--altda.enabled=" + str(da_server_context.enabled),
+        "--altda.da-server=" + da_server_context.http_url,
     ]
 
     # configure files

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -20,7 +20,9 @@ CANNED_VALUES = (
 )
 
 
-def deploy_contracts(plan, priv_key, l1_config_env_vars, optimism_args, l1_network):
+def deploy_contracts(
+    plan, priv_key, l1_config_env_vars, optimism_args, l1_network, altda_args
+):
     l2_chain_ids_list = [
         str(chain.network_params.network_id) for chain in optimism_args.chains
     ]
@@ -200,6 +202,37 @@ def deploy_contracts(plan, priv_key, l1_config_env_vars, optimism_args, l1_netwo
                 ),
                 address_update(
                     chain_key(i, "roles.unsafeBlockSigner"), "sequencer", chain_id
+                ),
+                # altda deploy config
+                (
+                    "bool",
+                    chain_key(i, "dangerousAltDAConfig.useAltDA"),
+                    altda_args.use_altda,
+                ),
+                (
+                    "string",
+                    chain_key(i, "dangerousAltDAConfig.daCommitmentType"),
+                    altda_args.da_commitment_type,
+                ),
+                (
+                    "int",
+                    chain_key(i, "dangerousAltDAConfig.daChallengeWindow"),
+                    altda_args.da_challenge_window,
+                ),
+                (
+                    "int",
+                    chain_key(i, "dangerousAltDAConfig.daResolveWindow"),
+                    altda_args.da_resolve_window,
+                ),
+                (
+                    "int",
+                    chain_key(i, "dangerousAltDAConfig.daBondSize"),
+                    altda_args.da_bond_size,
+                ),
+                (
+                    "int",
+                    chain_key(i, "dangerousAltDAConfig.daResolverRefundPercentage"),
+                    altda_args.da_resolver_refund_percentage,
                 ),
             ]
         )

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -44,6 +44,7 @@ def launch(
     additional_services,
     observability_helper,
     interop_params,
+    da_server_context,
 ):
     el_launchers = {
         "op-geth": {
@@ -336,6 +337,7 @@ def launch(
             sequencer_enabled,
             observability_helper,
             interop_params,
+            da_server_context,
         )
 
         for metrics_info in [x for x in cl_context.cl_nodes_metrics_info if x != None]:

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -34,6 +34,15 @@ SUPERVISOR_PARAMS = [
     "extra_params",
 ]
 
+ALTDA_DEPLOY_CONFIG_PARAMS = [
+    "use_altda",
+    "da_commitment_type",
+    "da_challenge_window",
+    "da_resolve_window",
+    "da_bond_size",
+    "da_resolver_refund_percentage",
+]
+
 PARTICIPANT_CATEGORIES = {
     "participants": [
         "el_type",
@@ -92,6 +101,10 @@ SUBCATEGORY_PARAMS = {
     ],
     "proposer_params": ["image", "extra_params", "game_type", "proposal_interval"],
     "mev_params": ["rollup_boost_image", "builder_host", "builder_port"],
+    "da_server_params": [
+        "image",
+        "cmd",
+    ],
 }
 
 OP_CONTRACT_DEPLOYER_PARAMS = [
@@ -106,11 +119,13 @@ OP_CONTRACT_DEPLOYER_GLOBAL_DEPLOY_OVERRIDES = ["faultGameAbsolutePrestate"]
 ADDITIONAL_SERVICES_PARAMS = [
     "blockscout",
     "rollup-boost",
+    "da_server",
 ]
 
 ROOT_PARAMS = [
     "observability",
     "interop",
+    "altda_deploy_config",
     "chains",
     "op_contract_deployer_params",
     "global_log_level",
@@ -199,6 +214,14 @@ def sanity_check(plan, optimism_config):
                 "supervisor_params",
                 SUPERVISOR_PARAMS,
             )
+
+    if "altda_deploy_config" in optimism_config:
+        validate_params(
+            plan,
+            optimism_config["altda_deploy_config"],
+            "altda_deploy_config",
+            ALTDA_DEPLOY_CONFIG_PARAMS,
+        )
 
     chains = optimism_config.get("chains", [])
 

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -29,6 +29,7 @@ def launch_participant_network(
     additional_services,
     observability_helper,
     interop_params,
+    da_server_context,
 ):
     num_participants = len(participants)
     # First EL and sequencer CL
@@ -49,6 +50,7 @@ def launch_participant_network(
         additional_services,
         observability_helper,
         interop_params,
+        da_server_context,
     )
 
     all_participants = []
@@ -89,6 +91,7 @@ def launch_participant_network(
         batcher_key,
         batcher_params,
         observability_helper,
+        da_server_context,
     )
 
     game_factory_address = util.read_network_config_value(


### PR DESCRIPTION
Closes #67 

Example network_params.yaml with altda support:
```
optimism_package:
  altda_deploy_config:
    use_altda: true
    da_commitment_type: KeccakCommitment
    da_challenge_window: 100
    da_resolve_window: 100
    da_bond_size: 0
    da_resolver_refund_percentage: 0
  chains:
    - participants:
      - el_type: op-geth
        cl_type: op-node
        count: 1
      network_params:
        network: "kurtosis"
        network_id: "2151908"
        seconds_per_slot: 2
        name: "op-kurtosis"
        fjord_time_offset: 0
        granite_time_offset: 0
        fund_dev_accounts: true
      da_server_params:
        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/da-server:latest
        # A list of optional extra params that will be passed to the da-server container for modifying its behaviour
        cmd:
          - "da-server"
          - "--file.path=/home"
          - "--addr=0.0.0.0"
          - "--port=3100"
          - "--log.level=debug"
      additional_services:
        - da_server
  op_contract_deployer_params:
    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11
    l1_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-c193a1863182092bc6cb723e523e8313a0f4b6e9c9636513927f1db74c047c15.tar.gz
    l2_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-c193a1863182092bc6cb723e523e8313a0f4b6e9c9636513927f1db74c047c15.tar.gz
  global_log_level: "info"
  global_node_selectors: {}
  global_tolerations: []
  persistent: false
ethereum_package:
  network_params:
    preset: minimal
    genesis_delay: 5
    additional_preloaded_contracts: '
      {
        "0x4e59b44847b379578588920cA78FbF26c0B4956C": {
          "balance": "0ETH",
          "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3",
          "storage": {},
          "nonce": "1"
        }
      }
    '
```
One can also replace da-server with eigenda-proxy by using
```
      da_server_params:
        image: ghcr.io/layr-labs/eigenda-proxy:v1.6.3
        # A list of optional extra params that will be passed to the da-server container for modifying its behaviour
        cmd:
          - "--memstore.enabled"
          - "--eigenda.cert-verification-disabled"
```