### PR TITLE
chore: add a challenger 'enabled' flag to make its deployment optional

### DIFF
--- a/main.star
+++ b/main.star
@@ -147,20 +147,21 @@ def run(plan, args):
             if chain.challenger_params.image != ""
             else input_parser.DEFAULT_CHALLENGER_IMAGES["op-challenger"]
         )
-        op_challenger_launcher.launch(
-            plan,
-            l2_num,
-            "op-challenger-{0}".format(chain.network_params.name),
-            chain.challenger_params.image,
-            l2.participants[0].el_context,
-            l2.participants[0].cl_context,
-            l1_config_env_vars,
-            deployment_output,
-            chain.network_params,
-            chain.challenger_params,
-            interop_params,
-            observability_helper,
-        )
+        if chain.challenger_params.enabled:
+            op_challenger_launcher.launch(
+                plan,
+                l2_num,
+                "op-challenger-{0}".format(chain.network_params.name),
+                chain.challenger_params.image,
+                l2.participants[0].el_context,
+                l2.participants[0].cl_context,
+                l1_config_env_vars,
+                deployment_output,
+                chain.network_params,
+                chain.challenger_params,
+                interop_params,
+                observability_helper,
+            )
 
     if observability_helper.enabled and len(observability_helper.metrics_jobs) > 0:
         plan.print("Launching prometheus...")

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -36,6 +36,9 @@ optimism_package:
         fund_dev_accounts: true
       batcher_params:
         extra_params: []
+      challenger_params:
+        enabled: true
+        extra_params: []
       mev_params:
         builder_host: ""
         builder_port: ""
@@ -44,6 +47,8 @@ optimism_package:
     image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.12
     l1_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz
     l2_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz
+  observability:
+    enabled: true
   global_log_level: "info"
   global_node_selectors: {}
   global_tolerations: []

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -205,6 +205,7 @@ def input_parser(plan, input_args):
                     extra_params=result["batcher_params"]["extra_params"],
                 ),
                 challenger_params=struct(
+                    enabled=result["challenger_params"]["enabled"],
                     image=result["challenger_params"]["image"],
                     extra_params=result["challenger_params"]["extra_params"],
                     cannon_prestate_path=result["challenger_params"][
@@ -302,11 +303,11 @@ def parse_network_params(plan, input_args):
         batcher_params = default_batcher_params()
         batcher_params.update(chain.get("batcher_params", {}))
 
-        challenger_params = default_challenger_params()
-        challenger_params.update(chain.get("challenger_params", {}))
-
         proposer_params = default_proposer_params()
         proposer_params.update(chain.get("proposer_params", {}))
+
+        challenger_params = default_challenger_params()
+        challenger_params.update(chain.get("challenger_params", {}))
 
         mev_params = default_mev_params()
         mev_params.update(chain.get("mev_params", {}))
@@ -491,8 +492,8 @@ def default_chains():
             "participants": [default_participant()],
             "network_params": default_network_params(),
             "batcher_params": default_batcher_params(),
-            "challenger_params": default_challenger_params(),
             "proposer_params": default_proposer_params(),
+            "challenger_params": default_challenger_params(),
             "mev_params": default_mev_params(),
             "da_server_params": default_da_server_params(),
             "additional_services": DEFAULT_ADDITIONAL_SERVICES,
@@ -524,6 +525,7 @@ def default_batcher_params():
 
 def default_challenger_params():
     return {
+        "enabled": True,
         "image": DEFAULT_CHALLENGER_IMAGES["op-challenger"],
         "extra_params": [],
         "cannon_prestate_path": "",

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -93,14 +93,15 @@ SUBCATEGORY_PARAMS = {
         "fund_dev_accounts",
     ],
     "batcher_params": ["image", "extra_params"],
+    "proposer_params": ["image", "extra_params", "game_type", "proposal_interval"],
     "challenger_params": [
+        "enabled",
         "image",
         "extra_params",
         "cannon_prestate_path",
         "cannon_prestates_url",
         "cannon_trace_types",
     ],
-    "proposer_params": ["image", "extra_params", "game_type", "proposal_interval"],
     "mev_params": ["rollup_boost_image", "builder_host", "builder_port"],
     "da_server_params": [
         "image",


### PR DESCRIPTION
challenger and its dependency (building the op-program cannon preimage) take a long time to build in op's monorepo.

This change is a first step in being able to disable the challenger when not needed. Will need to figure out a way to also make the cannon preimage building optional from op's repo.