### PR TITLE
fix(observability): network label for supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ optimism_package:
       # A list of optional extra params that will be passed to the supervisor container for modifying its behaviour
       extra_params: []
 
+      # Network name, used to enable syncing of alternative networks
+      # Defaults to "kurtosis"
+      network: "kurtosis"
+
   # AltDA Deploy Configuration, which is passed to op-deployer.
   #
   # For simplicity we currently enforce chains to all be altda or all rollups.

--- a/src/interop/op-supervisor/op_supervisor_launcher.star
+++ b/src/interop/op-supervisor/op_supervisor_launcher.star
@@ -77,7 +77,7 @@ def launch(
     )
 
     observability.register_op_service_metrics_job(
-        observability_helper, supervisor_service
+        observability_helper, supervisor_service, supervisor_params.network
     )
 
     return "op_supervisor"

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -123,6 +123,7 @@ def input_parser(plan, input_args):
                     "dependency_set"
                 ],
                 extra_params=results["interop"]["supervisor_params"]["extra_params"],
+                network=results["interop"]["supervisor_params"]["network"],
             ),
         ),
         altda_deploy_config=struct(
@@ -515,6 +516,7 @@ def default_supervisor_params():
         "image": DEFAULT_SUPERVISOR_IMAGES["op-supervisor"],
         "dependency_set": "",
         "extra_params": [],
+        "network": constants.NETWORK_NAME,
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -63,6 +63,7 @@ SUPERVISOR_PARAMS = [
     "image",
     "dependency_set",
     "extra_params",
+    "network",
 ]
 
 ALTDA_DEPLOY_CONFIG_PARAMS = [


### PR DESCRIPTION
Missed to add network param for supervisor at https://github.com/ethpandaops/optimism-package/pull/185.

Dodges below error when interop is enabled.
```
: interpretation error: Evaluation error: function register_op_service_metrics_job missing 1 argument (network_name)
        at [github.com/ethpandaops/optimism-package/main.star:130:38]: run
        at [github.com/ethpandaops/optimism-package/src/interop/op-supervisor/op_supervisor_launcher.star:79:50]: launch
        at [github.com/ethpandaops/optimism-package/src/observability/observability.star:87:5]: register_op_service_metrics_job
```