### PR TITLE
fix(observability): remove supervisor network label

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,6 @@ optimism_package:
       # A list of optional extra params that will be passed to the supervisor container for modifying its behaviour
       extra_params: []
 
-      # Network name, used to enable syncing of alternative networks
-      # Defaults to "kurtosis"
-      network: "kurtosis"
-
   # AltDA Deploy Configuration, which is passed to op-deployer.
   #
   # For simplicity we currently enforce chains to all be altda or all rollups.

--- a/src/interop/op-supervisor/op_supervisor_launcher.star
+++ b/src/interop/op-supervisor/op_supervisor_launcher.star
@@ -72,12 +72,12 @@ def launch(
         observability_helper,
     )
 
-    supervisor_service = plan.add_service(
+    service = plan.add_service(
         interop_constants.SUPERVISOR_SERVICE_NAME, config
     )
 
     observability.register_op_service_metrics_job(
-        observability_helper, supervisor_service, supervisor_params.network
+        observability_helper, service,
     )
 
     return "op_supervisor"

--- a/src/interop/op-supervisor/op_supervisor_launcher.star
+++ b/src/interop/op-supervisor/op_supervisor_launcher.star
@@ -72,12 +72,11 @@ def launch(
         observability_helper,
     )
 
-    service = plan.add_service(
-        interop_constants.SUPERVISOR_SERVICE_NAME, config
-    )
+    service = plan.add_service(interop_constants.SUPERVISOR_SERVICE_NAME, config)
 
     observability.register_op_service_metrics_job(
-        observability_helper, service,
+        observability_helper,
+        service,
     )
 
     return "op_supervisor"

--- a/src/observability/observability.star
+++ b/src/observability/observability.star
@@ -105,7 +105,7 @@ def register_service_metrics_job(
         "service": service_name,
         "namespace": service_name,
     }
-    if(network_name != None):
+    if network_name != None:
         labels["stack_optimism_io_network"] = network_name
 
     labels.update(additional_labels)

--- a/src/observability/observability.star
+++ b/src/observability/observability.star
@@ -83,7 +83,7 @@ def new_metrics_job(
     }
 
 
-def register_op_service_metrics_job(helper, service, network_name):
+def register_op_service_metrics_job(helper, service, network_name=None):
     register_service_metrics_job(
         helper,
         service_name=service.name,
@@ -95,8 +95,8 @@ def register_op_service_metrics_job(helper, service, network_name):
 def register_service_metrics_job(
     helper,
     service_name,
-    network_name,
     endpoint,
+    network_name=None,
     metrics_path="",
     additional_labels={},
     scrape_interval=DEFAULT_SCRAPE_INTERVAL,

--- a/src/observability/observability.star
+++ b/src/observability/observability.star
@@ -104,8 +104,10 @@ def register_service_metrics_job(
     labels = {
         "service": service_name,
         "namespace": service_name,
-        "stack_optimism_io_network": network_name,
     }
+    if(network_name != None):
+        labels["stack_optimism_io_network"] = network_name
+
     labels.update(additional_labels)
 
     add_metrics_job(

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -123,7 +123,6 @@ def input_parser(plan, input_args):
                     "dependency_set"
                 ],
                 extra_params=results["interop"]["supervisor_params"]["extra_params"],
-                network=results["interop"]["supervisor_params"]["network"],
             ),
         ),
         altda_deploy_config=struct(
@@ -516,7 +515,6 @@ def default_supervisor_params():
         "image": DEFAULT_SUPERVISOR_IMAGES["op-supervisor"],
         "dependency_set": "",
         "extra_params": [],
-        "network": constants.NETWORK_NAME,
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -63,7 +63,6 @@ SUPERVISOR_PARAMS = [
     "image",
     "dependency_set",
     "extra_params",
-    "network",
 ]
 
 ALTDA_DEPLOY_CONFIG_PARAMS = [


### PR DESCRIPTION
This PR follows up on the fix made in https://github.com/ethpandaops/optimism-package/pull/187 to make the network label optional, as `op-supervisor`is an interop component and hence not specific to any one network.