### PR TITLE
fix: Fix challenger <> supervisor interaction

### DIFF
--- a/main.star
+++ b/main.star
@@ -128,7 +128,7 @@ def run(plan, args={}):
         supervisors = [
             supervisor
             # Since starlark does not support the walrus operator, we need to use a nested list comprehension
-            # 
+            #
             # TODO We do this since launcher can return None, maybe it's worth removing all the disabled values from the list beforehand
             for supervisor in [
                 op_supervisor_launcher.launch(
@@ -165,7 +165,8 @@ def run(plan, args={}):
         l2_supervisors = [
             supervisor
             for supervisor in supervisors
-            if chain.network_params.network_id in [n.network_id for n in supervisor.networks]
+            if chain.network_params.network_id
+            in [n.network_id for n in supervisor.networks]
         ]
 
         # If there are multiple supervisors, we just let the user know

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -53,6 +53,10 @@ optimism_package:
   global_node_selectors: {}
   global_tolerations: []
   persistent: false
+  interop:
+    sets:
+      - name: "interop"
+        participants: "*"
 ethereum_package:
   participants:
   - el_type: geth

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -9,6 +9,7 @@ ethereum_package_constants = import_module(
 observability = import_module("../../observability/observability.star")
 prometheus = import_module("../../observability/prometheus/prometheus_launcher.star")
 
+constants = import_module("../../package_io/constants.star")
 interop_constants = import_module("../../interop/constants.star")
 util = import_module("../../util.star")
 
@@ -34,22 +35,22 @@ def launch(
     deployment_output,
     network_params,
     challenger_params,
-    interop_params,
+    supervisor,
     observability_helper,
 ):
     config = get_challenger_config(
-        plan,
-        l2_num,
-        service_name,
-        image,
-        el_context,
-        cl_context,
-        l1_config_env_vars,
-        deployment_output,
-        network_params,
-        challenger_params,
-        interop_params,
-        observability_helper,
+        plan=plan,
+        l2_num=l2_num,
+        service_name=service_name,
+        image=image,
+        el_context=el_context,
+        cl_context=cl_context,
+        l1_config_env_vars=l1_config_env_vars,
+        deployment_output=deployment_output,
+        network_params=network_params,
+        challenger_params=challenger_params,
+        supervisor=supervisor,
+        observability_helper=observability_helper,
     )
 
     service = plan.add_service(service_name, config)
@@ -72,7 +73,7 @@ def get_challenger_config(
     deployment_output,
     network_params,
     challenger_params,
-    interop_params,
+    supervisor,
     observability_helper,
 ):
     ports = dict(get_used_ports())
@@ -123,8 +124,14 @@ def get_challenger_config(
     if observability_helper.enabled:
         observability.configure_op_service_metrics(cmd, ports)
 
-    if interop_params.enabled:
-        cmd.append("--supervisor-rpc=" + interop_constants.SUPERVISOR_ENDPOINT)
+    if supervisor != None:
+        kurtosistest.debug(supervisor.service.ports[constants.RPC_PORT_ID].url)
+
+        cmd.append(
+            "--supervisor-rpc={0}".format(
+                supervisor.service.ports[constants.RPC_PORT_ID].url
+            )
+        )
         # TraceTypeSupper{Cannon|Permissioned} needs --cannon-depset-config to be set
         # Added at https://github.com/ethereum-optimism/optimism/pull/14666
         # Temporary fix: Add a dummy flag

--- a/src/challenger/op-challenger/op_challenger_launcher.star
+++ b/src/challenger/op-challenger/op_challenger_launcher.star
@@ -125,8 +125,6 @@ def get_challenger_config(
         observability.configure_op_service_metrics(cmd, ports)
 
     if supervisor != None:
-        kurtosistest.debug(supervisor.service.ports[constants.RPC_PORT_ID].url)
-
         cmd.append(
             "--supervisor-rpc={0}".format(
                 supervisor.service.ports[constants.RPC_PORT_ID].url

--- a/src/interop/constants.star
+++ b/src/interop/constants.star
@@ -6,6 +6,7 @@ INTEROP_WS_PORT_NUM = 9645
 SUPERVISOR_SERVICE_NAME = "op-supervisor"
 SUPERVISOR_RPC_PORT_NUM = 8545
 
+# FIXME This endpoint no longer exists and its usages should be dropped
 SUPERVISOR_ENDPOINT = util.make_http_url(
     SUPERVISOR_SERVICE_NAME, SUPERVISOR_RPC_PORT_NUM
 )

--- a/src/interop/op-supervisor/op_supervisor_launcher.star
+++ b/src/interop/op-supervisor/op_supervisor_launcher.star
@@ -110,7 +110,10 @@ def launch(
         service,
     )
 
-    return service
+    return struct(
+        service=service,
+        networks=interop_set_l2s,
+    )
 
 
 def get_supervisor_config(

--- a/test/interop/op-supervisor/op_supervisor_launcher_test.star
+++ b/test/interop/op-supervisor/op_supervisor_launcher_test.star
@@ -339,6 +339,74 @@ def test_op_supervisor_everything_in_one_set(plan):
         ),
     )
 
+def test_op_supervisor_with_challenger(plan):
+    main.run(
+        plan,
+        {
+            "optimism_package": {
+                "chains": [
+                    {
+                        "network_params": {
+                            "network_id": "1000",
+                        }
+                    },
+                    {
+                        "network_params": {
+                            "network_id": "2000",
+                        }
+                    },
+                    {
+                        "challenger_params": {
+                            "enabled": False,
+                        },
+                        "network_params": {
+                            "network_id": "3000",
+                        }
+                    },
+                    {
+                        "network_params": {
+                            "network_id": "4000",
+                        }
+                    },
+                ],
+                "interop": {
+                    "sets": [
+                        {
+                            "name": "the-interopest-of-sets",
+                            "participants": ["1000", "2000"],
+                        },
+                        {
+                            "name": "sibling-of-the-interopest-of-sets",
+                            "participants": ["2000", "3000", "4000"],
+                        },
+                    ],
+                },
+            },
+        },
+    )
+
+    services = plan.get_services()
+    challenger_service_configs_by_name = {
+        s.name: kurtosistest.get_service_config(s.name)
+        for s in services
+        if s.name.startswith("op-challenger-")
+    }
+
+    expect.true("op-challenger-1000" in challenger_service_configs_by_name)
+    expect.true("op-challenger-2000" in challenger_service_configs_by_name)
+    expect.true("op-challenger-3000" not in challenger_service_configs_by_name)
+    expect.true("op-challenger-4000" in challenger_service_configs_by_name)
+
+    challenger_service_config1000 = challenger_service_configs_by_name["op-challenger-1000"]
+    challenger_service_config2000 = challenger_service_configs_by_name["op-challenger-2000"]
+    challenger_service_config4000 = challenger_service_configs_by_name["op-challenger-4000"]
+
+    # The first challenger should point to the first supervisor since that's the only one for the 1000 network
+    expect.true("--supervisor-rpc={0}".format("http://op-supervisor-the-interopest-of-sets:8545") in challenger_service_config1000.cmd[0])
+    # The second challenger should point to the first supervisor since that's the first one of the two for the 2000 network
+    expect.true("--supervisor-rpc={0}".format("http://op-supervisor-the-interopest-of-sets:8545") in challenger_service_config2000.cmd[0])
+    # The third challenger should point to the second supervisor since that's the only one for the 4000 network
+    expect.true("--supervisor-rpc={0}".format("http://op-supervisor-sibling-of-the-interopest-of-sets:8545") in challenger_service_config4000.cmd[0])
 
 def test_create_dependency_set_filename(plan):
     expect.eq(

--- a/test/interop/op-supervisor/op_supervisor_launcher_test.star
+++ b/test/interop/op-supervisor/op_supervisor_launcher_test.star
@@ -339,6 +339,7 @@ def test_op_supervisor_everything_in_one_set(plan):
         ),
     )
 
+
 def test_op_supervisor_with_challenger(plan):
     main.run(
         plan,
@@ -361,7 +362,7 @@ def test_op_supervisor_with_challenger(plan):
                         },
                         "network_params": {
                             "network_id": "3000",
-                        }
+                        },
                     },
                     {
                         "network_params": {
@@ -397,16 +398,38 @@ def test_op_supervisor_with_challenger(plan):
     expect.true("op-challenger-3000" not in challenger_service_configs_by_name)
     expect.true("op-challenger-4000" in challenger_service_configs_by_name)
 
-    challenger_service_config1000 = challenger_service_configs_by_name["op-challenger-1000"]
-    challenger_service_config2000 = challenger_service_configs_by_name["op-challenger-2000"]
-    challenger_service_config4000 = challenger_service_configs_by_name["op-challenger-4000"]
+    challenger_service_config1000 = challenger_service_configs_by_name[
+        "op-challenger-1000"
+    ]
+    challenger_service_config2000 = challenger_service_configs_by_name[
+        "op-challenger-2000"
+    ]
+    challenger_service_config4000 = challenger_service_configs_by_name[
+        "op-challenger-4000"
+    ]
 
     # The first challenger should point to the first supervisor since that's the only one for the 1000 network
-    expect.true("--supervisor-rpc={0}".format("http://op-supervisor-the-interopest-of-sets:8545") in challenger_service_config1000.cmd[0])
+    expect.true(
+        "--supervisor-rpc={0}".format(
+            "http://op-supervisor-the-interopest-of-sets:8545"
+        )
+        in challenger_service_config1000.cmd[0]
+    )
     # The second challenger should point to the first supervisor since that's the first one of the two for the 2000 network
-    expect.true("--supervisor-rpc={0}".format("http://op-supervisor-the-interopest-of-sets:8545") in challenger_service_config2000.cmd[0])
+    expect.true(
+        "--supervisor-rpc={0}".format(
+            "http://op-supervisor-the-interopest-of-sets:8545"
+        )
+        in challenger_service_config2000.cmd[0]
+    )
     # The third challenger should point to the second supervisor since that's the only one for the 4000 network
-    expect.true("--supervisor-rpc={0}".format("http://op-supervisor-sibling-of-the-interopest-of-sets:8545") in challenger_service_config4000.cmd[0])
+    expect.true(
+        "--supervisor-rpc={0}".format(
+            "http://op-supervisor-sibling-of-the-interopest-of-sets:8545"
+        )
+        in challenger_service_config4000.cmd[0]
+    )
+
 
 def test_create_dependency_set_filename(plan):
     expect.eq(

--- a/test/op_challenger_launcher_test.star
+++ b/test/op_challenger_launcher_test.star
@@ -83,14 +83,18 @@ def test_launch_with_defaults(plan):
             ),
         ),
         l1_config_env_vars=l1_config_env_vars,
-        l2s=[struct(
-            network_id="1000",
-            participants=[struct(
-                el_context=el_context,
-                cl_context=cl_context,
-            )],
-        )],
-        jwt_file = "/path/to/jwt_file",
+        l2s=[
+            struct(
+                network_id="1000",
+                participants=[
+                    struct(
+                        el_context=el_context,
+                        cl_context=cl_context,
+                    )
+                ],
+            )
+        ],
+        jwt_file="/path/to/jwt_file",
         observability_helper=observability_helper,
     )
 


### PR DESCRIPTION
**Description**

This PR fixes the challenger <> supervisor communication broken by #220. The system has become more complex and constant `SUPERVISOR_ENDPOINT` is no longer sufficient.

This constant is still being used in several places - besides `op-geth` though its usages can be removed to (almost) break the circular dependency between `el` <> `supervisor`

Relates to https://github.com/ethereum-optimism/optimism/issues/15151