### PR TITLE
chore: Run lint in CI

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -65,5 +65,5 @@ jobs:
         uses: jdx/mise-action@v2
 
       - name: Run kurtosis-test tests
-        run: kurtosis-test .
+        run: just test
 

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -53,7 +53,7 @@ jobs:
         uses: jdx/mise-action@v2
 
       - name: Kurtosis Lint
-        run: kurtosis lint ${{ github.workspace }}
+        run: just lint
 
   test:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -20,3 +20,6 @@ lint:
         --checked-calls \
         --local-imports \
         main.star src/
+
+test:
+    kurtosis-test .

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 
 # Core dependencies
+just = "1.38.0"
 "ubi:ethereum-optimism/kurtosis-test" = "0.0.1"
 "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.4.4"
 "yq" = "v4.44.3"


### PR DESCRIPTION
**Description**

- Runs the new `lint` target on the CI
- Add `just` to `mise.toml`
- Adds a `test` just target