### PR TITLE
feat: Per-interop-set supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,18 @@ optimism_package:
       image: "grafana/grafana:11.5.0"
   # Interop configuration
   interop:
-    # Whether or not to enable interop mode
-    enabled: false
+    # A list of interop sets - connected L2 chains
+    # 
+    # If left empty, interop is disabled
+    sets: 
+        # Optional human-readable name for this interop set
+      - name:
+        # List of L2 IDs that participate in this set
+        participants: []
+        # Supervisor overrides for this particular interop set
+        # 
+        # Leave empty to use the default supervisor configuration
+        supervisor_params:
     # Default supervisor configuration
     supervisor_params:
       # The Docker image that should be used for the supervisor; leave blank to use the default op-supervisor image

--- a/README.md
+++ b/README.md
@@ -138,13 +138,18 @@ optimism_package:
     # If left empty, interop is disabled
     sets: 
         # Optional human-readable name for this interop set
-      - name:
-        # List of L2 IDs that participate in this set
-        participants: []
+      - name: "interop-set-0"
+        # List of L2 network_ids that participate in this set
+        # 
+        # Please refer to chains[].network_params.network_id for more information
+        participants: ["2151908"]
         # Supervisor overrides for this particular interop set
         # 
         # Leave empty to use the default supervisor configuration
         supervisor_params:
+      - name: "interop-set-1"
+        # "*" can be used to quickly add all networks into one interop set
+        participants: "*"
     # Default supervisor configuration
     supervisor_params:
       # The Docker image that should be used for the supervisor; leave blank to use the default op-supervisor image

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ optimism_package:
       image: "grafana/grafana:11.5.0"
   # Interop configuration
   interop:
+    # Interop can be enabled and disabled using this flag
+    # 
+    # By default, interop will be enabled if there is at least one interop set specified
+    enabled: false
     # A list of interop sets - connected L2 chains
     # 
     # If left empty, interop is disabled
@@ -147,6 +151,10 @@ optimism_package:
         # 
         # Leave empty to use the default supervisor configuration
         supervisor_params:
+        # Interop set can be disabled for ease of local development
+        # 
+        # Defaults to true
+        enabled: true
       - name: "interop-set-1"
         # "*" can be used to quickly add all networks into one interop set
         participants: "*"

--- a/main.star
+++ b/main.star
@@ -124,15 +124,15 @@ def run(plan, args={}):
         )
 
     if interop_params.enabled:
-        op_supervisor_launcher.launch(
-            plan,
-            l1_config_env_vars,
-            optimism_args.chains,
-            l2s,
-            jwt_file,
-            interop_params.supervisor_params,
-            observability_helper,
-        )
+        for i, interop_set in enumerate(interop_params.sets):
+            op_supervisor_launcher.launch(
+                plan=plan,
+                interop_set=interop_set,
+                l1_config_env_vars=l1_config_env_vars,
+                l2s=l2s,
+                jwt_file=jwt_file,
+                observability_helper=observability_helper,
+            )
 
     # challenger must launch after supervisor because it depends on it for interop
     for l2_num, l2 in enumerate(l2s):

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 
 # Core dependencies
-"ubi:ethereum-optimism/kurtosis-test" = "0.0.1"
+"ubi:ethereum-optimism/kurtosis-test" = "0.0.3"
 "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.4.4"
 "yq" = "v4.44.3"
 

--- a/src/interop/constants.star
+++ b/src/interop/constants.star
@@ -1,4 +1,3 @@
-constants = import_module("../package_io/constants.star")
 util = import_module("../util.star")
 
 INTEROP_WS_PORT_ID = "interop-ws"

--- a/src/interop/op-supervisor/op_supervisor_launcher.star
+++ b/src/interop/op-supervisor/op_supervisor_launcher.star
@@ -8,10 +8,10 @@ ethereum_package_constants = import_module(
     "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
 )
 
-constants = import_module("../../package_io/constants.star")
 observability = import_module("../../observability/observability.star")
 prometheus = import_module("../../observability/prometheus/prometheus_launcher.star")
 
+constants = import_module("../../package_io/constants.star")
 interop_constants = import_module("../constants.star")
 
 
@@ -30,15 +30,15 @@ DATA_DIR = "/etc/op-supervisor"
 DEPENDENCY_SET_FILE_NAME = "dependency_set.json"
 
 
-def create_dependency_set(chains):
+def create_dependency_set(l2s):
     result = {
         "dependencies": {
-            str(chain.network_params.network_id): {
-                "chainIndex": str(chain.network_params.network_id),
+            str(l2.network_id): {
+                "chainIndex": str(l2.network_id),
                 "activationTime": 0,
                 "historyMinTime": 0,
             }
-            for chain in chains
+            for l2 in l2s
         }
     }
     return result
@@ -46,40 +46,66 @@ def create_dependency_set(chains):
 
 def launch(
     plan,
+    interop_set,
     l1_config_env_vars,
-    chains,
     l2s,
     jwt_file,
-    supervisor_params,
     observability_helper,
 ):
-    dependency_set_json = supervisor_params.dependency_set
-    if not dependency_set_json:
-        dependency_set = create_dependency_set(chains)
-        dependency_set_json = json.encode(dependency_set)
+    # First we check that the supervisor is enabled for this interop set
+    if not interop_set.enabled:
+        plan.print(
+            "op-supervisor is not enabled for interop set {}, skipping launch".format(
+                interop_set.name
+            )
+        )
+        return None
 
+    # Then we check that we have some participants
+    if len(interop_set.participants) == 0:
+        plan.print(
+            "op-supervisor has no participants for interop set {}, skipping launch".format(
+                interop_set.name
+            )
+        )
+        return None
+
+    # Now we filter out the participating L2s
+    interop_set_l2s = [l2 for l2 in l2s if l2.network_id in interop_set.participants]
+
+    # Now we create dependency set if none was provided
+    dependency_set_json = interop_set.supervisor_params.dependency_set or json.encode(
+        create_dependency_set(interop_set_l2s)
+    )
+
+    # And write it to an artifact
     dependency_set_artifact = utils.write_to_file(
         plan, dependency_set_json, DATA_DIR, DEPENDENCY_SET_FILE_NAME
     )
 
-    config = get_supervisor_config(
-        plan,
-        l1_config_env_vars,
-        l2s,
-        jwt_file,
-        dependency_set_artifact,
-        supervisor_params,
-        observability_helper,
+    # We create a service name based on the interop set name
+    service_name = "{}-{}".format(
+        interop_constants.SUPERVISOR_SERVICE_NAME, interop_set.name
     )
 
-    service = plan.add_service(interop_constants.SUPERVISOR_SERVICE_NAME, config)
+    config = get_supervisor_config(
+        plan=plan,
+        l1_config_env_vars=l1_config_env_vars,
+        l2s=interop_set_l2s,
+        jwt_file=jwt_file,
+        dependency_set_artifact=dependency_set_artifact,
+        supervisor_params=interop_set.supervisor_params,
+        observability_helper=observability_helper,
+    )
+
+    service = plan.add_service(service_name, config)
 
     observability.register_op_service_metrics_job(
         observability_helper,
         service,
     )
 
-    return "op_supervisor"
+    return service
 
 
 def get_supervisor_config(

--- a/src/interop/op-supervisor/op_supervisor_launcher.star
+++ b/src/interop/op-supervisor/op_supervisor_launcher.star
@@ -27,7 +27,10 @@ def get_used_ports():
 
 
 DATA_DIR = "/etc/op-supervisor"
-DEPENDENCY_SET_FILE_NAME = "dependency_set.json"
+
+
+def create_dependency_set_filename(interop_set):
+    return "dependency_set-{}.json".format(interop_set.name)
 
 
 def create_dependency_set(l2s):
@@ -79,8 +82,9 @@ def launch(
     )
 
     # And write it to an artifact
+    dependency_set_filename = create_dependency_set_filename(interop_set)
     dependency_set_artifact = utils.write_to_file(
-        plan, dependency_set_json, DATA_DIR, DEPENDENCY_SET_FILE_NAME
+        plan, dependency_set_json, DATA_DIR, dependency_set_filename
     )
 
     # We create a service name based on the interop set name
@@ -94,6 +98,7 @@ def launch(
         l2s=interop_set_l2s,
         jwt_file=jwt_file,
         dependency_set_artifact=dependency_set_artifact,
+        dependency_set_filename=dependency_set_filename,
         supervisor_params=interop_set.supervisor_params,
         observability_helper=observability_helper,
     )
@@ -114,6 +119,7 @@ def get_supervisor_config(
     l2s,
     jwt_file,
     dependency_set_artifact,
+    dependency_set_filename,
     supervisor_params,
     observability_helper,
 ):
@@ -136,7 +142,7 @@ def get_supervisor_config(
         env_vars={
             "OP_SUPERVISOR_DATADIR": "/db",
             "OP_SUPERVISOR_DEPENDENCY_SET": "{0}/{1}".format(
-                DATA_DIR, DEPENDENCY_SET_FILE_NAME
+                DATA_DIR, dependency_set_filename
             ),
             "OP_SUPERVISOR_L1_RPC": l1_config_env_vars["L1_RPC_URL"],
             "OP_SUPERVISOR_L2_CONSENSUS_NODES": ",".join(

--- a/src/l2.star
+++ b/src/l2.star
@@ -48,6 +48,8 @@ def launch_l2(
         )
         plan.print("Successfully launched da-server")
 
+    kurtosistest.debug(l2_num)
+
     l2 = participant_network.launch_participant_network(
         plan,
         l2_args.participants,

--- a/src/l2.star
+++ b/src/l2.star
@@ -48,8 +48,6 @@ def launch_l2(
         )
         plan.print("Successfully launched da-server")
 
-    kurtosistest.debug(l2_num)
-
     l2 = participant_network.launch_participant_network(
         plan,
         l2_args.participants,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -451,7 +451,7 @@ def parse_network_params(plan, input_args):
 
     # configure interop
 
-    results["interop"] = build_interop_params(input_args.get("interop", {}), chains)
+    results["interop"] = compile_interop_params(input_args.get("interop", {}), chains)
 
     # configure op-deployer
 
@@ -548,15 +548,15 @@ def default_supervisor_params():
 
 
 # This function normalizes the interop args to ensure that all values are set
-def build_interop_params(interop_args, chains):
+def compile_interop_params(interop_args, chains):
     # We first filter the None values so that we can merge dicts easily
     interop_args_without_none = util.filter_none(interop_args)
 
     # Then we build the sub-params
-    supervisor_params = build_interop_supervisor_params(
+    supervisor_params = compile_interop_supervisor_params(
         interop_args_without_none.get("supervisor_params", {})
     )
-    sets_params = build_interop_sets_params(
+    sets_params = compile_interop_sets_params(
         interop_args_without_none.get("sets", []), supervisor_params, chains
     )
 
@@ -578,7 +578,7 @@ def build_interop_params(interop_args, chains):
 #
 # - to build the default interop supervisor params, in which case the default values are the global defaults
 # - to build the interop supervisor params for each interop set, in which case the default values are the interop supervisor params
-def build_interop_supervisor_params(
+def compile_interop_supervisor_params(
     interop_supervisor_args,
     default_interop_supervisor_params=default_supervisor_params(),
 ):
@@ -598,9 +598,9 @@ def build_interop_supervisor_params(
 
 
 # This function normalizes the interop sets args to ensure that all values are set
-def build_interop_sets_params(interop_sets_args, interop_supervisor_params, chains):
+def compile_interop_sets_params(interop_sets_args, interop_supervisor_params, chains):
     interop_sets_params = [
-        build_interop_set_params(
+        compile_interop_set_params(
             interop_set_args, interop_set_index, interop_supervisor_params, chains
         )
         for interop_set_index, interop_set_args in enumerate(interop_sets_args)
@@ -621,7 +621,7 @@ def build_interop_sets_params(interop_sets_args, interop_supervisor_params, chai
 
 
 # This function normalizes the interop sets args to ensure that all values are set
-def build_interop_set_params(
+def compile_interop_set_params(
     interop_set_args,
     # The suffix is used to create a default name for the interop set if no name is provided
     interop_set_suffix,
@@ -648,7 +648,7 @@ def build_interop_set_params(
     )
 
     # The interop set supervisor params are optional and default to the global interop supervisor params
-    interop_set_supervisor_params = build_interop_supervisor_params(
+    interop_set_supervisor_params = compile_interop_supervisor_params(
         interop_set_args_without_none.get("supervisor_params", {}),
         interop_supervisor_params,
     )

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -54,10 +54,7 @@ GRAFANA_PARAMS = [
     "max_mem",
 ]
 
-INTEROP_PARAMS = [
-    "enabled",
-    "supervisor_params",
-]
+INTEROP_PARAMS = ["enabled", "supervisor_params", "sets"]
 
 SUPERVISOR_PARAMS = [
     "image",

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -136,5 +136,6 @@ def launch_participant_network(
     )
 
     return struct(
+        network_id=network_params.network_id,
         participants=all_participants,
     )

--- a/src/util.star
+++ b/src/util.star
@@ -145,20 +145,23 @@ def make_execution_rpc_url(el_context):
         el_context.rpc_port_num,
     )
 
+
 # Removes all None values from a dictionary and returns a new dictionary.
 def filter_none(d):
     return {k: v for k, v in d.items() if v != None}
 
+
 # Returns a list of duplicate items in the input list.
 def get_duplicates(items):
     # Unfortunately kurotis star doesn't support sets so we'll have to do with O(N^2) complexity and a list
-    # 
+    #
     # The redeeming factor is the fact that we are dealing with very limited list sizes
     seen = []
     duplicates = []
     for item in items:
         if item in seen:
-            if item not in duplicates: duplicates.append(item)
+            if item not in duplicates:
+                duplicates.append(item)
         else:
             seen.append(item)
     return duplicates

--- a/src/util.star
+++ b/src/util.star
@@ -148,3 +148,17 @@ def make_execution_rpc_url(el_context):
 # Removes all None values from a dictionary and returns a new dictionary.
 def filter_none(d):
     return {k: v for k, v in d.items() if v != None}
+
+# Returns a list of duplicate items in the input list.
+def get_duplicates(items):
+    # Unfortunately kurotis star doesn't support sets so we'll have to do with O(N^2) complexity and a list
+    # 
+    # The redeeming factor is the fact that we are dealing with very limited list sizes
+    seen = []
+    duplicates = []
+    for item in items:
+        if item in seen:
+            if item not in duplicates: duplicates.append(item)
+        else:
+            seen.append(item)
+    return duplicates

--- a/src/util.star
+++ b/src/util.star
@@ -144,3 +144,7 @@ def make_execution_rpc_url(el_context):
         el_context.ip_addr,
         el_context.rpc_port_num,
     )
+
+# Removes all None values from a dictionary and returns a new dictionary.
+def filter_none(d):
+    return {k: v for k, v in d.items() if v != None}

--- a/test/interop/op-supervisor/op_supervisor_launcher_test.star
+++ b/test/interop/op-supervisor/op_supervisor_launcher_test.star
@@ -1,6 +1,9 @@
 main = import_module("/main.star")
 
 interop_constants = import_module("/src/interop/constants.star")
+op_supervisor_launcher = import_module(
+    "/src/interop/op-supervisor/op_supervisor_launcher.star"
+)
 
 
 def get_l2_cl_services(plan):
@@ -334,4 +337,13 @@ def test_op_supervisor_everything_in_one_set(plan):
                 ],
             ]
         ),
+    )
+
+
+def test_create_dependency_set_filename(plan):
+    expect.eq(
+        op_supervisor_launcher.create_dependency_set_filename(
+            struct(name="my-interop-set")
+        ),
+        "dependency_set-my-interop-set.json",
     )

--- a/test/interop/op-supervisor/op_supervisor_launcher_test.star
+++ b/test/interop/op-supervisor/op_supervisor_launcher_test.star
@@ -1,0 +1,259 @@
+main = import_module("/main.star")
+
+interop_constants = import_module("/src/interop/constants.star")
+
+
+def get_l2_cl_services(plan):
+    services = plan.get_services()
+
+    return [s for s in services if s.name.startswith("op-cl-")]
+
+
+def get_supervisor_services_by_service_name(plan):
+    services = plan.get_services()
+
+    return {
+        s.name: s
+        for s in services
+        if s.name.startswith(interop_constants.SUPERVISOR_SERVICE_NAME)
+    }
+
+
+def expect_no_supervisors(plan):
+    supervisor_services = get_supervisor_services_by_service_name(plan)
+
+    expect.eq(supervisor_services, {})
+
+
+def test_op_supervisor_disabled(plan):
+    main.run(
+        plan,
+        {
+            "optimism_package": {
+                "chains": [{}],
+                "interop": {
+                    "enabled": False,
+                },
+            },
+        },
+    )
+
+    expect_no_supervisors(plan)
+
+
+def test_op_supervisor_interop_set_disabled(plan):
+    main.run(
+        plan,
+        {
+            "optimism_package": {
+                "chains": [{}],
+                "interop": {
+                    "enabled": True,
+                    "sets": [
+                        {
+                            "enabled": False,
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    expect_no_supervisors(plan)
+
+
+def test_op_supervisor_interop_set_no_participants(plan):
+    main.run(
+        plan,
+        {
+            "optimism_package": {
+                "chains": [{}],
+                "interop": {
+                    "enabled": True,
+                    "sets": [
+                        {
+                            "enabled": True,
+                            "participants": [],
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    expect_no_supervisors(plan)
+
+
+def test_op_supervisor_single_interop_set(plan):
+    main.run(
+        plan,
+        {
+            "optimism_package": {
+                "chains": [
+                    {
+                        "network_params": {
+                            "network_id": "1",
+                        }
+                    }
+                ],
+                "interop": {
+                    "enabled": True,
+                    "sets": [
+                        {
+                            "enabled": True,
+                            "name": "great-interop-set-what-a-name",
+                            "participants": "*",
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    cl_services = get_l2_cl_services(plan)
+    cl_services_urls = [
+        "ws://{0}:{1}".format(
+            cl_service.ip_address,
+            interop_constants.INTEROP_WS_PORT_NUM,
+        )
+        for cl_service in cl_services
+    ]
+
+    supervisor_services = get_supervisor_services_by_service_name(plan)
+    supervisor_service = supervisor_services[
+        "op-supervisor-great-interop-set-what-a-name"
+    ]
+    expect.ne(supervisor_service, None)
+
+    supervisor_service_config = kurtosistest.get_service_config(supervisor_service.name)
+    expect.ne(supervisor_service_config, None)
+
+    expect.eq(
+        supervisor_service_config.image,
+        "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-supervisor:develop",
+    )
+    expect.eq(
+        supervisor_service_config.env_vars["OP_SUPERVISOR_L2_CONSENSUS_NODES"],
+        ",".join(cl_services_urls),
+    )
+
+
+def test_op_supervisor_multiple_interop_sets(plan):
+    main.run(
+        plan,
+        {
+            "optimism_package": {
+                "chains": [
+                    {
+                        "network_params": {
+                            "network_id": "1000",
+                        }
+                    },
+                    {
+                        "network_params": {
+                            "network_id": "2000",
+                        }
+                    },
+                    {
+                        "network_params": {
+                            "network_id": "3000",
+                        }
+                    },
+                    {
+                        "participants": [{}, {}],
+                        "network_params": {
+                            "network_id": "4000",
+                        },
+                    },
+                ],
+                "interop": {
+                    "enabled": True,
+                    "sets": [
+                        {
+                            "enabled": True,
+                            "name": "great-interop-set-what-a-name",
+                            "participants": ["1000", "3000"],
+                        },
+                        {
+                            "enabled": True,
+                            "name": "even-better-interop",
+                            "participants": ["2000"],
+                            "supervisor_params": {
+                                "image": "op-supervisor:latest",
+                                "extra_params": ["--foo", "--bar"],
+                            },
+                        },
+                        {
+                            "enabled": True,
+                            "name": "but-wait-theres-more",
+                            "participants": ["4000"],
+                        },
+                    ],
+                },
+            },
+        },
+    )
+
+    supervisor_services = get_supervisor_services_by_service_name(plan)
+
+    supervisor_service1 = supervisor_services[
+        "op-supervisor-great-interop-set-what-a-name"
+    ]
+    expect.ne(supervisor_service1, None)
+
+    supervisor_service2 = supervisor_services["op-supervisor-even-better-interop"]
+    expect.ne(supervisor_service2, None)
+
+    supervisor_service3 = supervisor_services["op-supervisor-but-wait-theres-more"]
+    expect.ne(supervisor_service3, None)
+
+    cl_services = get_l2_cl_services(plan)
+    cl_services_urls_by_service_name = {
+        s.name: "ws://{0}:{1}".format(
+            s.ip_address,
+            interop_constants.INTEROP_WS_PORT_NUM,
+        )
+        for s in cl_services
+    }
+
+    supervisor_service1_config = kurtosistest.get_service_config(
+        supervisor_service1.name
+    )
+    expect.eq(
+        supervisor_service1_config.env_vars["OP_SUPERVISOR_L2_CONSENSUS_NODES"],
+        ",".join(
+            [
+                cl_services_urls_by_service_name[
+                    "op-cl-1000-1-op-node-op-geth-op-kurtosis"
+                ],
+                cl_services_urls_by_service_name[
+                    "op-cl-3000-1-op-node-op-geth-op-kurtosis"
+                ],
+            ]
+        ),
+    )
+
+    supervisor_service2_config = kurtosistest.get_service_config(
+        supervisor_service2.name
+    )
+    expect.eq(
+        supervisor_service2_config.env_vars["OP_SUPERVISOR_L2_CONSENSUS_NODES"],
+        cl_services_urls_by_service_name["op-cl-2000-1-op-node-op-geth-op-kurtosis"],
+    )
+
+    supervisor_service3_config = kurtosistest.get_service_config(
+        supervisor_service3.name
+    )
+    expect.eq(
+        supervisor_service3_config.env_vars["OP_SUPERVISOR_L2_CONSENSUS_NODES"],
+        ",".join(
+            [
+                cl_services_urls_by_service_name[
+                    "op-cl-4000-1-op-node-op-geth-op-kurtosis"
+                ],
+                cl_services_urls_by_service_name[
+                    "op-cl-4000-2-op-node-op-geth-op-kurtosis"
+                ],
+            ]
+        ),
+    )

--- a/test/interop/op-supervisor/op_supervisor_launcher_test.star
+++ b/test/interop/op-supervisor/op_supervisor_launcher_test.star
@@ -257,3 +257,84 @@ def test_op_supervisor_multiple_interop_sets(plan):
             ]
         ),
     )
+
+def test_op_supervisor_everything_in_one_set(plan):
+    main.run(
+        plan,
+        {
+            "optimism_package": {
+                "chains": [
+                    {
+                        "network_params": {
+                            "network_id": "1000",
+                        }
+                    },
+                    {
+                        "network_params": {
+                            "network_id": "2000",
+                        }
+                    },
+                    {
+                        "network_params": {
+                            "network_id": "3000",
+                        }
+                    },
+                    {
+                        "participants": [{}, {}],
+                        "network_params": {
+                            "network_id": "4000",
+                        },
+                    },
+                ],
+                "interop": {
+                    "sets": [
+                        {
+                            "name": "the-interopest-of-sets",
+                            "participants": "*",
+                        },
+                    ],
+                },
+            },
+        },
+    )
+
+    supervisor_services = get_supervisor_services_by_service_name(plan)
+    supervisor_service = supervisor_services[
+        "op-supervisor-the-interopest-of-sets"
+    ]
+    expect.ne(supervisor_service, None)
+
+    cl_services = get_l2_cl_services(plan)
+    cl_services_urls_by_service_name = {
+        s.name: "ws://{0}:{1}".format(
+            s.ip_address,
+            interop_constants.INTEROP_WS_PORT_NUM,
+        )
+        for s in cl_services
+    }
+
+    supervisor_service_config = kurtosistest.get_service_config(
+        supervisor_service.name
+    )
+    expect.eq(
+        supervisor_service_config.env_vars["OP_SUPERVISOR_L2_CONSENSUS_NODES"],
+        ",".join(
+            [
+                cl_services_urls_by_service_name[
+                    "op-cl-1000-1-op-node-op-geth-op-kurtosis"
+                ],
+                cl_services_urls_by_service_name[
+                    "op-cl-2000-1-op-node-op-geth-op-kurtosis"
+                ],
+                cl_services_urls_by_service_name[
+                    "op-cl-3000-1-op-node-op-geth-op-kurtosis"
+                ],
+                cl_services_urls_by_service_name[
+                    "op-cl-4000-1-op-node-op-geth-op-kurtosis"
+                ],
+                cl_services_urls_by_service_name[
+                    "op-cl-4000-2-op-node-op-geth-op-kurtosis"
+                ],
+            ]
+        ),
+    )

--- a/test/interop/op-supervisor/op_supervisor_launcher_test.star
+++ b/test/interop/op-supervisor/op_supervisor_launcher_test.star
@@ -258,6 +258,7 @@ def test_op_supervisor_multiple_interop_sets(plan):
         ),
     )
 
+
 def test_op_supervisor_everything_in_one_set(plan):
     main.run(
         plan,
@@ -299,9 +300,7 @@ def test_op_supervisor_everything_in_one_set(plan):
     )
 
     supervisor_services = get_supervisor_services_by_service_name(plan)
-    supervisor_service = supervisor_services[
-        "op-supervisor-the-interopest-of-sets"
-    ]
+    supervisor_service = supervisor_services["op-supervisor-the-interopest-of-sets"]
     expect.ne(supervisor_service, None)
 
     cl_services = get_l2_cl_services(plan)
@@ -313,9 +312,7 @@ def test_op_supervisor_everything_in_one_set(plan):
         for s in cl_services
     }
 
-    supervisor_service_config = kurtosistest.get_service_config(
-        supervisor_service.name
-    )
+    supervisor_service_config = kurtosistest.get_service_config(supervisor_service.name)
     expect.eq(
         supervisor_service_config.env_vars["OP_SUPERVISOR_L2_CONSENSUS_NODES"],
         ",".join(

--- a/test/package_io/input_parser_test.star
+++ b/test/package_io/input_parser_test.star
@@ -90,3 +90,71 @@ def test_external_l1_network_params_input_parser_set_fields(plan):
     parsed_params = input_parser.external_l1_network_params_input_parser(plan, params)
 
     expect.eq(parsed_params, struct(**params))
+
+def test_interop_default_args(plan):
+    parsed_params = input_parser.parse_network_params(plan, {})
+
+    expect.eq(parsed_params["interop"], input_parser.default_interop_params())
+
+def test_interop_supervisor_params(plan):
+    supervisor_args = { "image": "supervisor.jpeg", "dependency_set": None, "extra_params": None }
+    parsed_params = input_parser.parse_network_params(plan, {
+        "interop": {
+            "supervisor_params": supervisor_args,
+        },
+    })
+
+    expect.eq(parsed_params["interop"], input_parser.default_interop_params() | {
+        "supervisor_params": {
+            "image": "supervisor.jpeg",
+            "dependency_set": "",
+            "extra_params": [],
+        },
+    })
+
+def test_interop_default_set_params(plan):
+    supervisor_args = { "image": "supervisor.jpeg" }
+    parsed_params = input_parser.parse_network_params(plan, {
+        "interop": {
+            "supervisor_params": supervisor_args,
+            "sets": [{}]
+        },
+    })
+
+    expect.eq(parsed_params["interop"], input_parser.default_interop_params() | {
+        "supervisor_params": input_parser.default_supervisor_params() | supervisor_args,
+        "sets": [{
+            "participants": [],
+            "name": "interop-set-0",
+            "supervisor_params": input_parser.default_supervisor_params() | supervisor_args
+        }]
+    })
+
+def test_interop_set_params(plan):
+    supervisor_args = { "image": "supervisor.jpeg" }
+    parsed_params = input_parser.parse_network_params(plan, {
+        "interop": {
+            "supervisor_params": supervisor_args,
+            "sets": [{}]
+        },
+    })
+
+    expect.eq(parsed_params["interop"], input_parser.default_interop_params() | {
+        "supervisor_params": input_parser.default_supervisor_params() | supervisor_args,
+        "sets": [{
+            "participants": [],
+            "name": "interop-set-0",
+            "supervisor_params": input_parser.default_supervisor_params() | supervisor_args
+        }]
+    })
+
+def test_interop_set_none_params(plan):
+    parsed_params = input_parser.parse_network_params(plan, {
+        "interop": {
+            "sets": [None]
+        },
+    })
+
+    expect.eq(parsed_params["interop"], input_parser.default_interop_params() | {
+        "sets": []
+    })

--- a/test/package_io/input_parser_test.star
+++ b/test/package_io/input_parser_test.star
@@ -417,7 +417,7 @@ def test_interop_explicitly_disabled(plan):
     )
 
 
-def test_interop__set_explicitly_disabled(plan):
+def test_interop_set_explicitly_disabled(plan):
     parsed_params = input_parser.parse_network_params(
         plan,
         {

--- a/test/package_io/input_parser_test.star
+++ b/test/package_io/input_parser_test.star
@@ -91,197 +91,359 @@ def test_external_l1_network_params_input_parser_set_fields(plan):
 
     expect.eq(parsed_params, struct(**params))
 
+
 def test_interop_default_args(plan):
     parsed_params = input_parser.parse_network_params(plan, {})
 
     expect.eq(parsed_params["interop"], input_parser.default_interop_params())
 
-def test_interop_supervisor_params(plan):
-    supervisor_args = { "image": "supervisor.jpeg", "dependency_set": None, "extra_params": None }
-    parsed_params = input_parser.parse_network_params(plan, {
-        "interop": {
-            "supervisor_params": supervisor_args,
-        },
-    })
 
-    expect.eq(parsed_params["interop"], input_parser.default_interop_params() | {
-        "supervisor_params": {
-            "image": "supervisor.jpeg",
-            "dependency_set": "",
-            "extra_params": [],
+def test_interop_supervisor_params(plan):
+    supervisor_args = {
+        "image": "supervisor.jpeg",
+        "dependency_set": None,
+        "extra_params": None,
+    }
+    parsed_params = input_parser.parse_network_params(
+        plan,
+        {
+            "interop": {
+                "supervisor_params": supervisor_args,
+            },
         },
-    })
+    )
+
+    expect.eq(
+        parsed_params["interop"],
+        input_parser.default_interop_params()
+        | {
+            "supervisor_params": {
+                "image": "supervisor.jpeg",
+                "dependency_set": "",
+                "extra_params": [],
+            },
+        },
+    )
+
 
 def test_interop_default_set_params(plan):
-    supervisor_args = { "image": "supervisor.jpeg" }
-    parsed_params = input_parser.parse_network_params(plan, {
-        "interop": {
-            "supervisor_params": supervisor_args,
-            "sets": [{}]
+    supervisor_args = {"image": "supervisor.jpeg"}
+    parsed_params = input_parser.parse_network_params(
+        plan,
+        {
+            "interop": {"supervisor_params": supervisor_args, "sets": [{}]},
         },
-    })
+    )
 
-    expect.eq(parsed_params["interop"], input_parser.default_interop_params() | {
-        "enabled": True,
-        "supervisor_params": input_parser.default_supervisor_params() | supervisor_args,
-        "sets": [{
-            "participants": ["2151908"],
-            "name": "interop-set-0",
-            "supervisor_params": input_parser.default_supervisor_params() | supervisor_args
-        }]
-    })
+    expect.eq(
+        parsed_params["interop"],
+        input_parser.default_interop_params()
+        | {
+            "enabled": True,
+            "supervisor_params": input_parser.default_supervisor_params()
+            | supervisor_args,
+            "sets": [
+                {
+                    "enabled": True,
+                    "participants": ["2151908"],
+                    "name": "interop-set-0",
+                    "supervisor_params": input_parser.default_supervisor_params()
+                    | supervisor_args,
+                }
+            ],
+        },
+    )
+
 
 def test_interop_set_params(plan):
-    supervisor_args = { "image": "supervisor.jpeg" }
-    parsed_params = input_parser.parse_network_params(plan, {
-        "interop": {
-            "supervisor_params": supervisor_args,
-            "sets": [{}]
+    supervisor_args = {"image": "supervisor.jpeg"}
+    parsed_params = input_parser.parse_network_params(
+        plan,
+        {
+            "interop": {"supervisor_params": supervisor_args, "sets": [{}]},
         },
-    })
+    )
 
-    expect.eq(parsed_params["interop"], input_parser.default_interop_params() | {
-        "enabled": True,
-        "supervisor_params": input_parser.default_supervisor_params() | supervisor_args,
-        "sets": [{
-            "participants": ["2151908"],
-            "name": "interop-set-0",
-            "supervisor_params": input_parser.default_supervisor_params() | supervisor_args
-        }]
-    })
+    expect.eq(
+        parsed_params["interop"],
+        input_parser.default_interop_params()
+        | {
+            "enabled": True,
+            "supervisor_params": input_parser.default_supervisor_params()
+            | supervisor_args,
+            "sets": [
+                {
+                    "enabled": True,
+                    "participants": ["2151908"],
+                    "name": "interop-set-0",
+                    "supervisor_params": input_parser.default_supervisor_params()
+                    | supervisor_args,
+                }
+            ],
+        },
+    )
+
 
 def test_interop_set_all_participants_by_default(plan):
-    parsed_params = input_parser.parse_network_params(plan, {
-        "chains": [{
-            "network_params": {
-                "network_id": "network-0",
-            },
-        }, {
-            "network_params": {
-                "network_id": "network-1",
-            },
-        }],
-        "interop": {
-            "sets": [{}]
+    parsed_params = input_parser.parse_network_params(
+        plan,
+        {
+            "chains": [
+                {
+                    "network_params": {
+                        "network_id": "network-0",
+                    },
+                },
+                {
+                    "network_params": {
+                        "network_id": "network-1",
+                    },
+                },
+            ],
+            "interop": {"sets": [{}]},
         },
-    })
+    )
 
-    expect.eq(parsed_params["interop"], input_parser.default_interop_params() | {
-        "enabled": True,
-        "sets": [{
-            "name": "interop-set-0",
-            "participants": ["network-0", "network-1"],
-            "supervisor_params": input_parser.default_supervisor_params()
-        }]
-    })
+    expect.eq(
+        parsed_params["interop"],
+        input_parser.default_interop_params()
+        | {
+            "enabled": True,
+            "sets": [
+                {
+                    "enabled": True,
+                    "name": "interop-set-0",
+                    "participants": ["network-0", "network-1"],
+                    "supervisor_params": input_parser.default_supervisor_params(),
+                }
+            ],
+        },
+    )
+
 
 def test_interop_set_all_participants_explicitly(plan):
-    parsed_params = input_parser.parse_network_params(plan, {
-        "chains": [{
-            "network_params": {
-                "network_id": "network-0",
-            },
-        }, {
-            "network_params": {
-                "network_id": "network-1",
-            },
-        }],
-        "interop": {
-            "sets": [{
-                "participants": "*"
-            }]
+    parsed_params = input_parser.parse_network_params(
+        plan,
+        {
+            "chains": [
+                {
+                    "network_params": {
+                        "network_id": "network-0",
+                    },
+                },
+                {
+                    "network_params": {
+                        "network_id": "network-1",
+                    },
+                },
+            ],
+            "interop": {"sets": [{"participants": "*"}]},
         },
-    })
+    )
 
-    expect.eq(parsed_params["interop"], input_parser.default_interop_params() | {
-        "enabled": True,
-        "sets": [{
-            "name": "interop-set-0",
-            "participants": ["network-0", "network-1"],
-            "supervisor_params": input_parser.default_supervisor_params()
-        }]
-    })
+    expect.eq(
+        parsed_params["interop"],
+        input_parser.default_interop_params()
+        | {
+            "enabled": True,
+            "sets": [
+                {
+                    "enabled": True,
+                    "name": "interop-set-0",
+                    "participants": ["network-0", "network-1"],
+                    "supervisor_params": input_parser.default_supervisor_params(),
+                }
+            ],
+        },
+    )
+
 
 # This test tests an invalid configuration that we want to support to model misconfiguration
-# 
+#
 # In this test case we have two interop sets that both contain the same network
 def test_interop_set_all_participants_multiple_times(plan):
-    parsed_params = input_parser.parse_network_params(plan, {
-        "chains": [{
-            "network_params": {
-                "network_id": "network-0",
-            },
-        }],
-        "interop": {
-            "sets": [{}, {}]
+    parsed_params = input_parser.parse_network_params(
+        plan,
+        {
+            "chains": [
+                {
+                    "network_params": {
+                        "network_id": "network-0",
+                    },
+                }
+            ],
+            "interop": {"sets": [{}, {}]},
         },
-    })
+    )
 
-    expect.eq(parsed_params["interop"], input_parser.default_interop_params() | {
-        "enabled": True,
-        "sets": [{
-            "name": "interop-set-0",
-            "participants": ["network-0"],
-            "supervisor_params": input_parser.default_supervisor_params(),
-        }, {
-            "name": "interop-set-1",
-            "participants": ["network-0"],
-            "supervisor_params": input_parser.default_supervisor_params(),
-        }]
-    })
+    expect.eq(
+        parsed_params["interop"],
+        input_parser.default_interop_params()
+        | {
+            "enabled": True,
+            "sets": [
+                {
+                    "enabled": True,
+                    "name": "interop-set-0",
+                    "participants": ["network-0"],
+                    "supervisor_params": input_parser.default_supervisor_params(),
+                },
+                {
+                    "enabled": True,
+                    "name": "interop-set-1",
+                    "participants": ["network-0"],
+                    "supervisor_params": input_parser.default_supervisor_params(),
+                },
+            ],
+        },
+    )
+
+
+def test_interop_set_duplicate_names(plan):
+    expect.fails(
+        lambda: input_parser.parse_network_params(
+            plan,
+            {
+                "chains": [
+                    {
+                        "network_params": {
+                            "network_id": "network-0",
+                        },
+                    }
+                ],
+                "interop": {
+                    "sets": [
+                        {
+                            "name": "interop-set-0",
+                            "participants": [],
+                        },
+                        {
+                            "name": "interop-set-0",
+                            "participants": [],
+                        },
+                    ]
+                },
+            },
+        ),
+        "fail: Duplicate interop set names: interop-set-0",
+    )
+
 
 def test_interop_set_duplicate_participants(plan):
-    expect.fails(lambda: input_parser.parse_network_params(plan, {
-        "chains": [{
-            "network_params": {
-                "network_id": "network-0",
+    expect.fails(
+        lambda: input_parser.parse_network_params(
+            plan,
+            {
+                "chains": [
+                    {
+                        "network_params": {
+                            "network_id": "network-0",
+                        },
+                    }
+                ],
+                "interop": {
+                    "sets": [
+                        {
+                            "participants": ["network-0", "network-0"],
+                        }
+                    ]
+                },
             },
-        }],
-        "interop": {
-            "sets": [{
-                "participants": ["network-0", "network-0"],
-            }]
-        },
-    }), "Duplicate network ids in list of interop participants: \\[\"network-0\"\\]")
+        ),
+        "fail: Duplicate network ids in list of interop participants: network-0",
+    )
+
 
 def test_interop_set_nonexistent_participants(plan):
-    expect.fails(lambda: input_parser.parse_network_params(plan, {
-        "chains": [{
-            "network_params": {
-                "network_id": "network-0",
+    expect.fails(
+        lambda: input_parser.parse_network_params(
+            plan,
+            {
+                "chains": [
+                    {
+                        "network_params": {
+                            "network_id": "network-0",
+                        },
+                    }
+                ],
+                "interop": {
+                    "sets": [
+                        {
+                            "participants": ["network-1"],
+                        }
+                    ]
+                },
             },
-        }],
-        "interop": {
-            "sets": [{
-                "participants": ["network-1"],
-            }]
-        },
-    }), "Unknown network id in list of interop participants: network-1")
+        ),
+        "Unknown network id in list of interop participants: network-1",
+    )
+
 
 def test_interop_set_none_params(plan):
-    parsed_params = input_parser.parse_network_params(plan, {
-        "interop": {
-            "sets": [None]
+    parsed_params = input_parser.parse_network_params(
+        plan,
+        {
+            "interop": {"sets": [None]},
         },
-    })
+    )
 
-    expect.eq(parsed_params["interop"], input_parser.default_interop_params() | {
-        "sets": []
-    })
+    expect.eq(
+        parsed_params["interop"], input_parser.default_interop_params() | {"sets": []}
+    )
+
 
 def test_interop_explicitly_disabled(plan):
-    parsed_params = input_parser.parse_network_params(plan, {
-        "interop": {
-            "enabled": False,
-            "sets": [{}]
+    parsed_params = input_parser.parse_network_params(
+        plan,
+        {
+            "interop": {"enabled": False, "sets": [{}]},
         },
-    })
+    )
 
-    expect.eq(parsed_params["interop"], input_parser.default_interop_params() | {
-        "enabled": False,
-        "sets": [{
-            "name": "interop-set-0",
-            "participants": ["2151908"],
-            "supervisor_params": input_parser.default_supervisor_params()
-        }]
-    })
+    expect.eq(
+        parsed_params["interop"],
+        input_parser.default_interop_params()
+        | {
+            "enabled": False,
+            "sets": [
+                {
+                    "enabled": True,
+                    "name": "interop-set-0",
+                    "participants": ["2151908"],
+                    "supervisor_params": input_parser.default_supervisor_params(),
+                }
+            ],
+        },
+    )
+
+
+def test_interop__set_explicitly_disabled(plan):
+    parsed_params = input_parser.parse_network_params(
+        plan,
+        {
+            "interop": {
+                "enabled": True,
+                "sets": [
+                    {
+                        "enabled": False,
+                    }
+                ],
+            },
+        },
+    )
+
+    expect.eq(
+        parsed_params["interop"],
+        input_parser.default_interop_params()
+        | {
+            "enabled": True,
+            "sets": [
+                {
+                    "enabled": False,
+                    "name": "interop-set-0",
+                    "participants": ["2151908"],
+                    "supervisor_params": input_parser.default_supervisor_params(),
+                }
+            ],
+        },
+    )

--- a/test/util_test.star
+++ b/test/util_test.star
@@ -58,3 +58,13 @@ def test_label_from_image_long_image_name_long_suffix(plan):
     image_label = util.label_from_image(image_name)
     expect.eq(len(image_label), 63)
     expect.eq(image_suffix[-63:], image_label)
+
+def test_filter_none(plan):
+    expect.eq(util.filter_none({}), {})
+    expect.eq(util.filter_none({ "key": "value" }), { "key": "value" })
+    expect.eq(util.filter_none({ "key": None }), {})
+    expect.eq(util.filter_none({ "key": False }), { "key": False })
+    expect.eq(util.filter_none({ "key": 0 }), { "key": 0 })
+    expect.eq(util.filter_none({ "key": "" }), { "key": "" })
+    expect.eq(util.filter_none({ "key": [] }), { "key": [] })
+    expect.eq(util.filter_none({ "key": {} }), { "key": {} })

--- a/test/util_test.star
+++ b/test/util_test.star
@@ -68,3 +68,13 @@ def test_filter_none(plan):
     expect.eq(util.filter_none({ "key": "" }), { "key": "" })
     expect.eq(util.filter_none({ "key": [] }), { "key": [] })
     expect.eq(util.filter_none({ "key": {} }), { "key": {} })
+
+def test_get_duplicates(plan):
+    expect.eq(util.get_duplicates([]), [])
+    expect.eq(util.get_duplicates([1]), [])
+    expect.eq(util.get_duplicates([1, 1]), [1])
+    expect.eq(util.get_duplicates([1, 1, 1, 2, 2, 2, 3]), [1, 2])
+    expect.eq(util.get_duplicates([1, 2, "1"]), [])
+    expect.eq(util.get_duplicates([{}, {}]), [{}])
+    expect.eq(util.get_duplicates([{}, {"key": "value"}]), [])
+    expect.eq(util.get_duplicates([[1], [1]]), [[1]])

--- a/test/util_test.star
+++ b/test/util_test.star
@@ -59,15 +59,17 @@ def test_label_from_image_long_image_name_long_suffix(plan):
     expect.eq(len(image_label), 63)
     expect.eq(image_suffix[-63:], image_label)
 
+
 def test_filter_none(plan):
     expect.eq(util.filter_none({}), {})
-    expect.eq(util.filter_none({ "key": "value" }), { "key": "value" })
-    expect.eq(util.filter_none({ "key": None }), {})
-    expect.eq(util.filter_none({ "key": False }), { "key": False })
-    expect.eq(util.filter_none({ "key": 0 }), { "key": 0 })
-    expect.eq(util.filter_none({ "key": "" }), { "key": "" })
-    expect.eq(util.filter_none({ "key": [] }), { "key": [] })
-    expect.eq(util.filter_none({ "key": {} }), { "key": {} })
+    expect.eq(util.filter_none({"key": "value"}), {"key": "value"})
+    expect.eq(util.filter_none({"key": None}), {})
+    expect.eq(util.filter_none({"key": False}), {"key": False})
+    expect.eq(util.filter_none({"key": 0}), {"key": 0})
+    expect.eq(util.filter_none({"key": ""}), {"key": ""})
+    expect.eq(util.filter_none({"key": []}), {"key": []})
+    expect.eq(util.filter_none({"key": {}}), {"key": {}})
+
 
 def test_get_duplicates(plan):
     expect.eq(util.get_duplicates([]), [])


### PR DESCRIPTION
**Description**

Adds a concept of interop sets so that `op-supervisor` can be set up with more nuance.

Interop sets get their configuration section under `interop.sets`. A single interop set binds several L2 chains (referenced by their network IDs) into an interoperable system.

- The `participants` field refers to network IDs of the L2 chains. Special value `*` can be used to quickly assign all L2s into a single interop set. To simulate misconfiguration, a single L2 can be assigned to multiple interop sets
- `supervisor_params` can override default supervisor parameters under `interop.supervisor_params`
- Interop is enabled if there is at least one interop set. It can be disabled explicitly either as a whole or per-interop-set using `interop.enabled` and `interop.sets[].enabled` boolean fields