### PR TITLE
feat: add new lint tool

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,3 +14,9 @@ open-service enclaveName serviceName:
 open-grafana enclaveName:
     just open-service {{enclaveName}} grafana
     
+# TODO(enable more checks)
+lint:
+    kurtosis-lint \
+        --checked-calls \
+        --local-imports \
+        main.star src/

--- a/mise.toml
+++ b/mise.toml
@@ -4,3 +4,6 @@
 "ubi:ethereum-optimism/kurtosis-test" = "0.0.1"
 "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.4.4"
 "yq" = "v4.44.3"
+
+# lint
+"pipx:ethereum-optimism/kurtosis-lint" = "v0.0.3"


### PR DESCRIPTION
This change makes use of a tool developed separately:
https://github.com/ethereum-optimism/kurtosis-lint to identify common
pitfalls while developing Kurtosis starlark code.

To give a quick idea, I broke a bunch of things on purpose, and the tool complained:

Running analysis...
.../optimism-package/main.star:2: Imported module './src/contracts/contract_deploy.star' does not exist at resolved path '.../optimism-package/src/contracts/contract_deploy.star'
.../optimism-package/main.star:40: Call to non-existent function 'input_parse' in module 'input_parser'
.../optimism-package/main.star:50: Too many positional arguments in call to 'observability.star:make_helper'
.../optimism-package/main.star:90: Module 'contract_deployer' has not been analyzed for call to 'contract_deployer.deploy_contracts'
.../optimism-package/main.star:107: Missing required positional argument 'interop_params' in call to 'l2.star:launch_l2'

Analyzed 38 .star files
Found 5 violations in the analyzed file(s)

Bottom-line, the goal is to make code maintenance a bit more
comfortable, by identifying classes of issues that easily appear
during refactoring operations, therefore slightly discouraging them.

Note that not all checks are enabled for now (because they don't pass !).
And also that this is not enabled in CI yet (because the tool is
brand-new, and probably buggy)
