### PR TITLE
chore: Make sure kurtosis runs with a lighthouse L1 client

### DIFF
--- a/.github/tests/lighthouse.yaml
+++ b/.github/tests/lighthouse.yaml
@@ -1,0 +1,13 @@
+ethereum_package:
+  participants:
+    - el_type: reth
+      cl_type: lighthouse
+optimism_package:
+  chains:
+    - participants:
+      - el_type: op-geth
+        el_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:latest
+        cl_type: op-node
+        cl_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:latest
+        cl_extra_params:
+          - "--l1.trustrpc=true"

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -13,7 +13,8 @@ jobs:
       matrix:
         file_name:
           [
-            "./network_params.yaml"
+            "./network_params.yaml",
+            "./.github/tests/lighthouse.yaml"
           ]
     runs-on: ubuntu-latest
     steps:

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -3,4 +3,4 @@ description: |
   # Optimism Package
   This is a Kurtosis package for deploying an Optimism Rollup
 replace:
-  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@4.5.0
+  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@4.4.0


### PR DESCRIPTION
*Description*

We are seeing errors with kurtosis setup after the `ethereum-package` upgrade. This PR aims to make sure `lighthouse` runs after the upgrade