### PR TITLE
fix: Fix k8s pipeline configuration

### DIFF
--- a/.github/workflows/conventional-pr-title-checker.yml
+++ b/.github/workflows/conventional-pr-title-checker.yml
@@ -10,7 +10,7 @@ on:
 
 # cancel redundant builds
 concurrency:
-  group: "title-checker-${{ github.head_ref }}"
+  group: "${{ github.workflow_ref }}-${{ github.head_ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   run_with_args:
+    name: Run kurtosis with arguments
     strategy:
       matrix:
         file_name:
@@ -28,6 +29,7 @@ jobs:
 
   # Make sure that `kurtosis run .` without an --args-file works fine (the defaults in input_parser.star are correct)
   run_without_args:
+    name: Run kurtosis without arguments
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -49,6 +51,7 @@ jobs:
     secrets: inherit
   
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -61,6 +64,7 @@ jobs:
         run: kurtosis lint ${{ github.workspace }}
 
   test:
+    name: Unit tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 concurrency:
-  group: "tests-${{ github.head_ref }}"
+  group: "${{ github.workflow_ref }}-${{ github.head_ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Run Starlark
         run: kurtosis run ${{ github.workspace }} --verbosity detailed
 
+  run_k8s_test:
+    name: Run k8s tests
+    uses: ./.github/workflows/reusable-run-k8s.yml
+    secrets: inherit
+  
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,10 @@ permissions:
 
 name: release-please
 
+concurrency:
+  group: ${{ github.workflow_ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-run-k8s.yml
+++ b/.github/workflows/reusable-run-k8s.yml
@@ -1,14 +1,7 @@
 name: Run k8s test
 
 on:
-  pull_request:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 2 * * *'
-
-concurrency:
-  group: "scheduled-test"
-  cancel-in-progress: false
+  workflow_call:
 
 jobs:
   run_k8s_test:

--- a/.github/workflows/scheduled-k8s.yml
+++ b/.github/workflows/scheduled-k8s.yml
@@ -1,0 +1,15 @@
+name: Run k8s test
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+concurrency:
+  group: "scheduled-test"
+  cancel-in-progress: false
+
+jobs:
+  run_k8s_test:
+    name: Run k8s tests
+    uses: ./.github/workflows/reusable-run-k8s.yml
+    secrets: inherit

--- a/.github/workflows/scheduled-k8s.yml
+++ b/.github/workflows/scheduled-k8s.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 2 * * *'
 
 concurrency:
-  group: "scheduled-test"
+  group: ${{ github.workflow_ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
**Description**

The `run_k8s_test` workflow has been used for both PRs and for scheduled pipelines. The concurrency setting has been tailored for the scheduled usecase, which meant that for some PRs this workflow would have been skipped and they would not be mergeable.