### PR TITLE
fix(cannon): update cannon vm type after type 2 was removed

### DIFF
--- a/network_params.yaml
+++ b/network_params.yaml
@@ -45,9 +45,9 @@ optimism_package:
       tx_fuzzer_params:
         tx_fuzzer_extra_args: []
   op_contract_deployer_params:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.3.0-rc.5
-    l1_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz
-    l2_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.4.0-rc.1
+    l1_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-02024c5a26c16fc1a5c716fff1c46b5bf7f23890d431bb554ddbad60971211d4.tar.gz
+    l2_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-02024c5a26c16fc1a5c716fff1c46b5bf7f23890d431bb554ddbad60971211d4.tar.gz
   global_log_level: "info"
   global_node_selectors: {}
   global_tolerations: []

--- a/src/challenger/op-challenger/launcher.star
+++ b/src/challenger/op-challenger/launcher.star
@@ -119,7 +119,8 @@ def get_challenger_config(
         "--l2-eth-rpc={}".format(
             ",".join(
                 [
-                    ",".join([p.el_context.rpc_http_url for p in l2.participants])
+                    # TODO: we need to handle multiple participants better
+                    l2.participants[0].el_context.rpc_http_url
                     for l2 in l2s
                 ]
             )
@@ -128,7 +129,8 @@ def get_challenger_config(
         "--rollup-rpc={}".format(
             ",".join(
                 [
-                    ",".join([p.cl_context.beacon_http_url for p in l2.participants])
+                    # TODO: we need to handle multiple participants better
+                    l2.participants[0].cl_context.beacon_http_url
                     for l2 in l2s
                 ]
             )

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -224,7 +224,7 @@ def deploy_contracts(
                         "faultGameClockExtension": 10800,
                         "faultGameMaxClockDuration": 302400,
                         "dangerouslyAllowCustomDisputeParameters": True,
-                        "vmType": "CANNON2",
+                        "vmType": "CANNON",
                         "useCustomOracle": False,
                         "oracleMinProposalSize": 0,
                         "oracleChallengePeriodSeconds": 0,

--- a/src/observability/observability.star
+++ b/src/observability/observability.star
@@ -107,15 +107,18 @@ def register_service_metrics_job(
         "service": service_name,
         "namespace": service_name,
     }
+
+    job_name = service_name
     if network_name != None:
         labels["stack_optimism_io_network"] = network_name
+        job_name += "-" + network_name
 
     labels.update(additional_labels)
 
     add_metrics_job(
         helper,
         new_metrics_job(
-            job_name=service_name,
+            job_name=job_name,
             endpoint=endpoint,
             metrics_path=metrics_path,
             labels=labels,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -681,9 +681,9 @@ def default_op_contract_deployer_global_deploy_overrides():
 
 def default_op_contract_deployer_params():
     return {
-        "image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.3.0-rc.5",
-        "l1_artifacts_locator": "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz",
-        "l2_artifacts_locator": "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz",
+        "image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.4.0-rc.1",
+        "l1_artifacts_locator": "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-02024c5a26c16fc1a5c716fff1c46b5bf7f23890d431bb554ddbad60971211d4.tar.gz",
+        "l2_artifacts_locator": "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-02024c5a26c16fc1a5c716fff1c46b5bf7f23890d431bb554ddbad60971211d4.tar.gz",
         "global_deploy_overrides": default_op_contract_deployer_global_deploy_overrides(),
     }
 


### PR DESCRIPTION
This updates the cannon vmType used, and the op-deployer version that supports it

Also fix some issues:
- rpc endpoints don't like multiple participants, we'll need some proxy there eventually
- observability job names are not unique enough