### PR TITLE
chore: pin all upstream packages

### DIFF
--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -4,3 +4,5 @@ description: |
   This is a Kurtosis package for deploying an Optimism Rollup
 replace:
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@4.5.0
+  github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@f5ce159aec728898e3deb827f6b921f8ecfc527f
+  github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae173


### PR DESCRIPTION
For reproducibility reasons, let's make sure we have a properly
captured set of packages that we will use when deploying
optimism-package.
