### PR TITLE
chore: Support multiple supervisors: Convention for launcher filenames - op-supervisor [2/N]

### DIFF
--- a/main.star
+++ b/main.star
@@ -1,9 +1,7 @@
 ethereum_package = import_module("github.com/ethpandaops/ethereum-package/main.star")
 contract_deployer = import_module("./src/contracts/contract_deployer.star")
 l2_launcher = import_module("./src/l2.star")
-op_supervisor_launcher = import_module(
-    "./src/interop/op-supervisor/op_supervisor_launcher.star"
-)
+op_supervisor_launcher = import_module("./src/interop/op-supervisor/launcher.star")
 op_challenger_launcher = import_module(
     "./src/challenger/op-challenger/op_challenger_launcher.star"
 )

--- a/src/interop/op-supervisor/launcher.star
+++ b/src/interop/op-supervisor/launcher.star
@@ -79,7 +79,7 @@ def launch(
         service,
     )
 
-    return "op_supervisor"
+    return struct(service=service)
 
 
 def get_supervisor_config(


### PR DESCRIPTION
**Description**

- Rename `op_supervisor_launcher/op_supervisor_launcher.star` to just `op_supervisor_launcher/launcher.star` - no need to make things double explicit
- Make the `launch` function return a `struct` with a standard `service` property. This convention will enable us to have consistent code when chaining launchers.

Related to https://github.com/ethereum-optimism/optimism/issues/15611