### PR TITLE
feat(op-signer): add op-signer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,17 @@ optimism_package:
         # Interval between submitting L2 output proposals
         proposal_internal: 10m
 
+      # Default signer configuration
+      signer_params:
+        # The Docker image that should be used for the signer; leave blank to use the default image
+        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-signer
+
+        # The Docker tag that should be used for the signer; leave blank to use the default tag
+        tag: ""
+
+        # A list of optional extra params that will be passed to the signer container for modifying its behaviour
+        extra_params: []
+
       # Default MEV configuration
       mev_params:
         # The Docker image that should be used for rollup boost; leave blank to use the default rollup-boost image

--- a/justfile
+++ b/justfile
@@ -20,3 +20,6 @@ lint:
         --checked-calls \
         --local-imports \
         main.star src/ test/
+
+test:
+    mise exec -- kurtosis-test .

--- a/main.star
+++ b/main.star
@@ -107,7 +107,6 @@ def run(plan, args={}):
             l2_launcher.launch_l2(
                 plan,
                 l2_num,
-                chain.network_params.name,
                 chain,
                 jwt_file,
                 deployment_output,
@@ -133,30 +132,6 @@ def run(plan, args={}):
             interop_params.supervisor_params,
             observability_helper,
         )
-
-    # challenger must launch after supervisor because it depends on it for interop
-    for l2_num, l2 in enumerate(l2s):
-        chain = optimism_args.chains[l2_num]
-        op_challenger_image = (
-            chain.challenger_params.image
-            if chain.challenger_params.image != ""
-            else input_parser.DEFAULT_CHALLENGER_IMAGES["op-challenger"]
-        )
-        if chain.challenger_params.enabled:
-            op_challenger_launcher.launch(
-                plan,
-                l2_num,
-                "op-challenger-{0}".format(chain.network_params.name),
-                chain.challenger_params.image,
-                l2.participants[0].el_context,
-                l2.participants[0].cl_context,
-                l1_config_env_vars,
-                deployment_output,
-                chain.network_params,
-                chain.challenger_params,
-                interop_params,
-                observability_helper,
-            )
 
     observability.launch(
         plan, observability_helper, global_node_selectors, observability_params

--- a/src/alt-da/da-server/da_server_launcher.star
+++ b/src/alt-da/da-server/da_server_launcher.star
@@ -25,13 +25,14 @@ def get_used_ports():
 
 def launch_da_server(
     plan,
-    service_name,
     image,
     cmd,
+    network_params,
 ):
+    service_name = "da-server-{0}".format(network_params.name)
+
     config = get_da_server_config(
         plan,
-        service_name,
         image,
         cmd,
     )
@@ -49,7 +50,6 @@ def launch_da_server(
 
 def get_da_server_config(
     plan,
-    service_name,
     image,
     cmd,
 ):

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -100,9 +100,6 @@ def get_batcher_config(
         "--num-confirmations=1",
         "--safe-abort-nonce-too-low-count=3",
         "--resubmission-timeout=30s",
-        "--rpc.addr=0.0.0.0",
-        "--rpc.port=" + str(BATCHER_HTTP_PORT_NUM),
-        "--rpc.enable-admin",
         "--max-channel-duration=1",
         "--l1-eth-rpc=" + l1_config_env_vars["L1_RPC_URL"],
         "--private-key=" + batcher_key,
@@ -119,6 +116,7 @@ def get_batcher_config(
     # apply customizations
 
     util.disable_op_service_tls(cmd)
+    util.configure_op_service_rpc(cmd, BATCHER_HTTP_PORT_NUM)
     op_signer_launcher.configure_op_signer(cmd, batcher_address)
 
     if observability_helper.enabled:

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -42,6 +42,7 @@ def launch(
     el_context,
     cl_context,
     l1_config_env_vars,
+    signer_service,
     batcher_key,
     deployment_output,
     batcher_params,
@@ -64,6 +65,7 @@ def launch(
         el_context,
         cl_context,
         l1_config_env_vars,
+        signer_service,
         batcher_key,
         batcher_address,
         batcher_params,
@@ -83,6 +85,7 @@ def make_service_config(
     el_context,
     cl_context,
     l1_config_env_vars,
+    signer_service,
     batcher_key,
     batcher_address,
     batcher_params,
@@ -116,7 +119,7 @@ def make_service_config(
     # apply customizations
 
     util.configure_op_service_rpc(cmd, HTTP_PORT_NUM)
-    op_signer_launcher.configure_op_signer(cmd, batcher_address)
+    op_signer_launcher.configure_op_signer(cmd, signer_service, batcher_address)
 
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -49,19 +49,24 @@ def launch(
     observability_helper,
     da_server_context,
 ):
-    service_instance_name = util.make_service_instance_name(SERVICE_NAME, network_params)
+    service_instance_name = util.make_service_instance_name(
+        SERVICE_NAME, network_params
+    )
 
-    service = plan.add_service(service_instance_name, make_service_config(
-        plan,
-        el_context,
-        cl_context,
-        l1_config_env_vars,
-        signer_service,
-        signer_client,
-        batcher_params,
-        observability_helper,
-        da_server_context,
-    ))
+    service = plan.add_service(
+        service_instance_name,
+        make_service_config(
+            plan,
+            el_context,
+            cl_context,
+            l1_config_env_vars,
+            signer_service,
+            signer_client,
+            batcher_params,
+            observability_helper,
+            da_server_context,
+        ),
+    )
 
     observability.register_op_service_metrics_job(
         observability_helper, service, network_params.network

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -106,8 +106,6 @@ def get_batcher_config(
         "--max-channel-duration=1",
         "--l1-eth-rpc=" + l1_config_env_vars["L1_RPC_URL"],
         "--private-key=" + batcher_key,
-        "--signer.endpoint=" + op_signer_launcher.ENDPOINT,
-        "--signer.address=" + batcher_address,
         # da commitments currently have to be sent as calldata to the batcher inbox
         "--data-availability-type="
         + ("calldata" if da_server_context.enabled else "blobs"),
@@ -119,6 +117,9 @@ def get_batcher_config(
     ]
 
     # apply customizations
+
+    util.disable_op_service_tls(cmd)
+    op_signer_launcher.configure_op_signer(cmd, batcher_address)
 
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -6,6 +6,7 @@ ethereum_package_constants = import_module(
     "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
 )
 
+input_parser = import_module("../../input_parser.star")
 constants = import_module("../../package_io/constants.star")
 util = import_module("../../util.star")
 
@@ -41,7 +42,6 @@ ENTRYPOINT_ARGS = ["sh", "-c"]
 
 def launch(
     plan,
-    image,
     el_context,
     cl_context,
     l1_config_env_vars,
@@ -64,7 +64,6 @@ def launch(
 
     config = get_batcher_config(
         plan,
-        image,
         el_context,
         cl_context,
         l1_config_env_vars,
@@ -86,7 +85,6 @@ def launch(
 
 def get_batcher_config(
     plan,
-    image,
     el_context,
     cl_context,
     l1_config_env_vars,
@@ -129,6 +127,13 @@ def get_batcher_config(
         observability.configure_op_service_metrics(cmd, ports)
 
     cmd += batcher_params.extra_params
+
+    # legacy default image logic
+    image = (
+        batcher_params.image
+        if batcher_params.image != ""
+        else input_parser.DEFAULT_BATCHER_IMAGES[SERVICE_NAME]
+    )
 
     return ServiceConfig(
         image=image,

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -37,7 +37,6 @@ ENTRYPOINT_ARGS = ["sh", "-c"]
 
 def launch(
     plan,
-    service_name,
     image,
     el_context,
     cl_context,
@@ -48,10 +47,11 @@ def launch(
     observability_helper,
     da_server_context,
 ):
+    service_name = "op-batcher-{0}".format(network_params.name)
+
     config = get_batcher_config(
         plan,
         image,
-        service_name,
         el_context,
         cl_context,
         l1_config_env_vars,
@@ -73,7 +73,6 @@ def launch(
 def get_batcher_config(
     plan,
     image,
-    service_name,
     el_context,
     cl_context,
     l1_config_env_vars,

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -62,13 +62,12 @@ def launch(
     )
 
     service = plan.add_service(service_name, config)
-    service_url = util.make_service_http_url(service)
 
     observability.register_op_service_metrics_job(
         observability_helper, service, network_params.network
     )
 
-    return service_url
+    return service
 
 
 def get_batcher_config(

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -15,7 +15,8 @@ op_signer_launcher = import_module("../../signer/op_signer_launcher.star")
 #
 #  ---------------------------------- Batcher client -------------------------------------
 
-SERVICE_NAME = "op-batcher"
+SERVICE_TYPE = "batcher"
+SERVICE_NAME = util.make_op_service_name(SERVICE_TYPE)
 
 # The Docker container runs as the "op-batcher" user so we can't write to root
 BATCHER_DATA_DIRPATH_ON_SERVICE_CONTAINER = "/data/{0}/{0}-data".format(SERVICE_NAME)
@@ -51,9 +52,15 @@ def launch(
     observability_helper,
     da_server_context,
 ):
-    service_name = util.make_service_name(SERVICE_NAME, network_params)
+    service_instance_name = util.make_service_instance_name(SERVICE_NAME, network_params)
 
-    batcher_address = util.read_service_network_config_value(plan, deployment_output, "batcher", network_params, ".address")
+    batcher_address = util.read_service_network_config_value(
+        plan,
+        deployment_output,
+        SERVICE_TYPE,
+        network_params,
+        ".address",
+    )
 
     config = get_batcher_config(
         plan,
@@ -68,7 +75,7 @@ def launch(
         da_server_context,
     )
 
-    service = plan.add_service(service_name, config)
+    service = plan.add_service(service_instance_name, config)
 
     observability.register_op_service_metrics_job(
         observability_helper, service, network_params.network

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -115,7 +115,6 @@ def get_batcher_config(
 
     # apply customizations
 
-    util.disable_op_service_tls(cmd)
     util.configure_op_service_rpc(cmd, BATCHER_HTTP_PORT_NUM)
     op_signer_launcher.configure_op_signer(cmd, batcher_address)
 

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -53,7 +53,7 @@ def launch(
 ):
     service_name = util.make_service_name(SERVICE_NAME, network_params)
 
-    batcher_address = util.read_service_network_config_value(plan, deployment_output, "batcher", network_params.network_id, ".address")
+    batcher_address = util.read_service_network_config_value(plan, deployment_output, "batcher", network_params, ".address")
 
     config = get_batcher_config(
         plan,

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -42,8 +42,7 @@ def launch(
     el_context,
     cl_context,
     l1_config_env_vars,
-    signer_service,
-    signer_client,
+    signer_context,
     batcher_params,
     network_params,
     observability_helper,
@@ -60,8 +59,7 @@ def launch(
             el_context,
             cl_context,
             l1_config_env_vars,
-            signer_service,
-            signer_client,
+            signer_context,
             batcher_params,
             observability_helper,
             da_server_context,
@@ -80,8 +78,7 @@ def make_service_config(
     el_context,
     cl_context,
     l1_config_env_vars,
-    signer_service,
-    signer_client,
+    signer_context,
     batcher_params,
     observability_helper,
     da_server_context,
@@ -99,7 +96,7 @@ def make_service_config(
         "--resubmission-timeout=30s",
         "--max-channel-duration=1",
         "--l1-eth-rpc=" + l1_config_env_vars["L1_RPC_URL"],
-        "--private-key=" + signer_client.key,
+        "--private-key=" + signer_context.clients[SERVICE_TYPE].key,
         # da commitments currently have to be sent as calldata to the batcher inbox
         "--data-availability-type="
         + ("calldata" if da_server_context.enabled else "blobs"),
@@ -115,7 +112,7 @@ def make_service_config(
     # apply customizations
 
     util.configure_op_service_rpc(cmd, HTTP_PORT_NUM)
-    op_signer_launcher.configure_op_signer(cmd, files, signer_service, signer_client)
+    op_signer_launcher.configure_op_signer(cmd, files, signer_context, SERVICE_TYPE)
 
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -62,7 +62,7 @@ def launch(
         ".address",
     )
 
-    config = get_batcher_config(
+    service = plan.add_service(service_instance_name, make_service_config(
         plan,
         el_context,
         cl_context,
@@ -72,9 +72,7 @@ def launch(
         batcher_params,
         observability_helper,
         da_server_context,
-    )
-
-    service = plan.add_service(service_instance_name, config)
+    ))
 
     observability.register_op_service_metrics_job(
         observability_helper, service, network_params.network
@@ -83,7 +81,7 @@ def launch(
     return service
 
 
-def get_batcher_config(
+def make_service_config(
     plan,
     el_context,
     cl_context,

--- a/src/batcher/op-batcher/op_batcher_launcher.star
+++ b/src/batcher/op-batcher/op_batcher_launcher.star
@@ -6,7 +6,7 @@ ethereum_package_constants = import_module(
     "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
 )
 
-input_parser = import_module("../../input_parser.star")
+input_parser = import_module("../../package_io/input_parser.star")
 constants = import_module("../../package_io/constants.star")
 util = import_module("../../util.star")
 
@@ -19,17 +19,14 @@ op_signer_launcher = import_module("../../signer/op_signer_launcher.star")
 SERVICE_TYPE = "batcher"
 SERVICE_NAME = util.make_op_service_name(SERVICE_TYPE)
 
-# The Docker container runs as the "op-batcher" user so we can't write to root
-BATCHER_DATA_DIRPATH_ON_SERVICE_CONTAINER = "/data/{0}/{0}-data".format(SERVICE_NAME)
-
 # Port nums
-BATCHER_HTTP_PORT_NUM = 8548
+HTTP_PORT_NUM = 8548
 
 
 def get_used_ports():
     used_ports = {
         constants.HTTP_PORT_ID: ethereum_package_shared_utils.new_port_spec(
-            BATCHER_HTTP_PORT_NUM,
+            HTTP_PORT_NUM,
             ethereum_package_shared_utils.TCP_PROTOCOL,
             ethereum_package_shared_utils.HTTP_APPLICATION_PROTOCOL,
         ),
@@ -118,7 +115,7 @@ def make_service_config(
 
     # apply customizations
 
-    util.configure_op_service_rpc(cmd, BATCHER_HTTP_PORT_NUM)
+    util.configure_op_service_rpc(cmd, HTTP_PORT_NUM)
     op_signer_launcher.configure_op_signer(cmd, batcher_address)
 
     if observability_helper.enabled:

--- a/src/blockscout/blockscout_launcher.star
+++ b/src/blockscout/blockscout_launcher.star
@@ -44,7 +44,6 @@ VERIF_USED_PORTS = {
 
 def launch_blockscout(
     plan,
-    l2_services_suffix,
     l1_rpc_url,
     l2_el_context,
     l2_network_name,
@@ -61,17 +60,13 @@ def launch_blockscout(
 
     postgres_output = postgres.run(
         plan,
-        service_name="{0}-postgres{1}".format(
-            SERVICE_NAME_BLOCKSCOUT, l2_services_suffix
-        ),
+        service_name="{0}-postgres{1}".format(SERVICE_NAME_BLOCKSCOUT, l2_network_name),
         database="blockscout",
         extra_configs=["max_connections=1000"],
     )
 
     config_verif = get_config_verif()
-    verif_service_name = "{0}-verif{1}".format(
-        SERVICE_NAME_BLOCKSCOUT, l2_services_suffix
-    )
+    verif_service_name = "{0}-verif{1}".format(SERVICE_NAME_BLOCKSCOUT, l2_network_name)
     verif_service = plan.add_service(verif_service_name, config_verif)
     verif_url = "http://{}:{}".format(
         verif_service.hostname, verif_service.ports["http"].number
@@ -93,7 +88,7 @@ def launch_blockscout(
         },
     )
     blockscout_service = plan.add_service(
-        "{0}{1}".format(SERVICE_NAME_BLOCKSCOUT, l2_services_suffix), config_backend
+        "{0}{1}".format(SERVICE_NAME_BLOCKSCOUT, l2_network_name), config_backend
     )
     plan.print(blockscout_service)
 

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -41,7 +41,9 @@ def launch(
     interop_params,
     observability_helper,
 ):
-    service_instance_name = util.make_service_instance_name(SERVICE_NAME, network_params)
+    service_instance_name = util.make_service_instance_name(
+        SERVICE_NAME, network_params
+    )
 
     cannon_prestate_artifact = None
     if challenger_params.cannon_prestate_path:
@@ -50,21 +52,24 @@ def launch(
             name="{}-prestates".format(service_instance_name),
         )
 
-    service = plan.add_service(service_instance_name, make_service_config(
-        plan,
-        cannon_prestate_artifact,
-        el_context,
-        cl_context,
-        l1_config_env_vars,
-        signer_service,
-        signer_client,
-        game_factory_address,
-        deployment_output,
-        network_params,
-        challenger_params,
-        interop_params,
-        observability_helper,
-    ))
+    service = plan.add_service(
+        service_instance_name,
+        make_service_config(
+            plan,
+            cannon_prestate_artifact,
+            el_context,
+            cl_context,
+            l1_config_env_vars,
+            signer_service,
+            signer_client,
+            game_factory_address,
+            deployment_output,
+            network_params,
+            challenger_params,
+            interop_params,
+            observability_helper,
+        ),
+    )
 
     observability.register_op_service_metrics_job(
         observability_helper, service, network_params.network
@@ -147,9 +152,7 @@ def make_service_config(
         fail("One of cannon_prestate_path or cannon_prestates_url must be set")
 
     cmd += challenger_params.extra_params
-    cmd = "mkdir -p {0} && {1}".format(
-        DATA_DIRPATH_ON_SERVICE_CONTAINER, " ".join(cmd)
-    )
+    cmd = "mkdir -p {0} && {1}".format(DATA_DIRPATH_ON_SERVICE_CONTAINER, " ".join(cmd))
 
     # legacy default image logic
     image = (

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -26,17 +26,20 @@ def get_used_ports():
 def launch(
     plan,
     l2_num,
-    service_name,
     image,
     el_context,
     cl_context,
     l1_config_env_vars,
+    challenger_key,
+    game_factory_address,
     deployment_output,
     network_params,
     challenger_params,
     interop_params,
     observability_helper,
 ):
+    service_name = "op-challenger-{0}".format(network_params.network)
+
     config = get_challenger_config(
         plan,
         l2_num,
@@ -45,6 +48,8 @@ def launch(
         el_context,
         cl_context,
         l1_config_env_vars,
+        challenger_key,
+        game_factory_address,
         deployment_output,
         network_params,
         challenger_params,
@@ -58,7 +63,7 @@ def launch(
         observability_helper, service, network_params.network
     )
 
-    return "op_challenger"
+    return service
 
 
 def get_challenger_config(
@@ -69,6 +74,8 @@ def get_challenger_config(
     el_context,
     cl_context,
     l1_config_env_vars,
+    challenger_key,
+    game_factory_address,
     deployment_output,
     network_params,
     challenger_params,
@@ -76,19 +83,6 @@ def get_challenger_config(
     observability_helper,
 ):
     ports = dict(get_used_ports())
-
-    game_factory_address = util.read_network_config_value(
-        plan,
-        deployment_output,
-        "state",
-        ".opChainDeployments[{0}].disputeGameFactoryProxyAddress".format(l2_num),
-    )
-    challenger_key = util.read_network_config_value(
-        plan,
-        deployment_output,
-        "challenger-{0}".format(network_params.network_id),
-        ".privateKey",
-    )
 
     cmd = [
         "op-challenger",

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -51,7 +51,7 @@ def launch(
         ".address",
     )
 
-    config = get_challenger_config(
+    service = plan.add_service(service_instance_name, make_service_config(
         plan,
         l2_num,
         service_instance_name,
@@ -66,9 +66,7 @@ def launch(
         challenger_params,
         interop_params,
         observability_helper,
-    )
-
-    service = plan.add_service(service_instance_name, config)
+    ))
 
     observability.register_op_service_metrics_job(
         observability_helper, service, network_params.network
@@ -77,7 +75,7 @@ def launch(
     return service
 
 
-def get_challenger_config(
+def make_service_config(
     plan,
     l2_num,
     service_instance_name,

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -32,6 +32,7 @@ def launch(
     el_context,
     cl_context,
     l1_config_env_vars,
+    signer_service,
     challenger_key,
     game_factory_address,
     deployment_output,
@@ -63,6 +64,7 @@ def launch(
         el_context,
         cl_context,
         l1_config_env_vars,
+        signer_service,
         challenger_key,
         challenger_address,
         game_factory_address,
@@ -86,6 +88,7 @@ def make_service_config(
     el_context,
     cl_context,
     l1_config_env_vars,
+    signer_service,
     challenger_key,
     challenger_address,
     game_factory_address,
@@ -127,7 +130,7 @@ def make_service_config(
 
     # apply customizations
 
-    op_signer_launcher.configure_op_signer(cmd, challenger_address)
+    op_signer_launcher.configure_op_signer(cmd, signer_service, challenger_address)
 
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -32,8 +32,7 @@ def launch(
     el_context,
     cl_context,
     l1_config_env_vars,
-    signer_service,
-    signer_client,
+    signer_context,
     game_factory_address,
     deployment_output,
     network_params,
@@ -60,8 +59,7 @@ def launch(
             el_context,
             cl_context,
             l1_config_env_vars,
-            signer_service,
-            signer_client,
+            signer_context,
             game_factory_address,
             deployment_output,
             network_params,
@@ -84,8 +82,7 @@ def make_service_config(
     el_context,
     cl_context,
     l1_config_env_vars,
-    signer_service,
-    signer_client,
+    signer_context,
     game_factory_address,
     deployment_output,
     network_params,
@@ -112,7 +109,7 @@ def make_service_config(
         "--l1-beacon=" + l1_config_env_vars["CL_RPC_URL"],
         "--l1-eth-rpc=" + l1_config_env_vars["L1_RPC_URL"],
         "--l2-eth-rpc=" + el_context.rpc_http_url,
-        "--private-key=" + signer_client.key,
+        "--private-key=" + signer_context.clients[SERVICE_TYPE].key,
         "--rollup-rpc=" + cl_context.beacon_http_url,
         "--trace-type=" + ",".join(challenger_params.cannon_trace_types),
     ]
@@ -125,7 +122,7 @@ def make_service_config(
 
     # apply customizations
 
-    op_signer_launcher.configure_op_signer(cmd, files, signer_service, signer_client)
+    op_signer_launcher.configure_op_signer(cmd, files, signer_context, SERVICE_TYPE)
 
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -160,7 +160,6 @@ def make_service_config(
     return ServiceConfig(
         image=image,
         ports=ports,
-        entrypoint=ENTRYPOINT_ARGS,
         cmd=cmd,
         files=files,
         private_ip_address_placeholder=ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -120,7 +120,6 @@ def get_challenger_config(
 
     # apply customizations
 
-    util.disable_op_service_tls(cmd)
     op_signer_launcher.configure_op_signer(cmd, challenger_address)
 
     if observability_helper.enabled:

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -108,8 +108,6 @@ def get_challenger_config(
         "--l1-eth-rpc=" + l1_config_env_vars["L1_RPC_URL"],
         "--l2-eth-rpc=" + el_context.rpc_http_url,
         "--private-key=" + challenger_key,
-        "--signer.endpoint=" + op_signer_launcher.ENDPOINT,
-        "--signer.address=" + challenger_address,
         "--rollup-rpc=" + cl_context.beacon_http_url,
         "--trace-type=" + ",".join(challenger_params.cannon_trace_types),
     ]
@@ -121,6 +119,9 @@ def get_challenger_config(
     }
 
     # apply customizations
+
+    util.disable_op_service_tls(cmd)
+    op_signer_launcher.configure_op_signer(cmd, challenger_address)
 
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -33,7 +33,7 @@ def launch(
     cl_context,
     l1_config_env_vars,
     signer_service,
-    challenger_key,
+    signer_client,
     game_factory_address,
     deployment_output,
     network_params,
@@ -42,14 +42,6 @@ def launch(
     observability_helper,
 ):
     service_instance_name = util.make_service_instance_name(SERVICE_NAME, network_params)
-
-    challenger_address = util.read_service_network_config_value(
-        plan,
-        deployment_output,
-        SERVICE_TYPE,
-        network_params,
-        ".address",
-    )
 
     cannon_prestate_artifact = None
     if challenger_params.cannon_prestate_path:
@@ -65,8 +57,7 @@ def launch(
         cl_context,
         l1_config_env_vars,
         signer_service,
-        challenger_key,
-        challenger_address,
+        signer_client,
         game_factory_address,
         deployment_output,
         network_params,
@@ -89,8 +80,7 @@ def make_service_config(
     cl_context,
     l1_config_env_vars,
     signer_service,
-    challenger_key,
-    challenger_address,
+    signer_client,
     game_factory_address,
     deployment_output,
     network_params,
@@ -117,7 +107,7 @@ def make_service_config(
         "--l1-beacon=" + l1_config_env_vars["CL_RPC_URL"],
         "--l1-eth-rpc=" + l1_config_env_vars["L1_RPC_URL"],
         "--l2-eth-rpc=" + el_context.rpc_http_url,
-        "--private-key=" + challenger_key,
+        "--private-key=" + signer_client.key,
         "--rollup-rpc=" + cl_context.beacon_http_url,
         "--trace-type=" + ",".join(challenger_params.cannon_trace_types),
     ]
@@ -130,7 +120,7 @@ def make_service_config(
 
     # apply customizations
 
-    op_signer_launcher.configure_op_signer(cmd, signer_service, challenger_address)
+    op_signer_launcher.configure_op_signer(cmd, files, signer_service, signer_client)
 
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -6,6 +6,7 @@ ethereum_package_constants = import_module(
     "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
 )
 
+input_parser = import_module("../../input_parser.star")
 observability = import_module("../../observability/observability.star")
 op_signer_launcher = import_module("../../signer/op_signer_launcher.star")
 
@@ -29,7 +30,6 @@ def get_used_ports():
 def launch(
     plan,
     l2_num,
-    image,
     el_context,
     cl_context,
     l1_config_env_vars,
@@ -55,7 +55,6 @@ def launch(
         plan,
         l2_num,
         service_instance_name,
-        image,
         el_context,
         cl_context,
         l1_config_env_vars,
@@ -82,7 +81,6 @@ def get_challenger_config(
     plan,
     l2_num,
     service_instance_name,
-    image,
     el_context,
     cl_context,
     l1_config_env_vars,
@@ -160,6 +158,13 @@ def get_challenger_config(
     cmd += challenger_params.extra_params
     cmd = "mkdir -p {0} && {1}".format(
         CHALLENGER_DATA_DIRPATH_ON_SERVICE_CONTAINER, " ".join(cmd)
+    )
+
+    # legacy default image logic
+    image = (
+        challenger_params.image
+        if challenger_params.image != ""
+        else input_parser.DEFAULT_CHALLENGER_IMAGES[SERVICE_NAME]
     )
 
     return ServiceConfig(

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -42,7 +42,7 @@ def launch(
 ):
     service_name = util.make_service_name(SERVICE_NAME, network_params)
 
-    challenger_address = util.read_service_network_config_value(plan, deployment_output, "challenger", network_params.network_id, ".address")
+    challenger_address = util.read_service_network_config_value(plan, deployment_output, "challenger", network_params, ".address")
 
     config = get_challenger_config(
         plan,

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -149,7 +149,6 @@ def make_service_config(
         fail("One of cannon_prestate_path or cannon_prestates_url must be set")
 
     cmd += challenger_params.extra_params
-    cmd = "mkdir -p {0} && {1}".format(DATA_DIRPATH_ON_SERVICE_CONTAINER, " ".join(cmd))
 
     # legacy default image logic
     image = (
@@ -162,7 +161,7 @@ def make_service_config(
         image=image,
         ports=ports,
         entrypoint=ENTRYPOINT_ARGS,
-        cmd=[cmd],
+        cmd=cmd,
         files=files,
         private_ip_address_placeholder=ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
     )

--- a/src/cl/op-node/op_node_builder_launcher.star
+++ b/src/cl/op-node/op_node_builder_launcher.star
@@ -247,11 +247,11 @@ def get_beacon_config(
         )
 
     if sequencer_enabled:
-        sequencer_private_key = util.read_network_config_value(
+        sequencer_private_key = util.read_service_private_key(
             plan,
             launcher.deployment_output,
-            "sequencer-{0}".format(launcher.network_params.network_id),
-            ".privateKey",
+            "sequencer",
+            launcher.network_params,
         )
 
         cmd += [

--- a/src/cl/op-node/op_node_builder_launcher.star
+++ b/src/cl/op-node/op_node_builder_launcher.star
@@ -179,9 +179,6 @@ def get_beacon_config(
             ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS,
             launcher.network_params.network_id,
         ),
-        "--rpc.addr=0.0.0.0",
-        "--rpc.port={0}".format(BEACON_HTTP_PORT_NUM),
-        "--rpc.enable-admin",
         "--l1={0}".format(l1_config_env_vars["L1_RPC_URL"]),
         "--l1.rpckind={0}".format(l1_config_env_vars["L1_RPC_KIND"]),
         "--l1.beacon={0}".format(l1_config_env_vars["CL_RPC_URL"]),
@@ -219,6 +216,8 @@ def get_beacon_config(
     env_vars = dict(participant.cl_builder_extra_env_vars)
 
     # apply customizations
+
+    util.configure_op_service_rpc(cmd, BEACON_HTTP_PORT_NUM)
 
     if observability_helper.enabled:
         cmd += [

--- a/src/cl/op-node/op_node_launcher.star
+++ b/src/cl/op-node/op_node_launcher.star
@@ -168,9 +168,6 @@ def get_beacon_config(
             ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS,
             launcher.network_params.network_id,
         ),
-        "--rpc.addr=0.0.0.0",
-        "--rpc.port={0}".format(BEACON_HTTP_PORT_NUM),
-        "--rpc.enable-admin",
         "--l1={0}".format(l1_config_env_vars["L1_RPC_URL"]),
         "--l1.rpckind={0}".format(l1_config_env_vars["L1_RPC_KIND"]),
         "--l1.beacon={0}".format(l1_config_env_vars["CL_RPC_URL"]),
@@ -209,14 +206,10 @@ def get_beacon_config(
 
     # apply customizations
 
-    if observability_helper.enabled:
-        cmd += [
-            "--metrics.enabled=true",
-            "--metrics.addr=0.0.0.0",
-            "--metrics.port={0}".format(observability.METRICS_PORT_NUM),
-        ]
+    util.configure_op_service_rpc(cmd, BEACON_HTTP_PORT_NUM)
 
-        observability.expose_metrics_port(ports)
+    if observability_helper.enabled:
+        observability.configure_op_service_metrics(cmd, ports)
 
     if interop_params.enabled:
         ports[

--- a/src/cl/op-node/op_node_launcher.star
+++ b/src/cl/op-node/op_node_launcher.star
@@ -236,11 +236,11 @@ def get_beacon_config(
         )
 
     if sequencer_enabled:
-        sequencer_private_key = util.read_network_config_value(
+        sequencer_private_key = util.read_service_private_key(
             plan,
             launcher.deployment_output,
-            "sequencer-{0}".format(launcher.network_params.network_id),
-            ".privateKey",
+            "sequencer",
+            launcher.network_params,
         )
 
         cmd += [

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -326,7 +326,7 @@ def deploy_contracts(
         }
         | contracts_extra_files,
         run=util.join_cmds(apply_cmds),
-        wait = None,
+        wait=None,
     )
 
     for chain in optimism_args.chains:

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -271,7 +271,7 @@ def deploy_contracts(
                 # convert op-deployer generated intent.toml to json
                 "dasel -r toml -w json -f {0}/intent.toml > {0}/intent-a.json".format(util.NETWORK_DATA_DIR),
                 # merge the two intent.json files, ensuring that the chains array is merged correctly
-                "jq -s 'add + {chains: map(.chains) | transpose | map(add)}' {0}/intent-a.json {0}/intent-b.json > {0}/intent-merged.json",
+                "jq -s 'add + {{chains: map(.chains) | transpose | map(add)}}' {0}/intent-a.json {0}/intent-b.json > {0}/intent-merged.json".format(util.NETWORK_DATA_DIR),
                 # convert the merged intent.json back to toml
                 "cat {0}/intent-merged.json | dasel -r json -w toml > {0}/intent.toml".format(util.NETWORK_DATA_DIR),
             ]

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -265,21 +265,33 @@ def deploy_contracts(
             [
                 # zhwrd: this mess is temporary until we implement json reading for op-deployer intent file
                 # convert intent_json to yaml. this is necessary because its unreliable to evaluate command substitutions in json.
-                "cat /tmp/intent.json | dasel -r json -w yaml > {0}/intent.yaml".format(util.NETWORK_DATA_DIR),
+                "cat /tmp/intent.json | dasel -r json -w yaml > {0}/intent.yaml".format(
+                    util.NETWORK_DATA_DIR
+                ),
                 # evaluate the command substitutions
-                "eval \"echo '$(cat {0}/intent.yaml)'\" | dasel -r yaml -w json > {0}/intent-b.json".format(util.NETWORK_DATA_DIR),
+                "eval \"echo '$(cat {0}/intent.yaml)'\" | dasel -r yaml -w json > {0}/intent-b.json".format(
+                    util.NETWORK_DATA_DIR
+                ),
                 # convert op-deployer generated intent.toml to json
-                "dasel -r toml -w json -f {0}/intent.toml > {0}/intent-a.json".format(util.NETWORK_DATA_DIR),
+                "dasel -r toml -w json -f {0}/intent.toml > {0}/intent-a.json".format(
+                    util.NETWORK_DATA_DIR
+                ),
                 # merge the two intent.json files, ensuring that the chains array is merged correctly
-                "jq -s 'add + {{chains: map(.chains) | transpose | map(add)}}' {0}/intent-a.json {0}/intent-b.json > {0}/intent-merged.json".format(util.NETWORK_DATA_DIR),
+                "jq -s 'add + {{chains: map(.chains) | transpose | map(add)}}' {0}/intent-a.json {0}/intent-b.json > {0}/intent-merged.json".format(
+                    util.NETWORK_DATA_DIR
+                ),
                 # convert the merged intent.json back to toml
-                "cat {0}/intent-merged.json | dasel -r json -w toml > {0}/intent.toml".format(util.NETWORK_DATA_DIR),
+                "cat {0}/intent-merged.json | dasel -r json -w toml > {0}/intent.toml".format(
+                    util.NETWORK_DATA_DIR
+                ),
             ]
         ),
     )
 
     apply_cmds = [
-        "op-deployer apply --l1-rpc-url $L1_RPC_URL --private-key $PRIVATE_KEY --workdir {0}".format(util.NETWORK_DATA_DIR),
+        "op-deployer apply --l1-rpc-url $L1_RPC_URL --private-key $PRIVATE_KEY --workdir {0}".format(
+            util.NETWORK_DATA_DIR
+        ),
     ]
     for chain in optimism_args.chains:
         network_id = chain.network_params.network_id
@@ -332,7 +344,9 @@ def deploy_contracts(
                 util.NETWORK_DATA_DIR: op_deployer_output.files_artifacts[0],
                 "/fund-script": fund_script_artifact,
             },
-            run='jq --from-file /fund-script/gen2spec.jq < "{0}/genesis-{1}.json" > "{0}/chainspec-{1}.json"'.format(util.NETWORK_DATA_DIR, chain.network_params.network_id),
+            run='jq --from-file /fund-script/gen2spec.jq < "{0}/genesis-{1}.json" > "{0}/chainspec-{1}.json"'.format(
+                util.NETWORK_DATA_DIR, chain.network_params.network_id
+            ),
         )
 
     return op_deployer_output.files_artifacts[0]
@@ -343,4 +357,6 @@ def chain_key(index, key):
 
 
 def read_chain_cmd(filename, l2_chain_id):
-    return "`jq -r .address {0}/{1}-{2}.json`".format(util.NETWORK_DATA_DIR, filename, l2_chain_id)
+    return "`jq -r .address {0}/{1}-{2}.json`".format(
+        util.NETWORK_DATA_DIR, filename, l2_chain_id
+    )

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -6,7 +6,7 @@ FACTORY_DEPLOYER_CODE = "0xf8a58085174876e800830186a08080b853604580600e600039806
 
 FUND_SCRIPT_FILEPATH = "../../static_files/scripts"
 
-utils = import_module("../util.star")
+util = import_module("../util.star")
 
 ethereum_package_genesis_constants = import_module(
     "github.com/ethpandaops/ethereum-package/src/prelaunch_data_generator/genesis_constants/genesis_constants.star"
@@ -85,15 +85,15 @@ def deploy_contracts(
         env_vars=l1_config_env_vars,
         store=[
             StoreSpec(
-                src="/network-data",
+                src=util.NETWORK_DATA_DIR,
                 name="op-deployer-configs",
             )
         ],
-        run=utils.join_cmds(
+        run=util.join_cmds(
             [
-                "mkdir -p /network-data",
-                "op-deployer init --intent-config-type custom --l1-chain-id $L1_CHAIN_ID --l2-chain-ids {0} --workdir /network-data".format(
-                    l2_chain_ids
+                "mkdir -p {0}".format(util.NETWORK_DATA_DIR),
+                "op-deployer init --intent-config-type custom --l1-chain-id $L1_CHAIN_ID --l2-chain-ids {0} --workdir {1}".format(
+                    l2_chain_ids, util.NETWORK_DATA_DIR
                 ),
             ]
         ),
@@ -118,7 +118,7 @@ def deploy_contracts(
     plan.run_sh(
         name="op-deployer-fund",
         description="Collect keys, and fund addresses",
-        image=utils.DEPLOYMENT_UTILS_IMAGE,
+        image=util.DEPLOYMENT_UTILS_IMAGE,
         env_vars={
             "DEPLOYER_PRIVATE_KEY": priv_key,
             "FUND_PRIVATE_KEY": ethereum_package_genesis_constants.PRE_FUNDED_ACCOUNTS[
@@ -130,12 +130,12 @@ def deploy_contracts(
         | l1_config_env_vars,
         store=[
             StoreSpec(
-                src="/network-data",
+                src=util.NETWORK_DATA_DIR,
                 name="op-deployer-configs",
             )
         ],
         files={
-            "/network-data": op_deployer_init.files_artifacts[0],
+            util.NETWORK_DATA_DIR: op_deployer_init.files_artifacts[0],
             "/fund-script": fund_script_artifact,
         },
         run='bash /fund-script/fund.sh "{0}"'.format(l2_chain_ids),
@@ -245,51 +245,51 @@ def deploy_contracts(
         intent["chains"].append(intent_chain)
 
     intent_json = json.encode(intent)
-    intent_json_artifact = utils.write_to_file(plan, intent_json, "/tmp", "intent.json")
+    intent_json_artifact = util.write_to_file(plan, intent_json, "/tmp", "intent.json")
 
     op_deployer_configure = plan.run_sh(
         name="op-deployer-configure",
         description="Configure L2 contract deployments",
-        image=utils.DEPLOYMENT_UTILS_IMAGE,
+        image=util.DEPLOYMENT_UTILS_IMAGE,
         store=[
             StoreSpec(
-                src="/network-data",
+                src=util.NETWORK_DATA_DIR,
                 name="op-deployer-configs",
             )
         ],
         files={
-            "/network-data": op_deployer_init.files_artifacts[0],
+            util.NETWORK_DATA_DIR: op_deployer_init.files_artifacts[0],
             "/tmp": intent_json_artifact,
         },
-        run=utils.join_cmds(
+        run=util.join_cmds(
             [
                 # zhwrd: this mess is temporary until we implement json reading for op-deployer intent file
                 # convert intent_json to yaml. this is necessary because its unreliable to evaluate command substitutions in json.
-                "cat /tmp/intent.json | dasel -r json -w yaml > /network-data/intent.yaml",
+                "cat /tmp/intent.json | dasel -r json -w yaml > {0}/intent.yaml".format(util.NETWORK_DATA_DIR),
                 # evaluate the command substitutions
-                "eval \"echo '$(cat /network-data/intent.yaml)'\" | dasel -r yaml -w json > /network-data/intent-b.json",
+                "eval \"echo '$(cat {0}/intent.yaml)'\" | dasel -r yaml -w json > {0}/intent-b.json".format(util.NETWORK_DATA_DIR),
                 # convert op-deployer generated intent.toml to json
-                "dasel -r toml -w json -f /network-data/intent.toml > /network-data/intent-a.json",
+                "dasel -r toml -w json -f {0}/intent.toml > {0}/intent-a.json".format(util.NETWORK_DATA_DIR),
                 # merge the two intent.json files, ensuring that the chains array is merged correctly
-                "jq -s 'add + {chains: map(.chains) | transpose | map(add)}' /network-data/intent-a.json /network-data/intent-b.json > /network-data/intent-merged.json",
+                "jq -s 'add + {chains: map(.chains) | transpose | map(add)}' {0}/intent-a.json {0}/intent-b.json > {0}/intent-merged.json",
                 # convert the merged intent.json back to toml
-                "cat /network-data/intent-merged.json | dasel -r json -w toml > /network-data/intent.toml",
+                "cat {0}/intent-merged.json | dasel -r json -w toml > {0}/intent.toml".format(util.NETWORK_DATA_DIR),
             ]
         ),
     )
 
     apply_cmds = [
-        "op-deployer apply --l1-rpc-url $L1_RPC_URL --private-key $PRIVATE_KEY --workdir /network-data",
+        "op-deployer apply --l1-rpc-url $L1_RPC_URL --private-key $PRIVATE_KEY --workdir {0}".format(util.NETWORK_DATA_DIR),
     ]
     for chain in optimism_args.chains:
         network_id = chain.network_params.network_id
         apply_cmds.extend(
             [
-                "op-deployer inspect genesis --workdir /network-data --outfile /network-data/genesis-{0}.json {0}".format(
-                    network_id
+                "op-deployer inspect genesis --workdir {0} --outfile {0}/genesis-{1}.json {1}".format(
+                    util.NETWORK_DATA_DIR, network_id
                 ),
-                "op-deployer inspect rollup --workdir /network-data --outfile /network-data/rollup-{0}.json {0}".format(
-                    network_id
+                "op-deployer inspect rollup --workdir {0} --outfile {0}/rollup-{1}.json {1}".format(
+                    util.NETWORK_DATA_DIR, network_id
                 ),
             ]
         )
@@ -305,34 +305,34 @@ def deploy_contracts(
         | l1_config_env_vars,
         store=[
             StoreSpec(
-                src="/network-data",
+                src=util.NETWORK_DATA_DIR,
                 name="op-deployer-configs",
             )
         ],
         files={
-            "/network-data": op_deployer_configure.files_artifacts[0],
+            util.NETWORK_DATA_DIR: op_deployer_configure.files_artifacts[0],
         }
         | contracts_extra_files,
-        run=utils.join_cmds(apply_cmds),
+        run=util.join_cmds(apply_cmds),
     )
 
     for chain in optimism_args.chains:
         plan.run_sh(
             name="op-deployer-generate-chainspec",
             description="Generate chainspec",
-            image=utils.DEPLOYMENT_UTILS_IMAGE,
+            image=util.DEPLOYMENT_UTILS_IMAGE,
             env_vars={"CHAIN_ID": str(chain.network_params.network_id)},
             store=[
                 StoreSpec(
-                    src="/network-data",
+                    src=util.NETWORK_DATA_DIR,
                     name="op-deployer-configs",
                 )
             ],
             files={
-                "/network-data": op_deployer_output.files_artifacts[0],
+                util.NETWORK_DATA_DIR: op_deployer_output.files_artifacts[0],
                 "/fund-script": fund_script_artifact,
             },
-            run='jq --from-file /fund-script/gen2spec.jq < "/network-data/genesis-$CHAIN_ID.json" > "/network-data/chainspec-$CHAIN_ID.json"',
+            run='jq --from-file /fund-script/gen2spec.jq < "{0}/genesis-{1}.json" > "{0}/chainspec-{1}.json"'.format(util.NETWORK_DATA_DIR, chain.network_params.network_id),
         )
 
     return op_deployer_output.files_artifacts[0]
@@ -343,4 +343,4 @@ def chain_key(index, key):
 
 
 def read_chain_cmd(filename, l2_chain_id):
-    return "`jq -r .address /network-data/{0}-{1}.json`".format(filename, l2_chain_id)
+    return "`jq -r .address {0}/{1}-{2}.json`".format(util.NETWORK_DATA_DIR, filename, l2_chain_id)

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -326,6 +326,7 @@ def deploy_contracts(
         }
         | contracts_extra_files,
         run=util.join_cmds(apply_cmds),
+        wait = None,
     )
 
     for chain in optimism_args.chains:

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -89,7 +89,7 @@ def deploy_contracts(
                 name="op-deployer-configs",
             )
         ],
-        run=" && ".join(
+        run=utils.join_cmds(
             [
                 "mkdir -p /network-data",
                 "op-deployer init --intent-config-type custom --l1-chain-id $L1_CHAIN_ID --l2-chain-ids {0} --workdir /network-data".format(
@@ -261,11 +261,11 @@ def deploy_contracts(
             "/network-data": op_deployer_init.files_artifacts[0],
             "/tmp": intent_json_artifact,
         },
-        run=" && ".join(
+        run=utils.join_cmds(
             [
                 # zhwrd: this mess is temporary until we implement json reading for op-deployer intent file
                 # convert intent_json to yaml. this is necessary because its unreliable to evaluate command substitutions in json.
-                """cat /tmp/intent.json | dasel -r json -w yaml > /network-data/intent.yaml""",
+                "cat /tmp/intent.json | dasel -r json -w yaml > /network-data/intent.yaml",
                 # evaluate the command substitutions
                 "eval \"echo '$(cat /network-data/intent.yaml)'\" | dasel -r yaml -w json > /network-data/intent-b.json",
                 # convert op-deployer generated intent.toml to json
@@ -313,7 +313,7 @@ def deploy_contracts(
             "/network-data": op_deployer_configure.files_artifacts[0],
         }
         | contracts_extra_files,
-        run=" && ".join(apply_cmds),
+        run=utils.join_cmds(apply_cmds),
     )
 
     for chain in optimism_args.chains:

--- a/src/el/op-besu/op_besu_launcher.star
+++ b/src/el/op-besu/op_besu_launcher.star
@@ -214,7 +214,7 @@ def get_config(
 
     if observability_helper.enabled:
         cmd += [
-            "--metrics-enabled=true",
+            "--metrics-enabled",
             "--metrics-host=0.0.0.0",
             "--metrics-port={0}".format(observability.METRICS_PORT_NUM),
         ]
@@ -240,12 +240,11 @@ def get_config(
         )
 
     cmd += participant.el_extra_params
-    cmd_str = " ".join(cmd)
 
     config_args = {
         "image": participant.el_image,
         "ports": ports,
-        "cmd": [cmd_str],
+        "cmd": cmd,
         "files": files,
         "entrypoint": ENTRYPOINT_ARGS,
         "private_ip_address_placeholder": ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -30,22 +30,21 @@ op_node_builder = import_module("./cl/op-node/op_node_builder_launcher.star")
 
 def launch(
     plan,
-    jwt_file,
     network_params,
     mev_params,
+    interop_params,
+    jwt_file,
     deployment_output,
     participants,
-    num_participants,
     l1_config_env_vars,
     l2_services_suffix,
+    da_server_context,
+    additional_services,
     global_log_level,
     global_node_selectors,
     global_tolerations,
     persistent,
-    additional_services,
     observability_helper,
-    interop_params,
-    da_server_context,
 ):
     el_launchers = {
         "op-geth": {
@@ -423,5 +422,5 @@ def launch(
         if sequencer_enabled:
             sequencer_enabled = False
 
-    plan.print("Successfully added {0} EL/CL participants".format(num_participants))
+    plan.print("Successfully added {0} EL/CL participants".format(len(participants)))
     return all_el_contexts, all_cl_contexts

--- a/src/l2.star
+++ b/src/l2.star
@@ -91,7 +91,7 @@ def launch_l2(
             network_params.network_id,
         )
         plan.print("Successfully launched op-blockscout")
-        
+
     if "tx_fuzzer" in l2_args.additional_services:
         plan.print("Launching transaction spammer")
         fuzz_target = "http://{0}:{1}".format(

--- a/src/l2.star
+++ b/src/l2.star
@@ -83,7 +83,6 @@ def launch_l2(
         plan.print("Launching op-blockscout")
         blockscout.launch_blockscout(
             plan,
-            l2_services_suffix,
             l1_rpc_url,
             all_el_contexts[0],  # first l2 EL url
             network_params.name,

--- a/src/l2.star
+++ b/src/l2.star
@@ -50,14 +50,8 @@ def launch_l2(
 
     l2 = participant_network.launch_participant_network(
         plan,
-        l2_args.participants,
+        l2_args,
         jwt_file,
-        network_params,
-        proxyd_params,
-        batcher_params,
-        challenger_params,
-        proposer_params,
-        mev_params,
         deployment_output,
         l1_config,
         l2_num,
@@ -66,7 +60,6 @@ def launch_l2(
         global_node_selectors,
         global_tolerations,
         persistent,
-        l2_args.additional_services,
         observability_helper,
         interop_params,
         da_server_context,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -359,6 +359,7 @@ def parse_network_params(plan, input_args):
 
         mev_params = default_mev_params()
         mev_params.update(chain.get("mev_params", {}))
+
         da_server_params = default_da_server_params()
         da_server_params.update(chain.get("da_server_params", {}))
 
@@ -630,7 +631,7 @@ def default_proposer_params():
 def default_signer_params():
     return {
         "image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-signer",
-        "tag": "v1.3.1"
+        "tag": "v1.4.0"
         "extra_params": [],
     }
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -245,6 +245,11 @@ def input_parser(plan, input_args):
                     game_type=result["proposer_params"]["game_type"],
                     proposal_interval=result["proposer_params"]["proposal_interval"],
                 ),
+                signer_params=struct(
+                    image=result["signer_params"]["image"],
+                    tag=result["signer_params"]["tag"],
+                    extra_params=result["signer_params"]["extra_params"],
+                ),
                 mev_params=struct(
                     rollup_boost_image=result["mev_params"]["rollup_boost_image"],
                     builder_host=result["mev_params"]["builder_host"],
@@ -349,6 +354,9 @@ def parse_network_params(plan, input_args):
         challenger_params = default_challenger_params()
         challenger_params.update(chain.get("challenger_params", {}))
 
+        signer_params = default_signer_params()
+        signer_params.update(chain.get("signer_params", {}))
+
         mev_params = default_mev_params()
         mev_params.update(chain.get("mev_params", {}))
         da_server_params = default_da_server_params()
@@ -432,6 +440,7 @@ def parse_network_params(plan, input_args):
             "batcher_params": batcher_params,
             "challenger_params": challenger_params,
             "proposer_params": proposer_params,
+            "signer_params": signer_params,
             "mev_params": mev_params,
             "da_server_params": da_server_params,
             "additional_services": chain.get(
@@ -559,6 +568,7 @@ def default_chains():
             "batcher_params": default_batcher_params(),
             "proposer_params": default_proposer_params(),
             "challenger_params": default_challenger_params(),
+            "signer_params": default_signer_params(),
             "mev_params": default_mev_params(),
             "da_server_params": default_da_server_params(),
             "additional_services": DEFAULT_ADDITIONAL_SERVICES,
@@ -614,6 +624,14 @@ def default_proposer_params():
         "extra_params": [],
         "game_type": 1,
         "proposal_interval": "10m",
+    }
+
+
+def default_signer_params():
+    return {
+        "image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-signer",
+        "tag": "v1.3.1"
+        "extra_params": [],
     }
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -631,7 +631,7 @@ def default_proposer_params():
 def default_signer_params():
     return {
         "image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-signer",
-        "tag": "v1.4.0",
+        "tag": "v1.4.1",
         "extra_params": [],
     }
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -631,7 +631,7 @@ def default_proposer_params():
 def default_signer_params():
     return {
         "image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-signer",
-        "tag": "v1.4.0"
+        "tag": "v1.4.0",
         "extra_params": [],
     }
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -631,7 +631,7 @@ def default_proposer_params():
 def default_signer_params():
     return {
         "image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-signer",
-        "tag": "v1.4.1",
+        "tag": "v1.5.0",
         "extra_params": [],
     }
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -155,6 +155,7 @@ SUBCATEGORY_PARAMS = {
         "cannon_prestates_url",
         "cannon_trace_types",
     ],
+    "signer_params": ["image", "tag", "extra_params"],
     "mev_params": ["rollup_boost_image", "builder_host", "builder_port"],
     "da_server_params": [
         "enabled",

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -121,14 +121,8 @@ def launch_participant_network(
         observability_helper,
     )
 
-    op_batcher_image = (
-        batcher_params.image
-        if batcher_params.image != ""
-        else input_parser.DEFAULT_BATCHER_IMAGES["op-batcher"]
-    )
     batcher_service = op_batcher_launcher.launch(
         plan,
-        op_batcher_image,
         all_el_contexts[0],
         all_cl_contexts[0],
         l1_config_env_vars,
@@ -146,14 +140,8 @@ def launch_participant_network(
         "state",
         ".opChainDeployments[{0}].disputeGameFactoryProxyAddress".format(l2_num),
     )
-    op_proposer_image = (
-        proposer_params.image
-        if proposer_params.image != ""
-        else input_parser.DEFAULT_PROPOSER_IMAGES["op-proposer"]
-    )
     proposer_service = op_proposer_launcher.launch(
         plan,
-        op_proposer_image,
         all_cl_contexts[0],
         l1_config_env_vars,
         proposer_key,
@@ -165,15 +153,9 @@ def launch_participant_network(
     )
 
     if challenger_params.enabled:
-        op_challenger_image = (
-            challenger_params.image
-            if challenger_params.image != ""
-            else input_parser.DEFAULT_CHALLENGER_IMAGES["op-challenger"]
-        )
         op_challenger_launcher.launch(
             plan,
             l2_num,
-            op_challenger_image,
             all_el_contexts[0],
             all_cl_contexts[0],
             l1_config_env_vars,

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -93,7 +93,9 @@ def launch_participant_network(
             op_signer_launcher.make_client(
                 op_challenger_launcher.SERVICE_TYPE,
                 op_challenger_launcher.SERVICE_NAME,
-            ) if challenger_params.enabled else None,
+            )
+            if challenger_params.enabled
+            else None,
         ],
     )
 

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -77,12 +77,11 @@ def launch_participant_network(
         observability_helper,
     )
 
-    batcher_key = util.read_service_network_config_value(
+    batcher_key = util.read_service_private_key(
         plan,
         deployment_output,
         "batcher",
-        network_params.network_id,
-        ".privateKey",
+        network_params,
     )
     op_batcher_image = (
         batcher_params.image
@@ -109,12 +108,11 @@ def launch_participant_network(
         "state",
         ".opChainDeployments[{0}].disputeGameFactoryProxyAddress".format(l2_num),
     )
-    proposer_key = util.read_service_network_config_value(
+    proposer_key = util.read_service_private_key(
         plan,
         deployment_output,
         "proposer",
-        network_params.network_id,
-        ".privateKey",
+        network_params,
     )
     op_proposer_image = (
         proposer_params.image
@@ -136,12 +134,11 @@ def launch_participant_network(
 
     challenger_service = None
     if challenger_params.enabled:
-        challenger_key = util.read_service_network_config_value(
+        challenger_key = util.read_service_private_key(
             plan,
             deployment_output,
             "challenger",
-            network_params.network_id,
-            ".privateKey",
+            network_params,
         )
         op_challenger_image = (
             challenger_params.image

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -136,10 +136,18 @@ def launch_participant_network(
         plan,
         chain_args.signer_params,
         network_params,
-        {
-            batcher_service.hostname: batcher_key,
-            proposer_service.hostname: proposer_key,
-        },
+        [
+            op_signer_launcher.make_client(
+                "batcher",
+                batcher_service.hostname,
+                batcher_key
+            ),
+            op_signer_launcher.make_client(
+                "proposer",
+                proposer_service.hostname,
+                proposer_key
+            ),
+        ],
         observability_helper,
     )
 

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -87,7 +87,8 @@ def launch_participant_network(
             op_batcher_launcher.SERVICE_TYPE: op_batcher_launcher.SERVICE_NAME,
             op_proposer_launcher.SERVICE_TYPE: op_proposer_launcher.SERVICE_NAME,
             op_challenger_launcher.SERVICE_TYPE: op_challenger_launcher.SERVICE_NAME
-            if challenger_params.enabled else None,
+            if challenger_params.enabled
+            else None,
         },
         observability_helper,
     )

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -96,6 +96,7 @@ def launch_participant_network(
         all_cl_contexts[0],
         l1_config_env_vars,
         batcher_key,
+        deployment_output,
         batcher_params,
         network_params,
         observability_helper,
@@ -127,6 +128,7 @@ def launch_participant_network(
         l1_config_env_vars,
         proposer_key,
         game_factory_address,
+        deployment_output,
         proposer_params,
         network_params,
         observability_helper,
@@ -181,7 +183,7 @@ def launch_participant_network(
                 "challenger",
                 challenger_service.hostname,
                 challenger_key
-            ) if challenger_service != None else None,
+            ) if challenger_params.enabled else None,
         ],
         observability_helper,
     )

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -77,6 +77,7 @@ def launch_participant_network(
         observability_helper,
     )
 
+    # get signer client keys
     batcher_key = util.read_service_private_key(
         plan,
         deployment_output,
@@ -97,7 +98,7 @@ def launch_participant_network(
     )
 
     # signer needs to start before its clients
-    op_signer_launcher.launch(
+    signer_service = op_signer_launcher.launch(
         plan,
         chain_args.signer_params,
         network_params,
@@ -126,6 +127,7 @@ def launch_participant_network(
         all_el_contexts[0],
         all_cl_contexts[0],
         l1_config_env_vars,
+        signer_service,
         batcher_key,
         deployment_output,
         batcher_params,
@@ -144,6 +146,7 @@ def launch_participant_network(
         plan,
         all_cl_contexts[0],
         l1_config_env_vars,
+        signer_service,
         proposer_key,
         game_factory_address,
         deployment_output,
@@ -158,6 +161,7 @@ def launch_participant_network(
             all_el_contexts[0],
             all_cl_contexts[0],
             l1_config_env_vars,
+            signer_service,
             challenger_key,
             game_factory_address,
             deployment_output,

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -155,7 +155,6 @@ def launch_participant_network(
     if challenger_params.enabled:
         op_challenger_launcher.launch(
             plan,
-            l2_num,
             all_el_contexts[0],
             all_cl_contexts[0],
             l1_config_env_vars,

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -83,20 +83,12 @@ def launch_participant_network(
         chain_args.signer_params,
         network_params,
         deployment_output,
-        [
-            op_signer_launcher.make_client(
-                op_batcher_launcher.SERVICE_TYPE,
-                op_batcher_launcher.SERVICE_NAME,
-            ),
-            op_signer_launcher.make_client(
-                op_proposer_launcher.SERVICE_TYPE,
-                op_proposer_launcher.SERVICE_NAME,
-            ),
-            op_signer_launcher.make_client(
-                op_challenger_launcher.SERVICE_TYPE,
-                op_challenger_launcher.SERVICE_NAME,
-            ) if challenger_params.enabled else None,
-        ],
+        {
+            op_batcher_launcher.SERVICE_TYPE: op_batcher_launcher.SERVICE_NAME,
+            op_proposer_launcher.SERVICE_TYPE: op_proposer_launcher.SERVICE_NAME,
+            op_challenger_launcher.SERVICE_TYPE: op_challenger_launcher.SERVICE_NAME
+            if challenger_params.enabled else None,
+        },
         observability_helper,
     )
 

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -6,6 +6,7 @@ op_challenger_launcher = import_module(
     "./challenger/op-challenger/op_challenger_launcher.star"
 )
 op_proposer_launcher = import_module("./proposer/op-proposer/op_proposer_launcher.star")
+op_signer_launcher = import_module("./signer/op_signer_launcher.star")
 proxyd_launcher = import_module("./proxyd/proxyd_launcher.star")
 util = import_module("./util.star")
 
@@ -22,26 +23,20 @@ def launch_participant_network(
     global_node_selectors,
     global_tolerations,
     persistent,
-    additional_services,
     observability_helper,
     interop_params,
     da_server_context,
 ):
     participants = chain_args.participants
     network_params = chain_args.network_params
-    proxyd_params = chain_args.proxyd_params
     batcher_params = chain_args.batcher_params
-    challenger_params = chain_args.challenger_params
     proposer_params = chain_args.proposer_params
-    signer_params = chain_args.signer_params
-    mev_params = chain_args.mev_params
 
-    num_participants = len(participants)
     # First EL and sequencer CL
     all_el_contexts, all_cl_contexts = el_cl_client_launcher.launch(
         plan,
         network_params,
-        mev_params,
+        chain_args.mev_params,
         interop_params,
         jwt_file,
         deployment_output,
@@ -49,7 +44,7 @@ def launch_participant_network(
         l1_config_env_vars,
         l2_services_suffix,
         da_server_context,
-        additional_services,
+        chain_args.additional_services,
         global_log_level,
         global_node_selectors,
         global_tolerations,
@@ -76,7 +71,7 @@ def launch_participant_network(
 
     proxyd_launcher.launch(
         plan,
-        proxyd_params,
+        chain_args.proxyd_params,
         network_params,
         all_el_contexts,
         observability_helper,
@@ -139,7 +134,7 @@ def launch_participant_network(
 
     op_signer_launcher.launch(
         plan,
-        signer_params,
+        chain_args.signer_params,
         network_params,
         {
             batcher_service.hostname: batcher_key,

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -77,8 +77,10 @@ def launch_participant_network(
         observability_helper,
     )
 
-    signer_clients = op_signer_launcher.generate_client_creds(
+    # signer needs to start before its clients
+    signer_context = op_signer_launcher.launch(
         plan,
+        chain_args.signer_params,
         network_params,
         deployment_output,
         [
@@ -93,18 +95,8 @@ def launch_participant_network(
             op_signer_launcher.make_client(
                 op_challenger_launcher.SERVICE_TYPE,
                 op_challenger_launcher.SERVICE_NAME,
-            )
-            if challenger_params.enabled
-            else None,
+            ) if challenger_params.enabled else None,
         ],
-    )
-
-    # signer needs to start before its clients
-    signer_service = op_signer_launcher.launch(
-        plan,
-        chain_args.signer_params,
-        network_params,
-        signer_clients,
         observability_helper,
     )
 
@@ -113,8 +105,7 @@ def launch_participant_network(
         all_el_contexts[0],
         all_cl_contexts[0],
         l1_config_env_vars,
-        signer_service,
-        signer_clients[op_batcher_launcher.SERVICE_TYPE],
+        signer_context,
         batcher_params,
         network_params,
         observability_helper,
@@ -131,8 +122,7 @@ def launch_participant_network(
         plan,
         all_cl_contexts[0],
         l1_config_env_vars,
-        signer_service,
-        signer_clients[op_proposer_launcher.SERVICE_TYPE],
+        signer_context,
         game_factory_address,
         proposer_params,
         network_params,
@@ -145,8 +135,7 @@ def launch_participant_network(
             all_el_contexts[0],
             all_cl_contexts[0],
             l1_config_env_vars,
-            signer_service,
-            signer_clients[op_challenger_launcher.SERVICE_TYPE],
+            signer_context,
             game_factory_address,
             deployment_output,
             network_params,

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -12,14 +12,8 @@ util = import_module("./util.star")
 
 def launch_participant_network(
     plan,
-    participants,
+    chain_args,
     jwt_file,
-    network_params,
-    proxyd_params,
-    batcher_params,
-    challenger_params,
-    proposer_params,
-    mev_params,
     deployment_output,
     l1_config_env_vars,
     l2_num,
@@ -33,26 +27,34 @@ def launch_participant_network(
     interop_params,
     da_server_context,
 ):
+    participants = chain_args.participants
+    network_params = chain_args.network_params
+    proxyd_params = chain_args.proxyd_params
+    batcher_params = chain_args.batcher_params
+    challenger_params = chain_args.challenger_params
+    proposer_params = chain_args.proposer_params
+    signer_params = chain_args.signer_params
+    mev_params = chain_args.mev_params
+
     num_participants = len(participants)
     # First EL and sequencer CL
     all_el_contexts, all_cl_contexts = el_cl_client_launcher.launch(
         plan,
-        jwt_file,
         network_params,
         mev_params,
+        interop_params,
+        jwt_file,
         deployment_output,
         participants,
-        num_participants,
         l1_config_env_vars,
         l2_services_suffix,
+        da_server_context,
+        additional_services,
         global_log_level,
         global_node_selectors,
         global_tolerations,
         persistent,
-        additional_services,
         observability_helper,
-        interop_params,
-        da_server_context,
     )
 
     all_participants = []
@@ -132,6 +134,17 @@ def launch_participant_network(
         game_factory_address,
         proposer_params,
         network_params,
+        observability_helper,
+    )
+
+    op_signer_launcher.launch(
+        plan,
+        signer_params,
+        network_params,
+        {
+            batcher_service.hostname: batcher_key,
+            proposer_service.hostname: proposer_key,
+        },
         observability_helper,
     )
 

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -91,7 +91,7 @@ def launch_participant_network(
         if batcher_params.image != ""
         else input_parser.DEFAULT_BATCHER_IMAGES["op-batcher"]
     )
-    op_batcher_launcher.launch(
+    batcher_service = op_batcher_launcher.launch(
         plan,
         "op-batcher-{0}".format(l2_services_suffix),
         op_batcher_image,
@@ -122,7 +122,7 @@ def launch_participant_network(
         if proposer_params.image != ""
         else input_parser.DEFAULT_PROPOSER_IMAGES["op-proposer"]
     )
-    op_proposer_launcher.launch(
+    proposer_service = op_proposer_launcher.launch(
         plan,
         "op-proposer-{0}".format(l2_services_suffix),
         op_proposer_image,

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -68,7 +68,7 @@ def launch(
         observability_helper, service, network_params.network
     )
 
-    return http_url
+    return service
 
 
 def get_proposer_config(

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -60,7 +60,7 @@ def launch(
         ".address",
     )
 
-    config = get_proposer_config(
+    service = plan.add_service(service_instance_name, make_service_config(
         plan,
         cl_context,
         l1_config_env_vars,
@@ -69,9 +69,7 @@ def launch(
         game_factory_address,
         proposer_params,
         observability_helper,
-    )
-
-    service = plan.add_service(service_instance_name, config)
+    ))
 
     observability.register_op_service_metrics_job(
         observability_helper, service, network_params.network
@@ -80,7 +78,7 @@ def launch(
     return service
 
 
-def get_proposer_config(
+def make_service_config(
     plan,
     cl_context,
     l1_config_env_vars,

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -13,8 +13,9 @@ observability = import_module("../../observability/observability.star")
 op_signer_launcher = import_module("../../signer/op_signer_launcher.star")
 
 #
-#  ---------------------------------- Batcher client -------------------------------------
-SERVICE_NAME = "op-proposer"
+#  ---------------------------------- Proposer client -------------------------------------
+SERVICE_TYPE = "proposer"
+SERVICE_NAME = util.make_op_service_name(SERVICE_TYPE)
 
 # The Docker container runs as the "op-proposer" user so we can't write to root
 DATA_DIRPATH_ON_SERVICE_CONTAINER = "/data/{0}/{0}-data".format(SERVICE_NAME)
@@ -49,9 +50,15 @@ def launch(
     network_params,
     observability_helper,
 ):
-    service_name = util.make_service_name(SERVICE_NAME, network_params)
+    service_instance_name = util.make_service_instance_name(SERVICE_NAME, network_params)
 
-    proposer_address = util.read_service_network_config_value(plan, deployment_output, "proposer", network_params, ".address")
+    proposer_address = util.read_service_network_config_value(
+        plan,
+        deployment_output,
+        SERVICE_TYPE,
+        network_params,
+        ".address",
+    )
 
     config = get_proposer_config(
         plan,
@@ -65,7 +72,7 @@ def launch(
         observability_helper,
     )
 
-    service = plan.add_service(service_name, config)
+    service = plan.add_service(service_instance_name, config)
 
     observability.register_op_service_metrics_job(
         observability_helper, service, network_params.network

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -43,8 +43,7 @@ def launch(
     plan,
     cl_context,
     l1_config_env_vars,
-    signer_service,
-    signer_client,
+    signer_context,
     game_factory_address,
     proposer_params,
     network_params,
@@ -60,8 +59,7 @@ def launch(
             plan,
             cl_context,
             l1_config_env_vars,
-            signer_service,
-            signer_client,
+            signer_context,
             game_factory_address,
             proposer_params,
             observability_helper,
@@ -79,8 +77,7 @@ def make_service_config(
     plan,
     cl_context,
     l1_config_env_vars,
-    signer_service,
-    signer_client,
+    signer_context,
     game_factory_address,
     proposer_params,
     observability_helper,
@@ -105,7 +102,7 @@ def make_service_config(
 
     # apply customizations
 
-    op_signer_launcher.configure_op_signer(cmd, files, signer_service, signer_client)
+    op_signer_launcher.configure_op_signer(cmd, files, signer_context, SERVICE_TYPE)
 
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -37,7 +37,6 @@ ENTRYPOINT_ARGS = ["sh", "-c"]
 
 def launch(
     plan,
-    service_name,
     image,
     cl_context,
     l1_config_env_vars,
@@ -47,12 +46,11 @@ def launch(
     network_params,
     observability_helper,
 ):
-    proposer_service_name = "{0}".format(service_name)
+    service_name = "op-proposer-{0}".format(network_params.name)
 
     config = get_proposer_config(
         plan,
         image,
-        service_name,
         cl_context,
         l1_config_env_vars,
         gs_proposer_private_key,
@@ -62,7 +60,6 @@ def launch(
     )
 
     service = plan.add_service(service_name, config)
-    http_url = util.make_service_http_url(service)
 
     observability.register_op_service_metrics_job(
         observability_helper, service, network_params.network
@@ -74,7 +71,6 @@ def launch(
 def get_proposer_config(
     plan,
     image,
-    service_name,
     cl_context,
     l1_config_env_vars,
     gs_proposer_private_key,

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -43,6 +43,7 @@ def launch(
     plan,
     cl_context,
     l1_config_env_vars,
+    signer_service,
     proposer_key,
     game_factory_address,
     deployment_output,
@@ -64,6 +65,7 @@ def launch(
         plan,
         cl_context,
         l1_config_env_vars,
+        signer_service,
         proposer_key,
         proposer_address,
         game_factory_address,
@@ -82,6 +84,7 @@ def make_service_config(
     plan,
     cl_context,
     l1_config_env_vars,
+    signer_service,
     proposer_key,
     proposer_address,
     game_factory_address,
@@ -106,7 +109,7 @@ def make_service_config(
 
     # apply customizations
 
-    op_signer_launcher.configure_op_signer(cmd, proposer_address)
+    op_signer_launcher.configure_op_signer(cmd, signer_service, proposer_address)
 
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -94,8 +94,6 @@ def get_proposer_config(
         "--rollup-rpc=" + cl_context.beacon_http_url,
         "--game-factory-address=" + str(game_factory_address),
         "--private-key=" + proposer_key,
-        "--signer.endpoint=" + op_signer_launcher.ENDPOINT,
-        "--signer.address=" + proposer_address,
         "--l1-eth-rpc=" + l1_config_env_vars["L1_RPC_URL"],
         "--allow-non-finalized=true",
         "--game-type={0}".format(proposer_params.game_type),
@@ -104,6 +102,9 @@ def get_proposer_config(
     ]
 
     # apply customizations
+
+    util.disable_op_service_tls(cmd)
+    op_signer_launcher.configure_op_signer(cmd, proposer_address)
 
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -50,18 +50,23 @@ def launch(
     network_params,
     observability_helper,
 ):
-    service_instance_name = util.make_service_instance_name(SERVICE_NAME, network_params)
+    service_instance_name = util.make_service_instance_name(
+        SERVICE_NAME, network_params
+    )
 
-    service = plan.add_service(service_instance_name, make_service_config(
-        plan,
-        cl_context,
-        l1_config_env_vars,
-        signer_service,
-        signer_client,
-        game_factory_address,
-        proposer_params,
-        observability_helper,
-    ))
+    service = plan.add_service(
+        service_instance_name,
+        make_service_config(
+            plan,
+            cl_context,
+            l1_config_env_vars,
+            signer_service,
+            signer_client,
+            game_factory_address,
+            proposer_params,
+            observability_helper,
+        ),
+    )
 
     observability.register_op_service_metrics_job(
         observability_helper, service, network_params.network

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -6,6 +6,7 @@ ethereum_package_constants = import_module(
     "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
 )
 
+input_parser = import_module("../../input_parser.star")
 constants = import_module("../../package_io/constants.star")
 util = import_module("../../util.star")
 
@@ -40,7 +41,6 @@ ENTRYPOINT_ARGS = ["sh", "-c"]
 
 def launch(
     plan,
-    image,
     cl_context,
     l1_config_env_vars,
     proposer_key,
@@ -62,7 +62,6 @@ def launch(
 
     config = get_proposer_config(
         plan,
-        image,
         cl_context,
         l1_config_env_vars,
         proposer_key,
@@ -83,7 +82,6 @@ def launch(
 
 def get_proposer_config(
     plan,
-    image,
     cl_context,
     l1_config_env_vars,
     proposer_key,
@@ -116,6 +114,13 @@ def get_proposer_config(
         observability.configure_op_service_metrics(cmd, ports)
 
     cmd += proposer_params.extra_params
+
+    # legacy default image logic
+    image = (
+        proposer_params.image
+        if proposer_params.image != ""
+        else input_parser.DEFAULT_PROPOSER_IMAGES[SERVICE_NAME]
+    )
 
     return ServiceConfig(
         image=image,

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -6,7 +6,7 @@ ethereum_package_constants = import_module(
     "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
 )
 
-input_parser = import_module("../../input_parser.star")
+input_parser = import_module("../../package_io/input_parser.star")
 constants = import_module("../../package_io/constants.star")
 util = import_module("../../util.star")
 

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -51,7 +51,7 @@ def launch(
 ):
     service_name = util.make_service_name(SERVICE_NAME, network_params)
 
-    proposer_address = util.read_service_network_config_value(plan, deployment_output, "proposer", network_params.network_id, ".address")
+    proposer_address = util.read_service_network_config_value(plan, deployment_output, "proposer", network_params, ".address")
 
     config = get_proposer_config(
         plan,

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -103,7 +103,6 @@ def get_proposer_config(
 
     # apply customizations
 
-    util.disable_op_service_tls(cmd)
     op_signer_launcher.configure_op_signer(cmd, proposer_address)
 
     if observability_helper.enabled:

--- a/src/proposer/op-proposer/op_proposer_launcher.star
+++ b/src/proposer/op-proposer/op_proposer_launcher.star
@@ -90,7 +90,7 @@ def make_service_config(
         "--rpc.port=" + str(HTTP_PORT_NUM),
         "--rollup-rpc=" + cl_context.beacon_http_url,
         "--game-factory-address=" + str(game_factory_address),
-        "--private-key=" + signer_client.key,
+        "--private-key=" + signer_context.clients[SERVICE_TYPE].key,
         "--l1-eth-rpc=" + l1_config_env_vars["L1_RPC_URL"],
         "--allow-non-finalized=true",
         "--game-type={0}".format(proposer_params.game_type),

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -59,11 +59,7 @@ def launch(
     )
 
     populated_clients = generate_client_creds(
-        plan,
-        network_params,
-        deployment_output,
-        signer_ca_artifact,
-        clients
+        plan, network_params, deployment_output, signer_ca_artifact, clients
     )
 
     client_key_artifacts = create_key_artifacts(
@@ -108,7 +104,7 @@ def create_tls_artifacts(
     service_instance_name,
 ):
     signer_ca = generate_ca(plan, service_instance_name)
-    
+
     signer_tls = generate_client_tls(
         plan,
         signer_ca,
@@ -246,7 +242,9 @@ def configure_op_signer(cmd, files, signer_context, client_type):
     cmd.append("--signer.tls.ca=" + TLS_CA_PATH)
     cmd.append("--signer.tls.cert=" + TLS_CERT_PATH)
     cmd.append("--signer.tls.key=" + TLS_KEY_PATH)
-    cmd.append("--signer.endpoint=" + util.make_service_https_url(signer_context.service))
+    cmd.append(
+        "--signer.endpoint=" + util.make_service_https_url(signer_context.service)
+    )
     cmd.append("--signer.address=" + client.address)
 
     configure_tls_files(
@@ -310,7 +308,8 @@ def generate_credentials(plan, args, store, files={}):
         image="alpine/openssl:3.3.3",
         files={
             "/script": script_artifact,
-        } | files,
+        }
+        | files,
         env_vars={
             "OP_SIGNER_GEN_TLS_DOCKER": "false",
             "TLS_DIR": TLS_DIR,
@@ -327,7 +326,7 @@ def generate_ca(plan, service_instance_name):
         [
             StoreSpec(
                 src="{0}/*".format(TLS_DIR),
-                name="{0}-tls-ca".format(service_instance_name)
+                name="{0}-tls-ca".format(service_instance_name),
             )
         ],
     )[0]
@@ -344,14 +343,21 @@ def generate_client_tls(plan, signer_ca_artifact, client_hostnames):
             )
             for client in client_hostnames
         ],
-        files={ TLS_DIR: signer_ca_artifact },
+        files={TLS_DIR: signer_ca_artifact},
     )
 
 
-def generate_client_creds(plan, network_params, deployment_output, signer_ca_artifact, client_map):
+def generate_client_creds(
+    plan, network_params, deployment_output, signer_ca_artifact, client_map
+):
     clients = []
     for client_type, client_name in client_map.items():
-        clients.append(make_client(client_type, util.make_service_instance_name(client_name, network_params)))
+        clients.append(
+            make_client(
+                client_type,
+                util.make_service_instance_name(client_name, network_params),
+            )
+        )
 
     client_tls_artifacts = generate_client_tls(
         plan,

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -113,7 +113,7 @@ def create_key_artifact(
 
         run = plan.run_sh(
             description="Convert ethereum private key to PEM",
-            image="alpine/openssl:latest",
+            image="alpine/openssl:3.3.3",
             store=[
                 StoreSpec(
                     src="{0}/{1}".format(CLIENT_KEY_DIRPATH_ON_SERVICE, file_name),

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -17,10 +17,6 @@ SERVICE_NAME = util.make_op_service_name(SERVICE_TYPE)
 # Port nums
 HTTP_PORT_NUM = 8545
 
-ENDPOINT = util.make_http_url(
-    SERVICE_NAME, HTTP_PORT_NUM
-)
-
 TEMPLATES_FILEPATH = "./templates"
 
 CONFIG_FILE_NAME = "config.yaml"
@@ -75,13 +71,12 @@ def launch(
         client_key_artifacts,
         observability_helper,
     ))
-    service_url = util.make_service_http_url(service)
 
     observability.register_op_service_metrics_job(
         observability_helper, service, network_params.network
     )
 
-    return service_url
+    return service
 
 def create_key_artifacts(
     plan,
@@ -190,7 +185,7 @@ def make_service_config(
         private_ip_address_placeholder=ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
     )
 
-def configure_op_signer(cmd, client_address):
+def configure_op_signer(cmd, signer_service, client_address):
     cmd.append("--signer.tls.enabled=false")
-    cmd.append("--signer.endpoint=" + ENDPOINT)
+    cmd.append("--signer.endpoint=" + util.make_service_http_url(signer_service))
     cmd.append("--signer.address=" + client_address)

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -168,6 +168,8 @@ def get_signer_config(
 
     # apply customizations
 
+    util.disable_op_service_tls(cmd)
+
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)
     
@@ -193,3 +195,7 @@ def get_signer_config(
         },
         private_ip_address_placeholder=ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
     )
+
+def configure_op_signer(cmd, client_address):
+    cmd.append("--signer.endpoint=" + ENDPOINT)
+    cmd.append("--signer.address=" + client_address)

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -66,15 +66,13 @@ def launch(
         observability_helper,
     )
 
-    config = get_signer_config(
+    service = plan.add_service(service_name, get_signer_config(
         plan,
         signer_params,
         config_artifact_name,
         client_key_artifacts,
         observability_helper,
-    )
-
-    service = plan.add_service(service_name, config)
+    ))
     service_url = util.make_service_http_url(service)
 
     observability.register_op_service_metrics_job(

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -1,0 +1,148 @@
+ethereum_package_shared_utils = import_module(
+    "github.com/ethpandaops/ethereum-package/src/shared_utils/shared_utils.star"
+)
+
+ethereum_package_constants = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
+)
+
+constants = import_module("../package_io/constants.star")
+util = import_module("../util.star")
+
+observability = import_module("../observability/observability.star")
+prometheus = import_module("../observability/prometheus/prometheus_launcher.star")
+
+# Port nums
+HTTP_PORT_NUM = 8080
+METRICS_PORT_NUM = 7300
+
+TEMPLATES_FILEPATH = "./templates"
+
+CONFIG_FILE_NAME = "config.yaml"
+CONFIG_TEMPLATE_FILEPATH = "{0}/{1}.tmpl".format(TEMPLATES_FILEPATH, CONFIG_FILE_NAME)
+
+CONFIG_DIRPATH_ON_SERVICE = "/app"
+KEY_DIRPATH_ON_SERVICE = "/{0}/tls".format(CONFIG_DIRPATH_ON_SERVICE)
+
+
+def get_used_ports():
+    used_ports = {
+        constants.HTTP_PORT_ID: ethereum_package_shared_utils.new_port_spec(
+            HTTP_PORT_NUM,
+            ethereum_package_shared_utils.TCP_PROTOCOL,
+            ethereum_package_shared_utils.HTTP_APPLICATION_PROTOCOL,
+        ),
+    }
+    return used_ports
+
+
+def launch(
+    plan,
+    signer_params,
+    network_params,
+    observability_helper,
+):
+    config_template = read_file(CONFIG_TEMPLATE_FILEPATH)
+
+    config_artifact_name = create_config_artifact(
+        plan,
+        config_template,
+        observability_helper,
+    )
+
+    key_artifact_name = create_key_artifact(
+        plan,
+    )
+
+    config = get_signer_config(
+        plan,
+        signer_params,
+        config_artifact_name,
+        key_artifact_name,
+        observability_helper,
+    )
+
+    service = plan.add_service("op-signer-{0}".format(network_params.network), config)
+    service_url = util.make_service_http_url(service)
+
+    observability.register_op_service_metrics_job(
+        observability_helper, service, network_params.network
+    )
+
+    return service_url
+
+def create_key_artifact(
+    plan,
+):
+    key_data = {
+    }
+
+    key_artifact_name = plan.render_templates(
+        {
+
+        },
+        name="signer-keys",
+    )
+
+    return key_artifact_name
+
+
+def create_config_artifact(
+    plan,
+    config_template,
+    observability_helper,
+):
+    config_data = {
+        "Ports": {
+            "http": HTTP_PORT_NUM,
+        },
+        "Metrics": {
+            "enabled": observability_helper.enabled,
+            "port": METRICS_PORT_NUM,
+        },
+    }
+
+    config_template_and_data = ethereum_package_shared_utils.new_template_and_data(
+        config_template, config_data
+    )
+
+    config_artifact_name = plan.render_templates(
+        {
+            CONFIG_FILE_NAME: config_template_and_data,
+        },
+        name="signer-config",
+    )
+
+    return config_artifact_name
+
+
+def get_signer_config(
+    plan,
+    signer_params,
+    config_artifact_name,
+    key_artifact_name,
+    observability_helper,
+):
+    ports = dict(get_used_ports())
+
+    # apply customizations
+
+    if observability_helper.enabled:
+        observability.expose_metrics_port(ports, port_num=METRICS_PORT_NUM)
+
+    cmd += signer_params.extra_params
+
+    return ServiceConfig(
+        image="{0}:{1}".format(signer_params.image, signer_params.tag),
+        ports=ports,
+        env_vars={
+            "OP_SIGNER_SERVER_CA": "{0}/ca.crt".format(KEY_DIRPATH_ON_SERVICE),
+            "OP_SIGNER_SERVER_CERT": "{0}/tls.crt".format(KEY_DIRPATH_ON_SERVICE),
+            "OP_SIGNER_SERVER_KEY": "{0}/tls.key".format(KEY_DIRPATH_ON_SERVICE),
+        },
+        files={
+            CONFIG_DIRPATH_ON_SERVICE: config_artifact_name,
+            KEY_DIRPATH_ON_SERVICE: key_artifact_name,
+        },
+        private_ip_address_placeholder=ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+    )

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -12,9 +12,14 @@ util = import_module("../util.star")
 observability = import_module("../observability/observability.star")
 prometheus = import_module("../observability/prometheus/prometheus_launcher.star")
 
+SERVICE_NAME = "op-signer"
+
 # Port nums
-HTTP_PORT_NUM = 8080
-METRICS_PORT_NUM = 7300
+HTTP_PORT_NUM = 8545
+
+ENDPOINT = util.make_http_url(
+    SERVICE_NAME, HTTP_PORT_NUM
+)
 
 TEMPLATES_FILEPATH = "./templates"
 
@@ -48,7 +53,7 @@ def launch(
     clients,
     observability_helper,
 ):
-    service_name = "op-signer-{0}".format(network_params.network)
+    service_name = util.make_service_name(SERVICE_NAME, network_params)
 
     client_key_artifacts = create_key_artifact(
         plan,

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -197,5 +197,6 @@ def get_signer_config(
     )
 
 def configure_op_signer(cmd, client_address):
+    cmd.append("--signer.tls.enabled=false")
     cmd.append("--signer.endpoint=" + ENDPOINT)
     cmd.append("--signer.address=" + client_address)

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -10,9 +10,9 @@ constants = import_module("../package_io/constants.star")
 util = import_module("../util.star")
 
 observability = import_module("../observability/observability.star")
-prometheus = import_module("../observability/prometheus/prometheus_launcher.star")
 
-SERVICE_NAME = "op-signer"
+SERVICE_TYPE = "signer"
+SERVICE_NAME = util.make_op_service_name(SERVICE_TYPE)
 
 # Port nums
 HTTP_PORT_NUM = 8545
@@ -53,7 +53,7 @@ def launch(
     clients,
     observability_helper,
 ):
-    service_name = util.make_service_name(SERVICE_NAME, network_params)
+    service_name = util.make_service_instance_name(SERVICE_NAME, network_params)
 
     client_key_artifacts = create_key_artifact(
         plan,

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -103,6 +103,7 @@ def create_key_artifact(
             "printf '\\xa0\\x07\\x06\\x05\\x2b\\x81\\x04\\x00\\x0a' >> {0}".format(der_file),
             # convert binary key to PEM
             "openssl ec -inform DER -in {0} -out {1}".format(der_file, file_name),
+            "chmod 666 {0}".format(file_name),
         ]
 
         run = plan.run_sh(

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -169,14 +169,16 @@ def get_signer_config(
     # apply customizations
 
     if observability_helper.enabled:
-        observability.expose_metrics_port(ports, port_num=METRICS_PORT_NUM)
+        observability.configure_op_service_metrics(cmd, ports)
     
     cmd += signer_params.extra_params
 
     return ServiceConfig(
         image="{0}:{1}".format(signer_params.image, signer_params.tag),
         ports=ports,
+        cmd=cmd,
         env_vars={
+            "OP_SIGNER_RPC_PORT": str(HTTP_PORT_NUM),
             "OP_SIGNER_TLS_ENABLED": "false",
             "OP_SIGNER_SERVICE_CONFIG": "{0}/{1}".format(CONFIG_DIRPATH_ON_SERVICE, CONFIG_FILE_NAME)
         },

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -39,10 +39,10 @@ def get_used_ports():
     }
     return used_ports
 
-def make_client(client_name,client_hostname, client_key):
+def make_client(client_type, client_name, client_key):
     return struct(
-        name = client_name,
-        hostname = client_hostname,
+        name = client_type,
+        hostname = client_name,
         key = client_key,
     )
 
@@ -167,8 +167,6 @@ def get_signer_config(
     cmd = []
 
     # apply customizations
-
-    util.disable_op_service_tls(cmd)
 
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -302,7 +302,7 @@ def generate_credentials(plan, args, store, files={}):
     cmds = [
         "chmod +x {0}".format(script_path),
         "{0} {1}".format(script_path, " ".join(args)),
-        "chmod 666 {0}/*".format(TLS_DIR),
+        "chmod -R 777 {0}/".format(TLS_DIR),
     ]
 
     return plan.run_sh(

--- a/src/signer/op_signer_launcher.star
+++ b/src/signer/op_signer_launcher.star
@@ -55,11 +55,17 @@ def launch(
 
     signer_ca_artifact, signer_tls_artifact = create_tls_artifacts(
         plan,
+        signer_params,
         service_instance_name,
     )
 
     populated_clients = generate_client_creds(
-        plan, network_params, signer_params, deployment_output, signer_ca_artifact, clients
+        plan,
+        network_params,
+        signer_params,
+        deployment_output,
+        signer_ca_artifact,
+        clients,
     )
 
     client_key_artifacts = create_key_artifacts(
@@ -101,12 +107,14 @@ def launch(
 
 def create_tls_artifacts(
     plan,
+    signer_params,
     service_instance_name,
 ):
-    signer_ca = generate_ca(plan, service_instance_name)
+    signer_ca = generate_ca(plan, signer_params, service_instance_name)
 
     signer_tls = generate_client_tls(
         plan,
+        signer_params,
         signer_ca,
         [service_instance_name],
     )[0]
@@ -235,6 +243,7 @@ def make_service_config(
         private_ip_address_placeholder=ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
     )
 
+
 def make_image(signer_params):
     return "{0}:{1}".format(signer_params.image, signer_params.tag)
 
@@ -294,7 +303,7 @@ def generate_credentials(plan, signer_params, args, store, files={}):
     # script_artifact = plan.get_files_artifact(name=script_artifact_name)
     # if script_artifact == None:
     script_artifact = plan.upload_files(
-        src="github.com/ethereum-optimism/infra/op-signer/{0}@op-signer/{1}".format(
+        src="github.com/ethereum-optimism/infra/op-signer/{0}@op-signer_{1}".format(
             gen_script, signer_params.tag
         ),
         # name=script_artifact_name,
@@ -353,7 +362,12 @@ def generate_client_tls(plan, signer_params, signer_ca_artifact, client_hostname
 
 
 def generate_client_creds(
-    plan, network_params, signer_params, deployment_output, signer_ca_artifact, client_map
+    plan,
+    network_params,
+    signer_params,
+    deployment_output,
+    signer_ca_artifact,
+    client_map,
 ):
     clients = []
     for client_type, client_name in client_map.items():

--- a/src/signer/templates/config.yaml.tmpl
+++ b/src/signer/templates/config.yaml.tmpl
@@ -1,0 +1,3 @@
+auth:
+  - name: localhost
+    key:

--- a/src/signer/templates/config.yaml.tmpl
+++ b/src/signer/templates/config.yaml.tmpl
@@ -1,3 +1,4 @@
+provider: LOCAL
 auth:
   {{ range $client_name, $client_key_artifact := .Clients }}
   - name: {{ $client_name }}

--- a/src/signer/templates/config.yaml.tmpl
+++ b/src/signer/templates/config.yaml.tmpl
@@ -1,3 +1,5 @@
 auth:
-  - name: localhost
-    key:
+  {{ range $client_name, $client_key_artifact := .Clients }}
+  - name: {{ $client_name }}
+    key: {{ $client_key_artifact }}
+  {{ end }}

--- a/src/signer/templates/config.yaml.tmpl
+++ b/src/signer/templates/config.yaml.tmpl
@@ -1,6 +1,6 @@
 provider: LOCAL
 auth:
-  {{ range $client_name, $client_key_artifact := .Clients }}
+  {{ range $client_name, $client_key := .Clients }}
   - name: {{ $client_name }}
-    key: {{ $.KeyDir }}/{{ $client_key_artifact }}
+    key: {{ $.KeyDir }}/{{ $client_key.filename }}
   {{ end }}

--- a/src/signer/templates/config.yaml.tmpl
+++ b/src/signer/templates/config.yaml.tmpl
@@ -1,5 +1,5 @@
 auth:
   {{ range $client_name, $client_key_artifact := .Clients }}
   - name: {{ $client_name }}
-    key: {{ $client_key_artifact }}
+    key: {{ $.KeyDir }}/{{ $client_key_artifact }}
   {{ end }}

--- a/src/util.star
+++ b/src/util.star
@@ -4,6 +4,7 @@ DEPLOYMENT_UTILS_IMAGE = "mslipper/deployment-utils:latest"
 
 NETWORK_DATA_DIR = "/network-data"
 
+
 def read_network_config_value(plan, network_config_file, json_file, json_path):
     mounts = {NETWORK_DATA_DIR: network_config_file}
     return read_json_value(
@@ -11,12 +12,21 @@ def read_network_config_value(plan, network_config_file, json_file, json_path):
     )
 
 
-def read_service_network_config_value(plan, network_config_file, service_type, network_params, json_path):
-    return read_network_config_value(plan, network_config_file, "{0}-{1}".format(service_type, network_params.network_id), json_path)
+def read_service_network_config_value(
+    plan, network_config_file, service_type, network_params, json_path
+):
+    return read_network_config_value(
+        plan,
+        network_config_file,
+        "{0}-{1}".format(service_type, network_params.network_id),
+        json_path,
+    )
 
 
 def read_service_private_key(plan, network_config_file, service_type, network_params):
-    return read_service_network_config_value(plan, network_config_file, service_type, network_params, ".privateKey")
+    return read_service_network_config_value(
+        plan, network_config_file, service_type, network_params, ".privateKey"
+    )
 
 
 def read_json_value(plan, json_file, json_path, mounts=None):
@@ -161,6 +171,7 @@ def make_execution_rpc_url(el_context):
         el_context.ip_addr,
         el_context.rpc_port_num,
     )
+
 
 def configure_op_service_rpc(cmd, port_num):
     cmd.append("--rpc.addr=0.0.0.0")

--- a/src/util.star
+++ b/src/util.star
@@ -158,9 +158,6 @@ def make_execution_rpc_url(el_context):
         el_context.rpc_port_num,
     )
 
-def disable_op_service_tls(cmd):
-    cmd.append("--tls.enabled=false")
-
 def configure_op_service_rpc(cmd, port_num):
     cmd.append("--rpc.addr=0.0.0.0")
     cmd.append("--rpc.port={0}".format(port_num))

--- a/src/util.star
+++ b/src/util.star
@@ -10,8 +10,12 @@ def read_network_config_value(plan, network_config_file, json_file, json_path):
     )
 
 
-def read_service_network_config_value(plan, network_config_file, service_type, network_id, json_path):
-    return read_network_config_value(plan, network_config_file, "{0}-{1}".format(service_type, network_id), json_path)
+def read_service_network_config_value(plan, network_config_file, service_type, network_params, json_path):
+    return read_network_config_value(plan, network_config_file, "{0}-{1}".format(service_type, network_params.network_id), json_path)
+
+
+def read_service_private_key(plan, network_config_file, service_type, network_params):
+    return read_service_network_config_value(plan, network_config_file, service_type, network_params, ".privateKey")
 
 
 def read_json_value(plan, json_file, json_path, mounts=None):

--- a/src/util.star
+++ b/src/util.star
@@ -133,6 +133,10 @@ def prefix_url_scheme_http(authority):
     return prefix_url_scheme("http", authority)
 
 
+def prefix_url_scheme_https(authority):
+    return prefix_url_scheme("https", authority)
+
+
 def prefix_url_scheme_ws(authority):
     return prefix_url_scheme("ws", authority)
 
@@ -153,6 +157,9 @@ def make_service_url_authority(service, port_id):
 
 def make_service_http_url(service, port_id=constants.HTTP_PORT_ID):
     return prefix_url_scheme_http(make_service_url_authority(service, port_id))
+
+def make_service_https_url(service, port_id=constants.HTTP_PORT_ID):
+    return prefix_url_scheme_https(make_service_url_authority(service, port_id))
 
 
 def make_service_ws_url(service, port_id=constants.WS_PORT_ID):

--- a/src/util.star
+++ b/src/util.star
@@ -157,3 +157,6 @@ def make_execution_rpc_url(el_context):
         el_context.ip_addr,
         el_context.rpc_port_num,
     )
+
+def disable_op_service_tls(cmd):
+    cmd.append("--tls.enabled=false")

--- a/src/util.star
+++ b/src/util.star
@@ -10,6 +10,10 @@ def read_network_config_value(plan, network_config_file, json_file, json_path):
     )
 
 
+def read_service_network_config_value(plan, network_config_file, service_type, network_id, json_path):
+    return read_network_config_value(plan, network_config_file, "{0}-{1}".format(service_type, network_id), json_path)
+
+
 def read_json_value(plan, json_file, json_path, mounts=None):
     run = plan.run_sh(
         description="Read JSON value",

--- a/src/util.star
+++ b/src/util.star
@@ -160,3 +160,8 @@ def make_execution_rpc_url(el_context):
 
 def disable_op_service_tls(cmd):
     cmd.append("--tls.enabled=false")
+
+def configure_op_service_rpc(cmd, port_num):
+    cmd.append("--rpc.addr=0.0.0.0")
+    cmd.append("--rpc.port={0}".format(port_num))
+    cmd.append("--rpc.enable-admin")

--- a/src/util.star
+++ b/src/util.star
@@ -95,7 +95,11 @@ def join_cmds(commands):
     return " && ".join(commands)
 
 
-def make_service_name(service_name, network_params):
+def make_op_service_name(service_type):
+    return "op-{0}".format(service_type)
+
+
+def make_service_instance_name(service_name, network_params):
     return "{0}-{1}".format(service_name, network_params.network)
 
 

--- a/src/util.star
+++ b/src/util.star
@@ -2,11 +2,12 @@ constants = import_module("./package_io/constants.star")
 
 DEPLOYMENT_UTILS_IMAGE = "mslipper/deployment-utils:latest"
 
+NETWORK_DATA_DIR = "/network-data"
 
 def read_network_config_value(plan, network_config_file, json_file, json_path):
-    mounts = {"/network-data": network_config_file}
+    mounts = {NETWORK_DATA_DIR: network_config_file}
     return read_json_value(
-        plan, "/network-data/{0}.json".format(json_file), json_path, mounts
+        plan, "{0}/{1}.json".format(NETWORK_DATA_DIR, json_file), json_path, mounts
     )
 
 

--- a/src/util.star
+++ b/src/util.star
@@ -90,6 +90,10 @@ def join_cmds(commands):
     return " && ".join(commands)
 
 
+def make_service_name(service_name, network_params):
+    return "{0}-{1}".format(service_name, network_params.network)
+
+
 def get_service_port_num(service, port_id):
     return service.ports[port_id].number
 

--- a/src/util.star
+++ b/src/util.star
@@ -151,7 +151,7 @@ def make_ws_url(host, port_num):
 
 def make_service_url_authority(service, port_id):
     return make_url_authority(
-        service.ip_address, get_service_port_num(service, port_id)
+        service.hostname, get_service_port_num(service, port_id)
     )
 
 

--- a/src/util.star
+++ b/src/util.star
@@ -150,13 +150,12 @@ def make_ws_url(host, port_num):
 
 
 def make_service_url_authority(service, port_id):
-    return make_url_authority(
-        service.hostname, get_service_port_num(service, port_id)
-    )
+    return make_url_authority(service.hostname, get_service_port_num(service, port_id))
 
 
 def make_service_http_url(service, port_id=constants.HTTP_PORT_ID):
     return prefix_url_scheme_http(make_service_url_authority(service, port_id))
+
 
 def make_service_https_url(service, port_id=constants.HTTP_PORT_ID):
     return prefix_url_scheme_https(make_service_url_authority(service, port_id))

--- a/test/el_cl_launcher_test.star
+++ b/test/el_cl_launcher_test.star
@@ -213,7 +213,7 @@ def test_launch_with_el_op_besu(plan):
     expect.ne(el_service_config, None)
     expect.eq(el_service_config.image, "op-besu:latest")
     expect.eq(el_service_config.env_vars, {})
-    
+
     test_utils.contains_all(
         el_service_config.cmd,
         [
@@ -244,16 +244,14 @@ def test_launch_with_el_op_besu(plan):
                 ethereum_package_constants.JWT_MOUNT_PATH_ON_CONTAINER
             ),
             "--engine-host-allowlist=*",
-            "--engine-rpc-port={0}".format(
-                el_service.ports["engine-rpc"].number
-            ),
+            "--engine-rpc-port={0}".format(el_service.ports["engine-rpc"].number),
             "--sync-mode=FULL",
             "--bonsai-limit-trie-logs-enabled=false",
             "--version-compatibility-protection=false",
             "--metrics-enabled",
             "--metrics-host=0.0.0.0",
             "--metrics-port=9001",
-        ]
+        ],
     )
 
     # TODO Once files are available on kurtosistest.get_service_config, make sure the JWT file is being mounted

--- a/test/op_challenger_launcher_test.star
+++ b/test/op_challenger_launcher_test.star
@@ -1,11 +1,15 @@
 op_challenger_launcher = import_module(
     "/src/challenger/op-challenger/op_challenger_launcher.star"
 )
+op_signer_launcher = import_module(
+    "/src/signer/op_signer_launcher.star"
+)
 input_parser = import_module("/src/package_io/input_parser.star")
 observability = import_module("/src/observability/observability.star")
 ethereum_package_constants = import_module(
     "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
 )
+constants = import_module("/src/package_io/constants.star")
 util = import_module("/src/util.star")
 
 
@@ -15,6 +19,9 @@ def test_launch_with_defaults(plan):
         {
             "chains": [
                 {
+                    "network_params": {
+                        "network": "kurtosis-test",
+                    },
                     "participants": [
                         {
                             "el_type": "op-reth",
@@ -43,9 +50,12 @@ def test_launch_with_defaults(plan):
 
     chains = parsed_input_args.chains
     chain = chains[0]
-    l2_num = 0
-    challenger_service_name = "op-challenger"
-    challenger_image = input_parser.DEFAULT_CHALLENGER_IMAGES["op-challenger"]
+    
+    service_type = op_challenger_launcher.SERVICE_TYPE
+    service_name = op_challenger_launcher.SERVICE_NAME
+    service_instance_name = util.make_service_instance_name(
+        service_name, chain.network_params
+    )
 
     deployment_output = "/path/to/deployment_output"
     l1_config_env_vars = {
@@ -54,24 +64,45 @@ def test_launch_with_defaults(plan):
         "CL_RPC_URL": "CL_RPC_URL",
     }
 
-    # We'll mock read_network_config_value since it returns a runtime value that we would not be able to retrieve
-    dispute_game_factory_mock = "dispute_game_factory"
-    kurtosistest.mock(util, "read_network_config_value").mock_return_value(
-        dispute_game_factory_mock
-    )
     challenger_private_key_mock = "challenger_private_key"
-    kurtosistest.mock(util, "read_network_config_value").mock_return_value(
-        challenger_private_key_mock
+    challenger_address_mock = "challenger_address"
+
+    signer_client = op_signer_launcher.make_client(
+        service_type,
+        service_instance_name,
     )
+
+    signer_context = struct(
+        service=struct(
+            hostname=util.make_service_instance_name(
+                op_signer_launcher.SERVICE_NAME, chain.network_params
+            ),
+            ports={
+                constants.HTTP_PORT_ID: struct(
+                    number=op_signer_launcher.HTTP_PORT_NUM,
+                ),
+            },
+        ),
+        ca_artifact="ca_artifact_mock",
+        clients={
+            service_type: op_signer_launcher.make_populated_client(
+                client=signer_client,
+                key=challenger_private_key_mock,
+                address=challenger_address_mock,
+                tls_artifact="tls_artifact_mock",
+            )
+        },
+    )
+
+    dispute_game_factory_address_mock = "dispute_game_factory_address"
 
     op_challenger_launcher.launch(
         plan=plan,
-        l2_num=l2_num,
-        service_name=challenger_service_name,
-        image=challenger_image,
         el_context=el_context,
         cl_context=cl_context,
         l1_config_env_vars=l1_config_env_vars,
+        signer_context=signer_context,
+        game_factory_address=dispute_game_factory_address_mock,
         deployment_output=deployment_output,
         network_params=chain.network_params,
         challenger_params=chain.challenger_params,
@@ -80,18 +111,40 @@ def test_launch_with_defaults(plan):
     )
 
     challenger_service_config = kurtosistest.get_service_config(
-        service_name=challenger_service_name
+        service_instance_name
     )
     expect.ne(challenger_service_config, None)
-    expect.eq(challenger_service_config.image, challenger_image)
     expect.eq(challenger_service_config.env_vars, {})
     expect.eq(
         challenger_service_config.entrypoint,
         ["sh", "-c"],
     )
+
+    flags = " ".join([
+        "--cannon-l2-genesis=/network-configs/genesis-2151908.json",
+        "--cannon-rollup-config=/network-configs/rollup-2151908.json",
+        "--game-factory-address=dispute_game_factory_address",
+        "--datadir=/data/op-challenger/op-challenger-data",
+        "--l1-beacon=CL_RPC_URL",
+        "--l1-eth-rpc=L1_RPC_URL",
+        "--l2-eth-rpc=rpc_http_url",
+        "--private-key=challenger_private_key",
+        "--rollup-rpc=beacon_http_url",
+        "--trace-type=cannon,permissioned",
+        "--signer.tls.ca=/tls/ca.crt",
+        "--signer.tls.cert=/tls/tls.crt",
+        "--signer.tls.key=/tls/tls.key",
+        "--signer.endpoint=https://op-signer-kurtosis-test:8545",
+        "--signer.address=challenger_address",
+        "--metrics.enabled",
+        "--metrics.addr=0.0.0.0",
+        "--metrics.port=9001",
+        "--cannon-prestates-url=https://storage.googleapis.com/oplabs-network-data/proofs/op-program/cannon",
+    ])
+
     expect.eq(
         challenger_service_config.cmd,
         [
-            "mkdir -p /data/op-challenger/op-challenger-data && op-challenger --cannon-l2-genesis=/network-configs/genesis-2151908.json --cannon-rollup-config=/network-configs/rollup-2151908.json --game-factory-address=challenger_private_key --datadir=/data/op-challenger/op-challenger-data --l1-beacon=CL_RPC_URL --l1-eth-rpc=L1_RPC_URL --l2-eth-rpc=rpc_http_url --private-key=challenger_private_key --rollup-rpc=beacon_http_url --trace-type=cannon,permissioned --metrics.enabled --metrics.addr=0.0.0.0 --metrics.port=9001 --cannon-prestates-url=https://storage.googleapis.com/oplabs-network-data/proofs/op-program/cannon"
+            "mkdir -p /data/op-challenger/op-challenger-data && op-challenger " + flags
         ],
     )

--- a/test/op_challenger_launcher_test.star
+++ b/test/op_challenger_launcher_test.star
@@ -120,31 +120,28 @@ def test_launch_with_defaults(plan):
         ["sh", "-c"],
     )
 
-    flags = " ".join([
-        "--cannon-l2-genesis=/network-configs/genesis-2151908.json",
-        "--cannon-rollup-config=/network-configs/rollup-2151908.json",
-        "--game-factory-address=dispute_game_factory_address",
-        "--datadir=/data/op-challenger/op-challenger-data",
-        "--l1-beacon=CL_RPC_URL",
-        "--l1-eth-rpc=L1_RPC_URL",
-        "--l2-eth-rpc=rpc_http_url",
-        "--private-key=challenger_private_key",
-        "--rollup-rpc=beacon_http_url",
-        "--trace-type=cannon,permissioned",
-        "--signer.tls.ca=/tls/ca.crt",
-        "--signer.tls.cert=/tls/tls.crt",
-        "--signer.tls.key=/tls/tls.key",
-        "--signer.endpoint=https://op-signer-kurtosis-test:8545",
-        "--signer.address=challenger_address",
-        "--metrics.enabled",
-        "--metrics.addr=0.0.0.0",
-        "--metrics.port=9001",
-        "--cannon-prestates-url=https://storage.googleapis.com/oplabs-network-data/proofs/op-program/cannon",
-    ])
-
     expect.eq(
         challenger_service_config.cmd,
         [
-            "mkdir -p /data/op-challenger/op-challenger-data && op-challenger " + flags
+            "op-challenger",
+            "--cannon-l2-genesis=/network-configs/genesis-2151908.json",
+            "--cannon-rollup-config=/network-configs/rollup-2151908.json",
+            "--game-factory-address=dispute_game_factory_address",
+            "--datadir=/data/op-challenger/op-challenger-data",
+            "--l1-beacon=CL_RPC_URL",
+            "--l1-eth-rpc=L1_RPC_URL",
+            "--l2-eth-rpc=rpc_http_url",
+            "--private-key=challenger_private_key",
+            "--rollup-rpc=beacon_http_url",
+            "--trace-type=cannon,permissioned",
+            "--signer.tls.ca=/tls/ca.crt",
+            "--signer.tls.cert=/tls/tls.crt",
+            "--signer.tls.key=/tls/tls.key",
+            "--signer.endpoint=https://op-signer-kurtosis-test:8545",
+            "--signer.address=challenger_address",
+            "--metrics.enabled",
+            "--metrics.addr=0.0.0.0",
+            "--metrics.port=9001",
+            "--cannon-prestates-url=https://storage.googleapis.com/oplabs-network-data/proofs/op-program/cannon",
         ],
     )

--- a/test/op_challenger_launcher_test.star
+++ b/test/op_challenger_launcher_test.star
@@ -1,9 +1,7 @@
 op_challenger_launcher = import_module(
     "/src/challenger/op-challenger/op_challenger_launcher.star"
 )
-op_signer_launcher = import_module(
-    "/src/signer/op_signer_launcher.star"
-)
+op_signer_launcher = import_module("/src/signer/op_signer_launcher.star")
 input_parser = import_module("/src/package_io/input_parser.star")
 observability = import_module("/src/observability/observability.star")
 ethereum_package_constants = import_module(
@@ -13,6 +11,7 @@ constants = import_module("/src/package_io/constants.star")
 util = import_module("/src/util.star")
 
 test_utils = import_module("/test/test_utils.star")
+
 
 def test_launch_with_defaults(plan):
     parsed_input_args = input_parser.input_parser(
@@ -51,7 +50,7 @@ def test_launch_with_defaults(plan):
 
     chains = parsed_input_args.chains
     chain = chains[0]
-    
+
     service_type = op_challenger_launcher.SERVICE_TYPE
     service_name = op_challenger_launcher.SERVICE_NAME
     service_instance_name = util.make_service_instance_name(
@@ -111,9 +110,7 @@ def test_launch_with_defaults(plan):
         observability_helper=observability_helper,
     )
 
-    challenger_service_config = kurtosistest.get_service_config(
-        service_instance_name
-    )
+    challenger_service_config = kurtosistest.get_service_config(service_instance_name)
     expect.ne(challenger_service_config, None)
     expect.eq(challenger_service_config.env_vars, {})
     expect.eq(

--- a/test/op_challenger_launcher_test.star
+++ b/test/op_challenger_launcher_test.star
@@ -12,6 +12,7 @@ ethereum_package_constants = import_module(
 constants = import_module("/src/package_io/constants.star")
 util = import_module("/src/util.star")
 
+test_utils = import_module("/test/test_utils.star")
 
 def test_launch_with_defaults(plan):
     parsed_input_args = input_parser.input_parser(
@@ -120,10 +121,10 @@ def test_launch_with_defaults(plan):
         ["sh", "-c"],
     )
 
-    expect.eq(
+    test_utils.contains_all(
         challenger_service_config.cmd,
         [
-            "op-challenger",
+            service_name,
             "--cannon-l2-genesis=/network-configs/genesis-2151908.json",
             "--cannon-rollup-config=/network-configs/rollup-2151908.json",
             "--game-factory-address=dispute_game_factory_address",

--- a/test/op_challenger_launcher_test.star
+++ b/test/op_challenger_launcher_test.star
@@ -113,10 +113,6 @@ def test_launch_with_defaults(plan):
     challenger_service_config = kurtosistest.get_service_config(service_instance_name)
     expect.ne(challenger_service_config, None)
     expect.eq(challenger_service_config.env_vars, {})
-    expect.eq(
-        challenger_service_config.entrypoint,
-        ["sh", "-c"],
-    )
 
     test_utils.contains_all(
         challenger_service_config.cmd,

--- a/test/test_utils.star
+++ b/test/test_utils.star
@@ -1,0 +1,3 @@
+def contains_all(actual, expected):
+    for e in expected:
+        expect.contains(actual, e)

--- a/test/util_test.star
+++ b/test/util_test.star
@@ -58,9 +58,3 @@ def test_label_from_image_long_image_name_long_suffix(plan):
     image_label = util.label_from_image(image_name)
     expect.eq(len(image_label), 63)
     expect.eq(image_suffix[-63:], image_label)
-
-def test_configure_op_service_rpc(plan):
-    port_num = 8545
-    cmd = ["op-service"]
-    util.configure_op_service_rpc(cmd, port_num)
-    expect.eq(cmd, ["op-service", "--rpc.addr=0.0.0.0", "--rpc.port={0}".format(port_num), "--rpc.enable-admin"])

--- a/test/util_test.star
+++ b/test/util_test.star
@@ -58,3 +58,9 @@ def test_label_from_image_long_image_name_long_suffix(plan):
     image_label = util.label_from_image(image_name)
     expect.eq(len(image_label), 63)
     expect.eq(image_suffix[-63:], image_label)
+
+def test_configure_op_service_rpc(plan):
+    port_num = 8545
+    cmd = ["op-service"]
+    util.configure_op_service_rpc(cmd, port_num)
+    expect.eq(cmd, ["op-service", "--rpc.addr=0.0.0.0", "--rpc.port={0}".format(port_num), "--rpc.enable-admin"])


### PR DESCRIPTION
This PR provisions an `op-signer` instance per network in order to support signing batcher/proposer/challenger transactions. It leverages the local KMS support added in [this PR](https://github.com/ethereum-optimism/infra/pull/252) in order to reuse the existing client private keys, which it converts from raw hex strings to PEM format.

It uses the `op-signer/gen-local-creds.sh` script (updated in [this PR](https://github.com/ethereum-optimism/infra/pull/265)) to generate mTLS credentials to authenticate connections between `op-signer` and its clients.

Resolves https://github.com/ethereum-optimism/platforms-team/issues/581.