### PR TITLE
chore: Clean up pipelines

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,21 +27,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup Kurtosis
-        run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt update
-          sudo apt install kurtosis-cli
-          kurtosis analytics disable
+      - name: Install mise
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
 
       - name: Run Starlark
-        id: test_execution
-        run: |
-          if [ "${{ matrix.file_name }}" != "./.github/tests/mix-with-tools-mev.yaml" ]; then
-            kurtosis run ${{ github.workspace }} --verbosity detailed --args-file ${{ matrix.file_name }} || echo "TEST_FAILED=true" >> $GITHUB_ENV
-          else
-            echo "Skipping ./.github/tests/mix-with-tools-mev.yaml"
-          fi
+        run: kurtosis run ${{ github.workspace }} --verbosity detailed --args-file ${{ matrix.file_name }} || echo "TEST_FAILED=true" >> $GITHUB_ENV
         continue-on-error: true  # Don't fail the entire job
 
       - name: Check if Discord Webhook is Set
@@ -70,12 +60,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup Kurtosis
-        run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt update
-          sudo apt install kurtosis-cli
-          kurtosis analytics disable
+      - name: Install mise
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
 
       - name: Deploy L1
         run: kurtosis run --enclave test --args-file ./.github/tests/external-l1/ethereum.yaml github.com/ethpandaops/ethereum-package

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -35,12 +35,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup Kurtosis
-        run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt update
-          sudo apt install kurtosis-cli
-          kurtosis analytics disable
+      - name: Install mise
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
 
       - name: Run Starlark
         run: kurtosis run ${{ github.workspace }} --verbosity detailed
@@ -60,8 +56,8 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
 
-      - name: Kurtosis Lint
-        run: kurtosis lint ${{ github.workspace }}
+      - name: Run lint
+        run: just lint
 
   test:
     name: Unit tests
@@ -73,6 +69,6 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
 
-      - name: Run kurtosis-test tests
-        run: kurtosis-test .
+      - name: Run unit tests
+        run: just test
 

--- a/justfile
+++ b/justfile
@@ -13,10 +13,21 @@ open-service enclaveName serviceName:
         
 open-grafana enclaveName:
     just open-service {{enclaveName}} grafana
+
+fix-style:
+    kurtosis lint . --format
+
+lint-style:
+    kurtosis lint .
     
 # TODO(enable more checks)
-lint:
+lint-code:
     kurtosis-lint \
         --checked-calls \
         --local-imports \
         main.star src/ test/
+
+lint: lint-style lint-code
+
+test:
+    kurtosis-test .

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 
 # Core dependencies
+just = "1.40.0"
 "ubi:ethereum-optimism/kurtosis-test" = "0.0.1"
 "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.4.4"
 "yq" = "v4.44.3"


### PR DESCRIPTION
**Description**

Small CI pipeline cleanups to speed things up, add linting etc.

- Add `just` as a dependency to `mise.toml` and use `mise` across the board instead of manual installation
- Remove outdated conditionals in CI pipeline
- Add `lint-style` and `lint-code` `just` targets and make them both run when running `just lint`
- Add `fix-style` just target. It was less words to rewrite the target than to parameterize the `lint-style` one
- Add `test` `just` targets