### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/workflows/conventional-pr-title-checker.yml
+++ b/.github/workflows/conventional-pr-title-checker.yml
@@ -17,6 +17,6 @@ jobs:
   title_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - id: set-matrix
         # List all yaml files in the .github/tests directory, except for the k8s.yaml file
         run: echo "matrix=$(ls ./.github/tests/*.yaml | grep -vE 'k8s.yaml$' | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
@@ -25,7 +25,7 @@ jobs:
     continue-on-error: true  # Prevent the whole job from failing due to one test failure
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup Kurtosis
         run: |
@@ -57,7 +57,7 @@ jobs:
 
       - name: Notify
         if: (cancelled() || failure()) && env.discord_webhook_set == 'true'
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@08d9328877d6954120eef2b07abbc79249bb6210 # master
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
@@ -68,7 +68,7 @@ jobs:
     continue-on-error: true  # Ensure failure here doesn't stop other jobs
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup Kurtosis
         run: |

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2
 
       - name: Run Starlark
         run: kurtosis run ${{ github.workspace }} --args-file ${{ matrix.file_name }} --verbosity detailed
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup Kurtosis
         run: |
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2
 
       - name: Kurtosis Lint
         run: kurtosis lint ${{ github.workspace }}
@@ -59,10 +59,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2
 
       - name: Run kurtosis-test tests
         run: kurtosis-test .

--- a/.github/workflows/run-k8s.yml
+++ b/.github/workflows/run-k8s.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup minikube
         id: minikube
-        uses: medyagh/setup-minikube@latest
+        uses: medyagh/setup-minikube@cea33675329b799adccc9526aa5daccc26cd5052 # latest
       - name: Get kubeconfig
         id: kubeconfig
         shell: bash
@@ -34,7 +34,7 @@ jobs:
       # run kurtosis test and assertoor
       - name: Run kurtosis testnet
         id: testnet
-        uses: ethpandaops/kurtosis-assertoor-github-action@v1
+        uses: ethpandaops/kurtosis-assertoor-github-action@5932604b244dbd2ddb811516b516a9094f4d2c2f # v1
         with:
           kurtosis_extra_args: "--image-download always --non-blocking-tasks --verbosity DETAILED"
           kurtosis_backend: "kubernetes"
@@ -60,7 +60,7 @@ jobs:
 
       - name: Notify
         if: (cancelled() || failure()) && env.discord_webhook_set == 'true'
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@08d9328877d6954120eef2b07abbc79249bb6210 # master
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.