### PR TITLE
chore: Support multiple supervisors: Remove unused params [3/N]

### DIFF
--- a/src/l2.star
+++ b/src/l2.star
@@ -27,7 +27,6 @@ def launch_l2(
     network_params = l2_args.network_params
     proxyd_params = l2_args.proxyd_params
     batcher_params = l2_args.batcher_params
-    challenger_params = l2_args.challenger_params
     proposer_params = l2_args.proposer_params
     mev_params = l2_args.mev_params
     tx_fuzzer_params = l2_args.tx_fuzzer_params
@@ -55,7 +54,6 @@ def launch_l2(
         network_params,
         proxyd_params,
         batcher_params,
-        challenger_params,
         proposer_params,
         mev_params,
         deployment_output,

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -2,9 +2,6 @@ el_cl_client_launcher = import_module("./el_cl_launcher.star")
 participant_module = import_module("./participant.star")
 input_parser = import_module("./package_io/input_parser.star")
 op_batcher_launcher = import_module("./batcher/op-batcher/op_batcher_launcher.star")
-op_challenger_launcher = import_module(
-    "./challenger/op-challenger/op_challenger_launcher.star"
-)
 op_proposer_launcher = import_module("./proposer/op-proposer/op_proposer_launcher.star")
 proxyd_launcher = import_module("./proxyd/proxyd_launcher.star")
 util = import_module("./util.star")
@@ -17,7 +14,6 @@ def launch_participant_network(
     network_params,
     proxyd_params,
     batcher_params,
-    challenger_params,
     proposer_params,
     mev_params,
     deployment_output,


### PR DESCRIPTION
**Description**

Removes unused `challenger_params` parameter from `l2` and `participant_network`. Removes an unused import as well

Related to https://github.com/ethereum-optimism/optimism/issues/15611