### PR TITLE
chore: Support multiple supervisors: utilities [1/N]

### DIFF
--- a/src/util/expansion.star
+++ b/src/util/expansion.star
@@ -1,0 +1,29 @@
+# Expands a field that can either be a list of values or a special "*" character into a list of values
+#
+# In case of "*", all_values value are returned.
+# In case of a list, thus function will fail if any of the values are not in all_values
+#
+# Examples:
+#
+# expand_artifact("*", [1, 2]) == [1, 2]
+# expand_artifact([1], [1, 2]) == [1]
+# expand_artifact([3], [1, 2]) fails, 3 is not in [1, 2]
+def expand_asterisc(
+    value,
+    all_values,
+    missing_value_message="value {0} not allowed. allowed values are: {1}",
+    wrong_type_message="value should be of type list. got {0} instead",
+):
+    # Asterics means all the values
+    if value == "*":
+        return all_values
+
+    # Now we need to make sure we got a list of values
+    if type(value) != "list":
+        fail(wrong_type_message.format(value))
+
+    # And we need to check that the values are a subset of all possible values
+    return [
+        e if e in all_values else fail(missing_value_message.format(e, all_values))
+        for e in value
+    ]

--- a/src/util/filter.star
+++ b/src/util/filter.star
@@ -1,0 +1,26 @@
+# Removes all None values from a dictionary (or a list) returns a new dictionary (or a list).
+def remove_none(p):
+    p_type = type(p)
+    if p_type == "list":
+        return [v for v in p if v != None]
+    elif p_type == "dict":
+        return {k: v for k, v in p.items() if v != None}
+    else:
+        fail(
+            "Unsupported type for remove_none: want list or dict, got {0}".format(
+                p_type
+            )
+        )
+
+
+# Removes all properties from a dictionary whose keys are not listed in the keys list
+def remove_keys(p, keys):
+    # Just a quick sanity check
+    if type(keys) != "list":
+        fail("Second argument to remove_keys must be a list, got {}".format(keys))
+
+    p_type = type(p)
+    if p_type == "dict":
+        return {k: v for k, v in p.items() if k not in keys}
+    else:
+        fail("Unsupported type for remove_keys: want dict, got {0}".format(p_type))

--- a/test/util/expansion_test.star
+++ b/test/util/expansion_test.star
@@ -1,0 +1,30 @@
+expansion = import_module("/src/util/expansion.star")
+
+
+def test_expansion_expand_asterisc(plan):
+    expect.eq(expansion.expand_asterisc("*", []), [])
+    expect.eq(expansion.expand_asterisc("*", [1, "hey"]), [1, "hey"])
+
+    expect.fails(
+        lambda: expansion.expand_asterisc([1, 2], [1, 10]),
+        "value 2 not allowed. allowed values are: \\[1, 10\\]",
+    )
+    expect.fails(
+        lambda: expansion.expand_asterisc({}, [1, 10]),
+        "value should be of type list. got \\{\\} instead",
+    )
+
+
+def test_expansion_expand_asterisc_custom_error_messages(plan):
+    expect.fails(
+        lambda: expansion.expand_asterisc(
+            [2], [1, 10], missing_value_message="{1} does not contain {0}"
+        ),
+        "\\[1, 10\\] does not contain 2",
+    )
+    expect.fails(
+        lambda: expansion.expand_asterisc(
+            False, [1, 10], wrong_type_message="value {} is no good"
+        ),
+        "value False is no good",
+    )

--- a/test/util/filter_test.star
+++ b/test/util/filter_test.star
@@ -1,0 +1,74 @@
+filter = import_module("/src/util/filter.star")
+
+
+def test_filter_remove_none(plan):
+    # Dictionaries
+    expect.eq(filter.remove_none({}), {})
+    expect.eq(filter.remove_none({"key": "value"}), {"key": "value"})
+    expect.eq(filter.remove_none({"key": None}), {})
+    expect.eq(filter.remove_none({"key": False}), {"key": False})
+    expect.eq(filter.remove_none({"key": 0}), {"key": 0})
+    expect.eq(filter.remove_none({"key": ""}), {"key": ""})
+    expect.eq(filter.remove_none({"key": []}), {"key": []})
+    expect.eq(filter.remove_none({"key": {}}), {"key": {}})
+
+    # Lists
+    expect.eq(filter.remove_none([]), [])
+    expect.eq(filter.remove_none(["value"]), ["value"])
+    expect.eq(filter.remove_none([None, None]), [])
+    expect.eq(filter.remove_none([False]), [False])
+    expect.eq(filter.remove_none([0]), [0])
+    expect.eq(filter.remove_none([""]), [""])
+    expect.eq(filter.remove_none([[]]), [[]])
+    expect.eq(filter.remove_none([{}]), [{}])
+
+    # Other values
+    expect.fails(
+        lambda: filter.remove_none(1),
+        "Unsupported type for remove_none: want list or dict, got int",
+    )
+    expect.fails(
+        lambda: filter.remove_none(""),
+        "Unsupported type for remove_none: want list or dict, got string",
+    )
+    expect.fails(
+        lambda: filter.remove_none(False),
+        "Unsupported type for remove_none: want list or dict, got bool",
+    )
+    expect.fails(
+        lambda: filter.remove_none(struct()),
+        "Unsupported type for remove_none: want list or dict, got struct",
+    )
+    expect.fails(
+        lambda: filter.remove_none(None),
+        "Unsupported type for remove_none: want list or dict, got NoneType",
+    )
+
+
+def test_filter_remove_keys(plan):
+    expect.eq(filter.remove_keys({}, ["k"]), {})
+    expect.eq(filter.remove_keys({"k": 1, "l": 2}, ["k"]), {"l": 2})
+    expect.eq(filter.remove_keys({"k": 1, "l": 2}, ["k", "l", "m"]), {})
+
+    expect.fails(
+        lambda: filter.remove_keys({}, {}),
+        "Second argument to remove_keys must be a list, got \\{\\}",
+    )
+
+    expect.fails(
+        lambda: filter.remove_keys({}, struct()),
+        "Second argument to remove_keys must be a list, got struct\\(\\)",
+    )
+
+    expect.fails(
+        lambda: filter.remove_keys(None, []),
+        "Unsupported type for remove_keys: want dict, got NoneType",
+    )
+    expect.fails(
+        lambda: filter.remove_keys(6, []),
+        "Unsupported type for remove_keys: want dict, got int",
+    )
+    expect.fails(
+        lambda: filter.remove_keys([], []),
+        "Unsupported type for remove_keys: want dict, got list",
+    )


### PR DESCRIPTION
**Description**

The multiple supervisor support will require a rework of a significant part of the challenger, L2 and supervisor code. To make the new code DRYer, we are creating utilities for working with dicts and lists:

- `filter.star`
  - `remove_none` for removing `None` values from `dict`s. YAML supports `None` o it's important we strip these out before merging any dictionaries with default values
  - `remove_keys` for removing a list of keys from `dict`s. This will be a part of the replacement for the centralized `sanity_check` functions - we will use it to fail the process if we find any unknown properties on a configuration object.
- `expansion.star`
  - `expand_asterisc` for working with special `"*"` values that mean _all_. This will be used in places where a configuration object needs to point to multiple objects, e.g. lists of L2s for challenger

The utilities have been placed in their individual files as opposed to the existing `util.star` that has gotten a bit out of control and mixes functions of all sorts into one big file.

Related to https://github.com/ethereum-optimism/optimism/issues/15611