### PR TITLE
chore: Use the renamed version of kurtestosis

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -55,6 +55,6 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@v2
 
-      - name: Run kurtestosis tests
-        run: kurtestosis .
+      - name: Run kurtosis-test tests
+        run: kurtosis-test .
 

--- a/README.md
+++ b/README.md
@@ -695,11 +695,11 @@ kurtosis lint --format .
 
 #### Unit tests
 
-We are using [`kurtestosis`](https://github.com/ethereum-optimism/kurtestosis) to run a set of unit tests against the starlark code:
+We are using [`kurtosis-test`](https://github.com/ethereum-optimism/kurtosis-test) to run a set of unit tests against the starlark code:
 
 ```bash
 # To run all unit tests
-kurtestosis .
+kurtosis-test .
 ```
 
 The tests can be found in `*_test.star` scripts located in the `test` directory.

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
 
 # Core dependencies
-"ubi:ethereum-optimism/kurtestosis" = "0.0.5"
+"ubi:ethereum-optimism/kurtosis-test" = "0.0.1"


### PR DESCRIPTION
*Description*

- `kurtestosis` has been renamed & migrated to [`kurtosis-test`](https://github.com/ethereum-optimism/kurtosis-test)