### PR TITLE
fix(grafana): use absolute file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,12 @@ optimism_package:
       image: "prom/prometheus:latest"
     # Default grafana configuration
     grafana_params:
-      # A list of locators for grafana dashboards to be loaded be the grafana service
-      dashboard_sources: []
+      # A list of locators for grafana dashboards to be loaded by the grafana service.
+      # Each locator should be a URL to a directory containing a /folders and a /dashboards directory.
+      # Those will be uploaded to the grafana service by using grizzly.
+      # See https://github.com/ethereum-optimism/grafana-dashboards-public for more info.
+      dashboard_sources:
+        - github.com/ethereum-optimism/grafana-dashboards-public/resources
       # Resource management for grafana container
       # CPU is milicores
       # RAM is in MB

--- a/src/observability/grafana/grafana_launcher.star
+++ b/src/observability/grafana/grafana_launcher.star
@@ -107,6 +107,7 @@ def get_config(
         node_selectors=node_selectors,
     )
 
+
 # The dashboards pointed by the dashboard_sources locators are uploaded
 # as file artifacts, then mounted into a container and pushed to the Grafana
 # instance using https://grafana.github.io/grizzly/.

--- a/src/observability/grafana/grafana_launcher.star
+++ b/src/observability/grafana/grafana_launcher.star
@@ -107,7 +107,9 @@ def get_config(
         node_selectors=node_selectors,
     )
 
-
+# The dashboards pointed by the dashboard_sources locators are uploaded
+# as file artifacts, then mounted into a container and pushed to the Grafana
+# instance using https://grafana.github.io/grizzly/.
 def provision_dashboards(plan, service_url, dashboard_sources):
     if len(dashboard_sources) == 0:
         return
@@ -130,7 +132,7 @@ def provision_dashboards(plan, service_url, dashboard_sources):
         dashboard_name = "dashboards-{0}".format(index)
         dashboard_artifact_name = plan.upload_files(dashboard_src, name=dashboard_name)
 
-        files[dashboard_name] = dashboard_artifact_name
+        files["/" + dashboard_name] = dashboard_artifact_name
         grr_commands += grr_push_dashboards(dashboard_name)
 
     plan.run_sh(

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -445,7 +445,7 @@ def default_prometheus_params():
 def default_grafana_params():
     return {
         "image": "grafana/grafana:latest",
-        "dashboard_sources": [],
+        "dashboard_sources": ["github.com/ethereum-optimism/grafana-dashboards-public/resources@ee47a8ec0545a06ef487ed5ec03ca692e258e5ec"],
         "min_cpu": 10,
         "max_cpu": 1000,
         "min_mem": 128,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -445,7 +445,9 @@ def default_prometheus_params():
 def default_grafana_params():
     return {
         "image": "grafana/grafana:latest",
-        "dashboard_sources": ["github.com/ethereum-optimism/grafana-dashboards-public/resources@ee47a8ec0545a06ef487ed5ec03ca692e258e5ec"],
+        "dashboard_sources": [
+            "github.com/ethereum-optimism/grafana-dashboards-public/resources@ee47a8ec0545a06ef487ed5ec03ca692e258e5ec"
+        ],
         "min_cpu": 10,
         "max_cpu": 1000,
         "min_mem": 128,


### PR DESCRIPTION
Was getting this error
![image](https://github.com/user-attachments/assets/22b13ef6-4500-41d8-af1c-7f99a211937f)

so uploaded the resources to `/dashboard-0` instead of the relative `dashboard-0` which docker wasn't accepting to mount.

Also made the dashboard provisioned by default. Can revert this change if you guys don't want it but I feel like everybody would be happy to have this by default.