### PR TITLE
fix(util): name artifacts created by write_to_file

### DIFF
--- a/src/util.star
+++ b/src/util.star
@@ -36,7 +36,9 @@ def write_to_file(plan, contents, directory, file_name):
     run = plan.run_sh(
         description="Write value to a file artifact",
         image=DEPLOYMENT_UTILS_IMAGE,
-        store=[file_path],
+        store=[
+            StoreSpec(src=file_path, name=file_name),
+        ],
         run="mkdir -p '{0}' && echo '{2}' > '{1}'".format(
             directory, file_path, contents
         ),


### PR DESCRIPTION
Calls to write_file are currently the only ones that create artifacts
with generated names, which is needlessly getting in the way of
looking at the outcomes.

We have 2 call sites for this function:
- dependency_set.json
- intent.json

Arguably the latter is not super useful to expose, as it's an
intermediate representation of what eventually lands in
op-deployer-configs, but it doesn't hurt either.