### PR TITLE
feat: Allow dynamically created custom launchers

### DIFF
--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,4 +1,4 @@
-name: github.com/ethpandaops/optimism-package
+name: github.com/dzejkop/optimism-package
 description: |
   # Optimism Package
   This is a Kurtosis package for deploying an Optimism Rollup

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,4 +1,4 @@
-name: github.com/dzejkop/optimism-package
+name: github.com/ethpandaops/optimism-package
 description: |
   # Optimism Package
   This is a Kurtosis package for deploying an Optimism Rollup

--- a/main.star
+++ b/main.star
@@ -18,7 +18,7 @@ ethereum_package_static_files = import_module(
 _registry = import_module("./src/package_io/registry.star")
 
 
-def run(plan, args={}):
+def run(plan, args={}, custom_launchers=None):
     """Deploy Optimism L2s on an Ethereum L1.
 
     Args:
@@ -135,6 +135,7 @@ def run(plan, args={}):
                 persistent=persistent,
                 observability_helper=observability_helper,
                 supervisors_params=l2_supervisors_params,
+                custom_launchers=custom_launchers,
                 registry=registry,
             )
         )

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -108,7 +108,7 @@ def launch(
                 network_params.network,
                 network_params.network_id,
             ),
-            "launch_method": custom_launchers["el_launcher"]["launch_method"]
+            "launch_method": custom_launchers["el_launcher"]["launch_method"],
         }
 
     el_builder_launchers = {
@@ -149,7 +149,7 @@ def launch(
                 network_params.network,
                 network_params.network_id,
             ),
-            "launch_method": custom_launchers["el_builder_launcher"]["launch_method"]
+            "launch_method": custom_launchers["el_builder_launcher"]["launch_method"],
         }
 
     cl_launchers = {
@@ -176,11 +176,9 @@ def launch(
     if custom_launchers and "cl_launcher" in custom_launchers:
         cl_launchers["custom"] = {
             "launcher": custom_launchers["cl_launcher"]["launcher"](
-                deployment_output,
-                jwt_file,
-                network_params
+                deployment_output, jwt_file, network_params
             ),
-            "launch_method": custom_launchers["cl_launcher"]["launch_method"]
+            "launch_method": custom_launchers["cl_launcher"]["launch_method"],
         }
 
     cl_builder_launchers = {
@@ -195,11 +193,9 @@ def launch(
     if custom_launchers and "cl_builder_launcher" in custom_launchers:
         cl_builder_launchers["custom"] = {
             "launcher": custom_launchers["cl_builder_launcher"]["launcher"](
-                deployment_output,
-                jwt_file,
-                network_params
+                deployment_output, jwt_file, network_params
             ),
-            "launch_method": custom_launchers["cl_builder_launcher"]["launch_method"]
+            "launch_method": custom_launchers["cl_builder_launcher"]["launch_method"],
         }
 
     sidecar_launchers = {
@@ -222,7 +218,7 @@ def launch(
                 network_params.network,
                 network_params.network_id,
             ),
-            "launch_method": custom_launchers["sidecar_launcher"]["launch_method"]
+            "launch_method": custom_launchers["sidecar_launcher"]["launch_method"],
         }
 
     all_cl_contexts = []

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -49,6 +49,7 @@ def launch(
     observability_helper,
     supervisors_params,
     da_server_context,
+    custom_launchers,
     registry=_registry.Registry(),
 ):
     el_launchers = {
@@ -99,6 +100,9 @@ def launch(
         },
     }
 
+    if custom_launchers and "el_launcher" in custom_launchers:
+        el_launchers["custom"] = custom_launchers["el_launcher"]
+
     el_builder_launchers = {
         "op-geth": {
             "launcher": op_geth_builder.new_op_geth_builder_launcher(
@@ -129,6 +133,9 @@ def launch(
         },
     }
 
+    if custom_launchers and "el_builder_launcher" in custom_launchers:
+        el_builder_launchers["custom"] = custom_launchers["el_builder_launcher"]
+
     cl_launchers = {
         "op-node": {
             "launcher": op_node.new_op_node_launcher(
@@ -150,6 +157,9 @@ def launch(
         },
     }
 
+    if custom_launchers and "cl_launcher" in custom_launchers:
+        cl_launchers["custom"] = custom_launchers["cl_launcher"]
+
     cl_builder_launchers = {
         "op-node": {
             "launcher": op_node_builder.new_op_node_builder_launcher(
@@ -158,6 +168,9 @@ def launch(
             "launch_method": op_node_builder.launch,
         },
     }
+
+    if custom_launchers and "cl_builder_launcher" in custom_launchers:
+        cl_builder_launchers["custom"] = custom_launchers["cl_builder_launcher"]
 
     sidecar_launchers = {
         "rollup-boost": {
@@ -170,6 +183,9 @@ def launch(
             "launch_method": rollup_boost.launch,
         }
     }
+
+    if custom_launchers and "sidecar_launcher" in custom_launchers:
+        sidecar_launchers["custom"] = custom_launchers["sidecar_launcher"]
 
     all_cl_contexts = []
     all_el_contexts = []

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -101,7 +101,15 @@ def launch(
     }
 
     if custom_launchers and "el_launcher" in custom_launchers:
-        el_launchers["custom"] = custom_launchers["el_launcher"]
+        el_launchers["custom"] = {
+            "launcher": custom_launchers["el_launcher"]["launcher"](
+                deployment_output,
+                jwt_file,
+                network_params.network,
+                network_params.network_id,
+            ),
+            "launch_method": custom_launchers["el_launcher"]["launch_method"]
+        }
 
     el_builder_launchers = {
         "op-geth": {
@@ -166,7 +174,14 @@ def launch(
     }
 
     if custom_launchers and "cl_launcher" in custom_launchers:
-        cl_launchers["custom"] = custom_launchers["cl_launcher"]
+        cl_launchers["custom"] = {
+            "launcher": custom_launchers["cl_launcher"]["launcher"](
+                deployment_output,
+                jwt_file,
+                network_params
+            ),
+            "launch_method": custom_launchers["cl_launcher"]["launch_method"]
+        }
 
     cl_builder_launchers = {
         "op-node": {
@@ -178,7 +193,14 @@ def launch(
     }
 
     if custom_launchers and "cl_builder_launcher" in custom_launchers:
-        cl_builder_launchers["custom"] = custom_launchers["cl_builder_launcher"]
+        cl_builder_launchers["custom"] = {
+            "launcher": custom_launchers["cl_builder_launcher"]["launcher"](
+                deployment_output,
+                jwt_file,
+                network_params
+            ),
+            "launch_method": custom_launchers["cl_builder_launcher"]["launch_method"]
+        }
 
     sidecar_launchers = {
         "rollup-boost": {
@@ -193,7 +215,15 @@ def launch(
     }
 
     if custom_launchers and "sidecar_launcher" in custom_launchers:
-        sidecar_launchers["custom"] = custom_launchers["sidecar_launcher"]
+        sidecar_launchers["custom"] = {
+            "launcher": custom_launchers["sidecar_launcher"]["launcher"](
+                deployment_output,
+                jwt_file,
+                network_params.network,
+                network_params.network_id,
+            ),
+            "launch_method": custom_launchers["sidecar_launcher"]["launch_method"]
+        }
 
     all_cl_contexts = []
     all_el_contexts = []

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -134,7 +134,15 @@ def launch(
     }
 
     if custom_launchers and "el_builder_launcher" in custom_launchers:
-        el_builder_launchers["custom"] = custom_launchers["el_builder_launcher"]
+        el_builder_launchers["custom"] = {
+            "launcher": custom_launchers["el_builder_launcher"]["launcher"](
+                deployment_output,
+                jwt_file,
+                network_params.network,
+                network_params.network_id,
+            ),
+            "launch_method": custom_launchers["el_builder_launcher"]["launch_method"]
+        }
 
     cl_launchers = {
         "op-node": {

--- a/src/l2.star
+++ b/src/l2.star
@@ -23,6 +23,7 @@ def launch_l2(
     persistent,
     observability_helper,
     supervisors_params,
+    custom_launchers,
     registry=None,
 ):
     network_params = l2_args.network_params
@@ -69,6 +70,7 @@ def launch_l2(
         observability_helper=observability_helper,
         supervisors_params=supervisors_params,
         da_server_context=da_server_context,
+        custom_launchers=custom_launchers,
         registry=registry,
     )
 

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -29,6 +29,7 @@ def launch_participant_network(
     observability_helper,
     supervisors_params,
     da_server_context,
+    custom_launchers,
     registry=_registry.Registry(),
 ):
     num_participants = len(participants)
@@ -52,6 +53,7 @@ def launch_participant_network(
         observability_helper=observability_helper,
         supervisors_params=supervisors_params,
         da_server_context=da_server_context,
+        custom_launchers=custom_launchers,
         registry=registry,
     )
 

--- a/test/el_cl_launcher_test.star
+++ b/test/el_cl_launcher_test.star
@@ -310,7 +310,7 @@ def test_launch_with_custom_launcher(plan):
         da_server_context=da_server_context,
         custom_launchers={
             "el_launcher": {
-                "launcher": {},
+                "launcher": custom_launcher,
                 "launch_method": custom_launch,
             },
         }
@@ -322,6 +322,9 @@ def test_launch_with_custom_launcher(plan):
 
     expect.eq(el_service_config.image, "custom-image")
 
+    pass
+
+def custom_launcher(deployment_output, jwt_file, network, network_id):
     pass
 
 def custom_launch(
@@ -350,7 +353,6 @@ def custom_launch(
         ip_addr="192.168.0.1",
         engine_rpc_port_num=123,
     )
-
     # TODO Once files are available on kurtosistest.get_service_config, make sure the JWT file is being mounted
 
 

--- a/test/el_cl_launcher_test.star
+++ b/test/el_cl_launcher_test.star
@@ -73,7 +73,7 @@ def test_launch_with_defaults(plan):
         observability_helper=observability_helper,
         supervisors_params=parsed_input_args.supervisors,
         da_server_context=da_server_context,
-        custom_launchers=None
+        custom_launchers=None,
     )
 
     el_service_name = "op-el-2151908-1-op-reth-op-node-"
@@ -206,7 +206,7 @@ def test_launch_with_el_op_besu(plan):
         observability_helper=observability_helper,
         supervisors_params=parsed_input_args.supervisors,
         da_server_context=da_server_context,
-        custom_launchers=None
+        custom_launchers=None,
     )
 
     el_service_name = "op-el-2151908-1-op-besu-op-node-"
@@ -261,6 +261,7 @@ def test_launch_with_el_op_besu(plan):
         ],
     )
 
+
 def test_launch_with_custom_launcher(plan):
     parsed_input_args = input_parser.input_parser(
         plan,
@@ -313,7 +314,7 @@ def test_launch_with_custom_launcher(plan):
                 "launcher": custom_launcher,
                 "launch_method": custom_launch,
             },
-        }
+        },
     )
 
     el_service_name = "custom-launcher"
@@ -324,8 +325,10 @@ def test_launch_with_custom_launcher(plan):
 
     pass
 
+
 def custom_launcher(deployment_output, jwt_file, network, network_id):
     pass
+
 
 def custom_launch(
     plan,
@@ -342,9 +345,7 @@ def custom_launch(
     observability_helper,
     interop_params,
 ):
-    plan.add_service("custom-launcher", ServiceConfig(
-        image = "custom-image"
-    ))
+    plan.add_service("custom-launcher", ServiceConfig(image="custom-image"))
 
     # Just some mocked data that's used in other parts of the codebase
     return struct(


### PR DESCRIPTION
# How this works

This feature allows one to specify a `custom` el/cl/builder type in the network params, e.g.

```
optimism_package:
  chains:
    - participants:
        - el_type: custom
```

which, can then be dynamically in one's own kurtosis package, e.g.
```
optimism_package = import_module("github.com/ethpandaops/optimism-package/main.star")

def run(plan, args={}):
  optimism_package.run(plan, args, custom_launchers={
      "el_launcher": {
        "launcher": custom_launcher(),
        "launch_method": custom_launch,
      },
    }
  )
```

# Motivation
We're setting up our own devnet using kurtosis and we're testing our own custom builder. We tried forking/vendoring the whole optimism package and extending it with our own functionality but this is very cumbersome.

I explored if it'd be possible to import `optimism-package` as a dep, run it and then add our custom builder service later, but the package either deploys with rollup boost & builder nodes or nothing at all. It's possible to setup an external builder but then we need to dynamically figure out the ip address of the host machine as it has to be known ahead of time.

This approach also allows us to benefit from observability integration.