### PR TITLE
fix desc for l1 consensus

### DIFF
--- a/src/wait/wait_for_sync.star
+++ b/src/wait/wait_for_sync.star
@@ -27,10 +27,10 @@ def wait_for_sync(plan, l1_config_env_vars):
 def wait_for_startup(plan, l1_config_env_vars):
     plan.run_sh(
         name="wait-for-l1-consensus-startup",
-        description="Wait for L1 to start up - can take up to 2 minutes",
+        description="Wait for L1 consensus to start up - can take up to 2 minutes",
         image=utils.DEPLOYMENT_UTILS_IMAGE,
         env_vars=l1_config_env_vars,
-        run="while true; do sleep 5; echo 'L1 Chain is starting up'; if [ \"$(curl -s $CL_RPC_URL/eth/v1/beacon/headers/ | jq -r '.data[0].header.message.slot')\" != \"0\" ]; then echo 'L1 Chain has started!'; break; fi; done",
+        run="while true; do sleep 5; echo 'L1 Consensus is starting up'; if [ \"$(curl -s $CL_RPC_URL/eth/v1/beacon/headers/ | jq -r '.data[0].header.message.slot')\" != \"0\" ]; then echo 'L1 Consensus has started!'; break; fi; done",
         wait="300s",
     )
 


### PR DESCRIPTION
<img width="518" alt="image" src="https://github.com/user-attachments/assets/8e77ce0a-aa98-4208-9abd-8190c6c324d4" />

The original log for `l1 consensus` is a bit vague, this PR makes it more accurate.