### PR TITLE
chore: Support multiple supervisors: Create files from interpretation-time strings [4/N]

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,4 +7,4 @@ just = "1.40.0"
 "yq" = "v4.44.3"
 
 # lint
-"pipx:ethereum-optimism/kurtosis-lint" = "v0.0.6"
+"pipx:ethereum-optimism/kurtosis-lint" = "v0.0.7"

--- a/mise.toml
+++ b/mise.toml
@@ -7,4 +7,4 @@ just = "1.40.0"
 "yq" = "v4.44.3"
 
 # lint
-"pipx:ethereum-optimism/kurtosis-lint" = "v0.0.3"
+"pipx:ethereum-optimism/kurtosis-lint" = "v0.0.6"

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 
 # Core dependencies
 just = "1.40.0"
-"ubi:ethereum-optimism/kurtosis-test" = "0.0.1"
+"ubi:ethereum-optimism/kurtosis-test" = "0.0.3"
 "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.4.4"
 "yq" = "v4.44.3"
 

--- a/src/interop/op-supervisor/launcher.star
+++ b/src/interop/op-supervisor/launcher.star
@@ -1,3 +1,5 @@
+_file = import_module("/src/util/file.star")
+
 utils = import_module("../../util.star")
 
 ethereum_package_shared_utils = import_module(
@@ -58,8 +60,12 @@ def launch(
         dependency_set = create_dependency_set(chains)
         dependency_set_json = json.encode(dependency_set)
 
-    dependency_set_artifact = utils.write_to_file(
-        plan, dependency_set_json, DATA_DIR, DEPENDENCY_SET_FILE_NAME
+    dependency_set_artifact = _file.from_string(
+        plan=plan,
+        path="dependency_set.json",
+        contents=dependency_set_json,
+        artifact_name="op-supervisor dependency set",
+        description="Creating a dependency set JSON file for op-supervisor",
     )
 
     config = get_supervisor_config(

--- a/src/util.star
+++ b/src/util.star
@@ -20,16 +20,6 @@ def read_json_value(plan, json_file, json_path, mounts=None):
     return run.output
 
 
-def read_file(plan, file_path, mounts=None):
-    run = plan.run_sh(
-        description="Read file",
-        image=DEPLOYMENT_UTILS_IMAGE,
-        files=mounts,
-        run="cat {0}".format(file_path),
-    )
-    return run.output
-
-
 def write_to_file(plan, contents, directory, file_name):
     file_path = "{0}/{1}".format(directory, file_name)
 

--- a/src/util/file.star
+++ b/src/util/file.star
@@ -1,0 +1,28 @@
+_filter = import_module("./filter.star")
+
+
+# from_string creates a file artifact from a static string
+def from_string(plan, path, contents, artifact_name=None, description=None):
+    # We'll need to escape anything that go might interpret as template braces
+    #
+    # We are limited with the replace function - we would need to run replace twice,
+    # once for each bracket type BUT the result of the first replace would introduce
+    # braces that do not need to be escaped (and would result in an invalid template)
+    #
+    # Because of this, we'll first split the template into segments delimited by "{{", then run replace on each segment for "}}",
+    # then we rejoin the template with the "{{" substitution
+    escaped_contents = "{{ `{{` }}".join(
+        [segment.replace("}}", "{{ `}}` }}") for segment in contents.split("{{")]
+    )
+
+    kwargs = _filter.remove_none({"name": artifact_name, "description": description})
+
+    return plan.render_templates(
+        config={
+            path: struct(
+                template=escaped_contents,
+                data={},
+            ),
+        },
+        **kwargs,
+    )

--- a/test/util/file_test.star
+++ b/test/util/file_test.star
@@ -1,0 +1,70 @@
+file = import_module("/src/util/file.star")
+
+
+def test_file_from_string_simple_template(plan):
+    render_templates_mock = kurtosistest.mock(plan, "render_templates")
+
+    file_artifact = file.from_string(plan, "/path", "{{.Name}}")
+    expect.eq(
+        render_templates_mock.calls(),
+        [
+            struct(
+                args=[],
+                kwargs={
+                    "config": {
+                        "/path": struct(template="{{ `{{` }}.Name{{ `}}` }}", data={})
+                    }
+                },
+                return_value=file_artifact,
+            )
+        ],
+    )
+
+
+def test_file_from_string_weird_template(plan):
+    render_templates_mock = kurtosistest.mock(plan, "render_templates")
+
+    file_artifact = file.from_string(plan, "/path", "{{{{.Name}} }{{")
+    expect.eq(
+        render_templates_mock.calls(),
+        [
+            struct(
+                args=[],
+                kwargs={
+                    "config": {
+                        "/path": struct(
+                            template="{{ `{{` }}{{ `{{` }}.Name{{ `}}` }} }{{ `{{` }}",
+                            data={},
+                        )
+                    }
+                },
+                return_value=file_artifact,
+            )
+        ],
+    )
+
+
+def test_file_from_string_optional_args(plan):
+    render_templates_mock = kurtosistest.mock(plan, "render_templates")
+
+    file_artifact = file.from_string(
+        plan,
+        "/path",
+        "Hello!",
+        artifact_name="My artifact",
+        description="My description",
+    )
+    expect.eq(
+        render_templates_mock.calls(),
+        [
+            struct(
+                args=[],
+                kwargs={
+                    "config": {"/path": struct(template="Hello!", data={})},
+                    "description": "My description",
+                    "name": "My artifact",
+                },
+                return_value=file_artifact,
+            )
+        ],
+    )


### PR DESCRIPTION
**Description**

A precursor for multiple supervisor support and performance improvement for creating files from static (interpretation-time) strings.