### PR TITLE
chore: add missing log-level flags to node launchers

### DIFF
--- a/src/cl/hildr/hildr_launcher.star
+++ b/src/cl/hildr/hildr_launcher.star
@@ -169,6 +169,7 @@ def get_beacon_config(
 
     cmd = [
         "--devnet",
+        "--log.level=" + log_level,
         "--jwt-file=" + ethereum_package_constants.JWT_MOUNT_PATH_ON_CONTAINER,
         "--l1-beacon-url={0}".format(l1_config_env_vars["CL_RPC_URL"]),
         "--l1-rpc-url={0}".format(l1_config_env_vars["L1_RPC_URL"]),

--- a/src/cl/op-node/op_node_launcher.star
+++ b/src/cl/op-node/op_node_launcher.star
@@ -168,6 +168,7 @@ def get_beacon_config(
 
     cmd = [
         "op-node",
+        "--log.level=" + log_level,
         "--l2={0}".format(EXECUTION_ENGINE_ENDPOINT),
         "--l2.jwt-secret=" + ethereum_package_constants.JWT_MOUNT_PATH_ON_CONTAINER,
         "--verifier.l1-confs=1",

--- a/test/el_cl_launcher_test.star
+++ b/test/el_cl_launcher_test.star
@@ -81,6 +81,7 @@ def test_launch_with_defaults(plan):
         cl_service_config.cmd,
         [
             "op-node",
+            "--log.level=INFO",
             "--l2=http://{0}:{1}".format(
                 el_sevice.ip_address, el_sevice.ports["engine-rpc"].number
             ),


### PR DESCRIPTION
I would guess there's probably more missing but I needed these so figured I'd upstream the changes.