### PR TITLE
chore: unpin ethereum-package

### DIFF
--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -2,5 +2,3 @@ name: github.com/ethpandaops/optimism-package
 description: |
   # Optimism Package
   This is a Kurtosis package for deploying an Optimism Rollup
-replace:
-  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@4.5.0

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -57,7 +57,6 @@ ethereum_package:
   participants:
   - el_type: geth
     cl_type: teku
-    cl_image: consensys/teku:25.4.0
   network_params:
     preset: minimal
     genesis_delay: 5

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -695,7 +695,6 @@ def default_ethereum_package_network_params():
             {
                 "el_type": "geth",
                 "cl_type": "teku",
-                "cl_image": "consensys/teku:25.4.0",
             }
         ],
         "network_params": {


### PR DESCRIPTION
The pinning was initially needed for optimism monorepo sanity, but we
have a way to pin there instead.

Also revert the teku version pinning that was needed because of it.

Pinning at this level causes unncessary friction, as it sets the
lowest possible synchronization point for downstream consumers.
