### PR TITLE
fix(observability): label improvements

### DIFF
--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -44,6 +44,7 @@ def launch(
     l1_config_env_vars,
     gs_batcher_private_key,
     batcher_params,
+    network_params,
     observability_helper,
     da_server_context,
 ):
@@ -63,7 +64,9 @@ def launch(
     service = plan.add_service(service_name, config)
     service_url = util.make_service_http_url(service)
 
-    observability.register_op_service_metrics_job(observability_helper, service)
+    observability.register_op_service_metrics_job(
+        observability_helper, service, network_params.network
+    )
 
     return service_url
 

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -37,8 +37,6 @@ def launch(
     interop_params,
     observability_helper,
 ):
-    challenger_service_name = "{0}".format(service_name)
-
     config = get_challenger_config(
         plan,
         l2_num,
@@ -54,10 +52,10 @@ def launch(
         observability_helper,
     )
 
-    challenger_service = plan.add_service(service_name, config)
+    service = plan.add_service(service_name, config)
 
     observability.register_op_service_metrics_job(
-        observability_helper, challenger_service
+        observability_helper, service, network_params.network
     )
 
     return "op_challenger"

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -272,7 +272,11 @@ def launch(
 
         for metrics_info in [x for x in el_context.el_metrics_info if x != None]:
             observability.register_node_metrics_job(
-                observability_helper, el_context.client_name, "execution", metrics_info
+                observability_helper,
+                el_context.client_name,
+                "execution",
+                network_params.network,
+                metrics_info,
             )
 
         if rollup_boost_enabled and sequencer_enabled:
@@ -314,6 +318,7 @@ def launch(
                         observability_helper,
                         el_builder_context.client_name,
                         "execution-builder",
+                        network_params.network,
                         metrics_info,
                     )
             rollup_boost_image = (
@@ -365,6 +370,7 @@ def launch(
                 observability_helper,
                 cl_context.client_name,
                 "beacon",
+                network_params.network,
                 metrics_info,
                 {
                     "supernode": str(cl_context.supernode),
@@ -397,6 +403,7 @@ def launch(
                     observability_helper,
                     cl_builder_context.client_name,
                     "beacon-builder",
+                    network_params.network,
                     metrics_info,
                     {
                         "supernode": str(cl_builder_context.supernode),

--- a/src/mev/rollup-boost/rollup_boost_launcher.star
+++ b/src/mev/rollup-boost/rollup_boost_launcher.star
@@ -66,7 +66,6 @@ def launch(
         engine_rpc_port_num=RPC_PORT_NUM,
         rpc_http_url=http_url,
         service_name=service_name,
-        el_metrics_info=None,
     )
 
 

--- a/src/observability/observability.star
+++ b/src/observability/observability.star
@@ -101,7 +101,7 @@ def register_service_metrics_job(
 ):
     labels = {
         "service": service_name,
-        "namespace": "kurtosis",
+        "namespace": service_name,
         "stack_optimism_io_network": "kurtosis",
     }
     labels.update(additional_labels)

--- a/src/observability/observability.star
+++ b/src/observability/observability.star
@@ -83,10 +83,11 @@ def new_metrics_job(
     }
 
 
-def register_op_service_metrics_job(helper, service):
+def register_op_service_metrics_job(helper, service, network_name):
     register_service_metrics_job(
         helper,
         service_name=service.name,
+        network_name=network_name,
         endpoint=util.make_service_url_authority(service, METRICS_PORT_ID),
     )
 
@@ -94,6 +95,7 @@ def register_op_service_metrics_job(helper, service):
 def register_service_metrics_job(
     helper,
     service_name,
+    network_name,
     endpoint,
     metrics_path="",
     additional_labels={},
@@ -102,7 +104,7 @@ def register_service_metrics_job(
     labels = {
         "service": service_name,
         "namespace": service_name,
-        "stack_optimism_io_network": "kurtosis",
+        "stack_optimism_io_network": network_name,
     }
     labels.update(additional_labels)
 
@@ -119,7 +121,12 @@ def register_service_metrics_job(
 
 
 def register_node_metrics_job(
-    helper, client_name, client_type, node_metrics_info, additional_labels={}
+    helper,
+    client_name,
+    client_type,
+    network_name,
+    node_metrics_info,
+    additional_labels={},
 ):
     labels = {
         "client_type": client_type,
@@ -144,6 +151,7 @@ def register_node_metrics_job(
     register_service_metrics_job(
         helper,
         service_name=node_metrics_info[METRICS_INFO_NAME_KEY],
+        network_name=network_name,
         endpoint=node_metrics_info[METRICS_INFO_URL_KEY],
         metrics_path=node_metrics_info[METRICS_INFO_PATH_KEY],
         additional_labels=labels,

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -1,3 +1,5 @@
+NETWORK_NAME = "kurtosis"
+
 HTTP_PORT_ID = "http"
 RPC_PORT_ID = "rpc"
 WS_PORT_ID = "ws"

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2,6 +2,7 @@ ethereum_package_input_parser = import_module(
     "github.com/ethpandaops/ethereum-package/src/package_io/input_parser.star"
 )
 
+constants = import_module("../package_io/constants.star")
 sanity_check = import_module("./sanity_check.star")
 
 DEFAULT_EL_IMAGES = {
@@ -542,7 +543,7 @@ def default_chains():
 
 def default_network_params():
     return {
-        "network": "kurtosis",
+        "network": constants.NETWORK_NAME,
         "network_id": "2151908",
         "name": "op-kurtosis",
         "seconds_per_slot": 2,

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -90,6 +90,7 @@ def launch_participant_network(
         l1_config_env_vars,
         batcher_key,
         batcher_params,
+        network_params,
         observability_helper,
         da_server_context,
     )
@@ -120,6 +121,7 @@ def launch_participant_network(
         proposer_key,
         game_factory_address,
         proposer_params,
+        network_params,
         observability_helper,
     )
 

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -44,6 +44,7 @@ def launch(
     gs_proposer_private_key,
     game_factory_address,
     proposer_params,
+    network_params,
     observability_helper,
 ):
     proposer_service_name = "{0}".format(service_name)
@@ -63,7 +64,9 @@ def launch(
     service = plan.add_service(service_name, config)
     http_url = util.make_service_http_url(service)
 
-    observability.register_op_service_metrics_job(observability_helper, service)
+    observability.register_op_service_metrics_job(
+        observability_helper, service, network_params.network
+    )
 
     return http_url
 


### PR DESCRIPTION
This PR improves the way the `service`, `namespace`. and `stack_optimism_io_network` labels are applied to services, in order to enable per-replica filtering in Grafana dashboards.

These changes have been successfully tested with a 2-replica params file:

<img width="749" alt="image" src="https://github.com/user-attachments/assets/071f1a59-30e6-4ea8-a59a-ea9f0bb3c682" />

Resolves #182.