### PR TITLE
feat: add op-faucet component

### DIFF
--- a/src/faucet/op-faucet/config.tmpl
+++ b/src/faucet/op-faucet/config.tmpl
@@ -1,0 +1,8 @@
+faucets:
+  {{- range . }}
+  {{ .Name }}:
+    el_rpc: "{{ .RPC }}"
+    chain_id: {{ .ChainID }}
+    tx_cfg:
+      private_key: "{{ .PrivateKey }}"
+  {{ end }}

--- a/src/faucet/op-faucet/op_faucet_launcher.star
+++ b/src/faucet/op-faucet/op_faucet_launcher.star
@@ -1,0 +1,97 @@
+"""
+Support for the op-faucet service.
+
+TODO: op-faucet doesn't have a proper release yet. Don't use this for now
+unless you know what you're doing.
+"""
+
+
+def launch(
+    plan,
+    service_name,
+    image,
+    faucets,
+):
+    """Launch the op-faucet service.
+
+    Args:
+        plan: The plan to add the service to.
+        service_name (str): The name of the service.
+        image (str): The image to use for the op-faucet service.
+        faucets (list of faucet_data): The faucets to use for the op-faucet service.
+    """
+    faucet_config = plan.render_templates(
+        name="faucet_config",
+        description="rendering op-faucet config",
+        config={
+            "/config.yaml": struct(
+                template=read_file("./config.tmpl"),
+                data=faucets,
+            )
+        },
+    )
+
+    config = _get_config(
+        image,
+        faucet_config,
+    )
+    plan.add_service(service_name, config)
+
+
+def _get_config(
+    image,
+    faucet_config,
+):
+    """Get the ServiceConfig for the op-faucet service.
+
+    Args:
+        image (str): The image to use for the op-faucet service.
+        faucet_config (artifact): The config artifact for the op-faucet service.
+    """
+    mount_path = "/config"
+    cmd = [
+        "op-faucet",
+        "--rpc.port=9000",
+        "--config={0}/config.yaml".format(mount_path),
+    ]
+
+    return ServiceConfig(
+        image=image,
+        cmd=cmd,
+        ports={
+            "rpc": PortSpec(
+                number=9000,
+                transport_protocol="TCP",
+                application_protocol="http",
+            ),
+        },
+        files={
+            mount_path: faucet_config,
+        },
+    )
+
+
+def faucet_data(
+    chain_id,
+    el_rpc,
+    private_key,
+    name=None,
+):
+    """Constructor for a faucet data struct.
+
+    Args:
+        chain_id (str): The chain ID the faucet will be used on.
+        el_rpc (str): The EL RPC the faucet will use.
+        private_key (str): The private key of the underlying faucet wallet.
+        name (str): The name of the faucet.
+    """
+    if name == None:
+        name = chain_id
+
+    return struct(
+        # capitalization for Go template expansion
+        Name=name,
+        ChainID=chain_id,
+        RPC=el_rpc,
+        PrivateKey=private_key,
+    )

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -59,6 +59,12 @@ DEFAULT_TX_FUZZER_IMAGES = {
     "tx-fuzzer": "ethpandaops/tx-fuzz:master",
 }
 
+DEFAULT_FAUCET_IMAGES = {
+    # TODO: update to use a versioned image when available
+    # For now, we'll need users to pass the image explicitly
+    "op-faucet": "",
+}
+
 DEFAULT_ADDITIONAL_SERVICES = []
 
 
@@ -119,6 +125,10 @@ def input_parser(plan, input_args):
                 min_mem=results["observability"]["grafana_params"]["min_mem"],
                 max_mem=results["observability"]["grafana_params"]["max_mem"],
             ),
+        ),
+        faucet=struct(
+            enabled=results["faucet"]["enabled"],
+            image=results["faucet"]["image"],
         ),
         interop=struct(
             enabled=results["interop"]["enabled"],
@@ -308,6 +318,9 @@ def parse_network_params(plan, input_args):
     results["observability"] = default_observability_params()
     results["observability"].update(input_args.get("observability", {}))
 
+    results["faucet"] = default_faucet_params()
+    results["faucet"].update(input_args.get("faucet", {}))
+
     results["observability"]["prometheus_params"] = default_prometheus_params()
     results["observability"]["prometheus_params"].update(
         input_args.get("observability", {}).get("prometheus_params", {})
@@ -479,6 +492,13 @@ def default_observability_params():
     return {
         "enabled": True,
         "enable_k8s_features": False,
+    }
+
+
+def default_faucet_params():
+    return {
+        "enabled": False,
+        "image": DEFAULT_FAUCET_IMAGES["op-faucet"],
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -8,6 +8,7 @@ ROOT_PARAMS = [
     "global_node_selectors",
     "global_tolerations",
     "persistent",
+    "faucet",
 ]
 
 OBSERVABILITY_PARAMS = [
@@ -17,6 +18,11 @@ OBSERVABILITY_PARAMS = [
     "loki_params",
     "promtail_params",
     "grafana_params",
+]
+
+FAUCET_PARAMS = [
+    "enabled",
+    "image",
 ]
 
 PROMETHEUS_PARAMS = [
@@ -255,6 +261,14 @@ def sanity_check(plan, optimism_config):
                 "grafana_params",
                 GRAFANA_PARAMS,
             )
+
+    if "faucet" in optimism_config:
+        validate_params(
+            plan,
+            optimism_config["faucet"],
+            "faucet",
+            FAUCET_PARAMS,
+        )
 
     if "interop" in optimism_config:
         validate_params(

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -136,6 +136,7 @@ def launch_participant_network(
     )
 
     return struct(
+        name=network_params.name,
         network_id=network_params.network_id,
         participants=all_participants,
     )

--- a/test/op_faucet_launcher_test.star
+++ b/test/op_faucet_launcher_test.star
@@ -1,0 +1,80 @@
+"""
+Tests for the op-faucet launcher.
+"""
+
+op_faucet_launcher = import_module("/src/faucet/op-faucet/op_faucet_launcher.star")
+input_parser = import_module("/src/package_io/input_parser.star")
+constants = import_module("/src/package_io/constants.star")
+
+
+def test_launch_with_defaults(plan):
+    """Test launching the op-faucet service with default parameters."""
+    faucet_image = input_parser.DEFAULT_FAUCET_IMAGES["op-faucet"]
+    service_name = "op-faucet"
+
+    # Create test faucet data
+    faucets = [
+        op_faucet_launcher.faucet_data(
+            chain_id="1",
+            el_rpc="http://l1-rpc",
+            private_key=constants.dev_accounts[0]["private_key"],
+            name="l1",
+        ),
+        op_faucet_launcher.faucet_data(
+            chain_id="10",
+            el_rpc="http://l2-rpc",
+            private_key=constants.dev_accounts[1]["private_key"],
+            name="l2",
+        ),
+    ]
+
+    op_faucet_launcher.launch(
+        plan=plan,
+        service_name=service_name,
+        image=faucet_image,
+        faucets=faucets,
+    )
+
+    # Verify service configuration
+    faucet_service_config = kurtosistest.get_service_config(service_name=service_name)
+    expect.ne(faucet_service_config, None)
+    expect.eq(faucet_service_config.image, faucet_image)
+    expect.eq(faucet_service_config.env_vars, {})
+    expect.eq(faucet_service_config.entrypoint, [])
+    expect.eq(
+        faucet_service_config.cmd,
+        [
+            "op-faucet",
+            "--rpc.port=9000",
+            "--config=/config/config.yaml",
+        ],
+    )
+    expect.eq(faucet_service_config.ports["rpc"].number, 9000)
+    expect.eq(faucet_service_config.ports["rpc"].transport_protocol, "TCP")
+    expect.eq(faucet_service_config.ports["rpc"].application_protocol, "http")
+
+
+def test_launch_with_custom_image(plan):
+    """Test launching the op-faucet service with a custom image."""
+    custom_image = "custom-op-faucet:latest"
+    service_name = "op-faucet"
+
+    # Create test faucet data
+    faucets = [
+        op_faucet_launcher.faucet_data(
+            chain_id="1",
+            el_rpc="http://l1-rpc",
+            private_key=constants.dev_accounts[0]["private_key"],
+        ),
+    ]
+
+    op_faucet_launcher.launch(
+        plan=plan,
+        service_name=service_name,
+        image=custom_image,
+        faucets=faucets,
+    )
+
+    # Verify service configuration
+    faucet_service_config = kurtosistest.get_service_config(service_name=service_name)
+    expect.eq(faucet_service_config.image, custom_image)


### PR DESCRIPTION
This adds preliminary support for op-faucet.

see https://github.com/ethereum-optimism/optimism/tree/develop/op-faucet

An official image doesn't exist for it yet, so there will need to be a
followup once this is addressed.

This is a test-only construct.
When enabled, we have an unrestricted faucet tied to the (funded)
faucet wallets.

Each chain in the devnet (l1, and all l2s) are mapped to this faucet.