### PR TITLE
fix: teku set older version

### DIFF
--- a/network_params.yaml
+++ b/network_params.yaml
@@ -57,6 +57,7 @@ ethereum_package:
   participants:
   - el_type: geth
     cl_type: teku
+    cl_image: consensys/teku:25.4.0
   network_params:
     preset: minimal
     genesis_delay: 5

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -714,6 +714,7 @@ def default_ethereum_package_network_params():
             {
                 "el_type": "geth",
                 "cl_type": "teku",
+                "cl_image": "consensys/teku:25.4.0",
             }
         ],
         "network_params": {


### PR DESCRIPTION
Setting teku away from latest, as their latest branch requires support for fulu. Fulu is not yet supported in the older version of ethereum package that optimism-package is using. So the workaround is to use an older version of teku, and then eventually once there will be a new release for ethereum package, then we can pin it to that, and use the client releases. 