### PR TITLE
feat(op-deployer): add alternate way to produce valid prestates

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,10 +421,10 @@ optimism_package:
         # A list of optional extra params that will be passed to the challenger container for modifying its behaviour
         extra_params: []
 
-        # Path to folder containing cannon prestate-proof.json file
+        # Path to folder containing cannon prestate-proof.json file. Mutually exclusive with cannon_prestates_url.
         cannon_prestates_path: "static_files/prestates"
 
-        # Base URL to absolute prestates to use when generating trace data.
+        # Base URL to absolute prestates to use when generating trace data. Mutually excluive with cannon_prestates_path.
         cannon_prestates_url: ""
 
       # Default proposer configuration
@@ -481,10 +481,15 @@ optimism_package:
   # The docker image that should be used for the L2 contract deployer.
   # Locators can be http(s) URLs, or point to an enclave artifact with
   # a pseudo URL artifact://NAME
+  # If specified, prestate_builder_image will be deployed as a service
+  # that takes genesis/rollup information as input and generates the
+  # corresponding prestate. In that case, challenger will be pointed to the outcome,
+  # effectively ignoring cannon_prestate_path / cannon_prestate_url.
   op_contract_deployer_params:
     image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11
     l1_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-c193a1863182092bc6cb723e523e8313a0f4b6e9c9636513927f1db74c047c15.tar.gz
     l2_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-c193a1863182092bc6cb723e523e8313a0f4b6e9c9636513927f1db74c047c15.tar.gz
+    prestate_builder_image: ""
 
   # The global log level that all clients should log at
   # Valid values are "error", "warn", "info", "debug", and "trace"

--- a/main.star
+++ b/main.star
@@ -87,7 +87,7 @@ def run(plan, args={}):
         plan.print("Waiting for L1 to start up")
         wait_for_sync.wait_for_startup(plan, l1_config_env_vars)
 
-    deployment_output = contract_deployer.deploy_contracts(
+    deployment = contract_deployer.deploy_contracts(
         plan,
         l1_priv_key,
         l1_config_env_vars,
@@ -95,6 +95,8 @@ def run(plan, args={}):
         l1_network,
         altda_deploy_config,
     )
+    deployment_output = deployment.output
+    prestates_url = deployment.prestates_url
 
     jwt_file = plan.upload_files(
         src=ethereum_package_static_files.JWT_PATH_FILEPATH,
@@ -144,18 +146,19 @@ def run(plan, args={}):
         )
         if chain.challenger_params.enabled:
             op_challenger_launcher.launch(
-                plan,
-                l2_num,
-                "op-challenger-{0}".format(chain.network_params.name),
-                chain.challenger_params.image,
-                l2.participants[0].el_context,
-                l2.participants[0].cl_context,
-                l1_config_env_vars,
-                deployment_output,
-                chain.network_params,
-                chain.challenger_params,
-                interop_params,
-                observability_helper,
+                plan=plan,
+                l2_num=l2_num,
+                service_name="op-challenger-{0}".format(chain.network_params.name),
+                image=chain.challenger_params.image,
+                el_context=l2.participants[0].el_context,
+                cl_context=l2.participants[0].cl_context,
+                l1_config_env_vars=l1_config_env_vars,
+                deployment_output=deployment_output,
+                network_params=chain.network_params,
+                challenger_params=chain.challenger_params,
+                interop_params=interop_params,
+                observability_helper=observability_helper,
+                prestates_url=prestates_url,
             )
 
     observability.launch(

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -36,20 +36,21 @@ def launch(
     challenger_params,
     interop_params,
     observability_helper,
+    prestates_url=None,
 ):
     config = get_challenger_config(
-        plan,
-        l2_num,
-        service_name,
-        image,
-        el_context,
-        cl_context,
-        l1_config_env_vars,
-        deployment_output,
-        network_params,
-        challenger_params,
-        interop_params,
-        observability_helper,
+        plan=plan,
+        l2_num=l2_num,
+        image=image,
+        el_context=el_context,
+        cl_context=cl_context,
+        l1_config_env_vars=l1_config_env_vars,
+        deployment_output=deployment_output,
+        network_params=network_params,
+        challenger_params=challenger_params,
+        interop_params=interop_params,
+        observability_helper=observability_helper,
+        prestates_url=prestates_url,
     )
 
     service = plan.add_service(service_name, config)
@@ -58,13 +59,12 @@ def launch(
         observability_helper, service, network_params.network
     )
 
-    return "op_challenger"
+    return "op-challenger"
 
 
 def get_challenger_config(
     plan,
     l2_num,
-    service_name,
     image,
     el_context,
     cl_context,
@@ -74,6 +74,7 @@ def get_challenger_config(
     challenger_params,
     interop_params,
     observability_helper,
+    prestates_url,
 ):
     ports = dict(get_used_ports())
 
@@ -131,22 +132,12 @@ def get_challenger_config(
         # Tracked at issue https://github.com/ethpandaops/optimism-package/issues/189
         cmd.append("--cannon-depset-config=dummy-file.json")
 
-    if (
-        challenger_params.cannon_prestate_path
-        and challenger_params.cannon_prestates_url
-    ):
-        fail("Only one of cannon_prestate_path and cannon_prestates_url can be set")
-    elif challenger_params.cannon_prestate_path:
-        cannon_prestate_artifact = plan.upload_files(
-            src=challenger_params.cannon_prestate_path,
-            name="{}-prestates".format(service_name),
+    cmd.append(
+        get_prestates_flag(
+            prestates_url,
+            challenger_params,
         )
-        files["/prestates"] = cannon_prestate_artifact
-        cmd.append("--cannon-prestate=/prestates/prestate-proof.json")
-    elif challenger_params.cannon_prestates_url:
-        cmd.append("--cannon-prestates-url=" + challenger_params.cannon_prestates_url)
-    else:
-        fail("One of cannon_prestate_path or cannon_prestates_url must be set")
+    )
 
     cmd += challenger_params.extra_params
     cmd = "mkdir -p {0} && {1}".format(
@@ -161,3 +152,21 @@ def get_challenger_config(
         files=files,
         private_ip_address_placeholder=ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
     )
+
+
+def get_prestates_flag(prestates_url, challenger_params):
+    if (
+        challenger_params.cannon_prestate_path
+        and challenger_params.cannon_prestates_url
+    ):
+        fail("Only one of cannon_prestate_path and cannon_prestates_url can be set")
+
+    if prestates_url:
+        # this takes precedence over cannon_prestate_path and cannon_prestates_url
+        return "--cannon-prestates-url=" + prestates_url
+
+    if challenger_params.cannon_prestate_path:
+        return "--cannon-prestate=/prestates/prestate-proof.json"
+
+    # we have default for cannon_prestates_url, so it's a safe fallback
+    return "--cannon-prestates-url=" + challenger_params.cannon_prestates_url

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -267,6 +267,9 @@ def input_parser(plan, input_args):
             global_deploy_overrides=results["op_contract_deployer_params"][
                 "global_deploy_overrides"
             ],
+            prestate_builder_image=results["op_contract_deployer_params"][
+                "prestate_builder_image"
+            ],
         ),
         global_log_level=results["global_log_level"],
         global_node_selectors=results["global_node_selectors"],
@@ -672,6 +675,7 @@ def default_op_contract_deployer_params():
         "l1_artifacts_locator": "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz",
         "l2_artifacts_locator": "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz",
         "global_deploy_overrides": default_op_contract_deployer_global_deploy_overrides(),
+        "prestate_builder_image": "",
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -168,6 +168,7 @@ OP_CONTRACT_DEPLOYER_PARAMS = [
     "l1_artifacts_locator",
     "l2_artifacts_locator",
     "global_deploy_overrides",
+    "prestate_builder_image",
 ]
 
 OP_CONTRACT_DEPLOYER_GLOBAL_DEPLOY_OVERRIDES = ["faultGameAbsolutePrestate"]


### PR DESCRIPTION
This change leverages https://github.com/ethereum-optimism/optimism/pull/14524 to generate prestates based on the genesis/rollup information computed at deployment time.

This will eventually result in a verifiable proof (in particular for interop).

Note that this is purely opt-in right now