### PR TITLE
fix(op-deployer): allow overriding cannon vm type

### DIFF
--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -7,6 +7,7 @@ FACTORY_DEPLOYER_CODE = "0xf8a58085174876e800830186a08080b853604580600e600039806
 FUND_SCRIPT_FILEPATH = "../../static_files/scripts"
 
 utils = import_module("../util.star")
+_filter = import_module("../util/filter.star")
 
 ethereum_package_genesis_constants = import_module(
     "github.com/ethpandaops/ethereum-package/src/prelaunch_data_generator/genesis_constants/genesis_constants.star"
@@ -175,18 +176,20 @@ def deploy_contracts(
     }
 
     absolute_prestate = ""
-    if optimism_args.op_contract_deployer_params.global_deploy_overrides[
+    if (
         "faultGameAbsolutePrestate"
-    ]:
-        absolute_prestate = (
-            optimism_args.op_contract_deployer_params.global_deploy_overrides[
-                "faultGameAbsolutePrestate"
-            ]
-        )
+        in optimism_args.op_contract_deployer_params.overrides
+    ):
+        absolute_prestate = optimism_args.op_contract_deployer_params.overrides[
+            "faultGameAbsolutePrestate"
+        ]
         intent["globalDeployOverrides"] = {
             "dangerouslyAllowCustomDisputeParameters": True,
             "faultGameAbsolutePrestate": absolute_prestate,
         }
+
+    overrides = _filter.remove_none(optimism_args.op_contract_deployer_params.overrides)
+    vm_type = overrides.get("vmType", "CANNON")
 
     for i, chain in enumerate(optimism_args.chains):
         chain_id = str(chain.network_params.network_id)
@@ -224,7 +227,7 @@ def deploy_contracts(
                         "faultGameClockExtension": 10800,
                         "faultGameMaxClockDuration": 302400,
                         "dangerouslyAllowCustomDisputeParameters": True,
-                        "vmType": "CANNON",
+                        "vmType": vm_type,
                         "useCustomOracle": False,
                         "oracleMinProposalSize": 0,
                         "oracleChallengePeriodSeconds": 0,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -273,9 +273,7 @@ def input_parser(plan, input_args):
             l2_artifacts_locator=results["op_contract_deployer_params"][
                 "l2_artifacts_locator"
             ],
-            global_deploy_overrides=results["op_contract_deployer_params"][
-                "global_deploy_overrides"
-            ],
+            overrides=results["op_contract_deployer_params"]["overrides"],
         ),
         global_log_level=results["global_log_level"],
         global_node_selectors=results["global_node_selectors"],
@@ -674,18 +672,12 @@ def default_participant():
     }
 
 
-def default_op_contract_deployer_global_deploy_overrides():
-    return {
-        "faultGameAbsolutePrestate": "",
-    }
-
-
 def default_op_contract_deployer_params():
     return {
         "image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.4.0-rc.1",
         "l1_artifacts_locator": "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-02024c5a26c16fc1a5c716fff1c46b5bf7f23890d431bb554ddbad60971211d4.tar.gz",
         "l2_artifacts_locator": "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-02024c5a26c16fc1a5c716fff1c46b5bf7f23890d431bb554ddbad60971211d4.tar.gz",
-        "global_deploy_overrides": default_op_contract_deployer_global_deploy_overrides(),
+        "overrides": {},
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -170,10 +170,13 @@ OP_CONTRACT_DEPLOYER_PARAMS = [
     "image",
     "l1_artifacts_locator",
     "l2_artifacts_locator",
-    "global_deploy_overrides",
+    "overrides",
 ]
 
-OP_CONTRACT_DEPLOYER_GLOBAL_DEPLOY_OVERRIDES = ["faultGameAbsolutePrestate"]
+OP_CONTRACT_DEPLOYER_OVERRIDES = [
+    "faultGameAbsolutePrestate",
+    "vmType",
+]
 
 ADDITIONAL_SERVICES_PARAMS = ["blockscout", "rollup-boost", "da_server", "tx_fuzzer"]
 
@@ -344,8 +347,8 @@ def sanity_check(plan, optimism_config):
         validate_params(
             plan,
             optimism_config["op_contract_deployer_params"],
-            "global_deploy_overrides",
-            OP_CONTRACT_DEPLOYER_GLOBAL_DEPLOY_OVERRIDES,
+            "overrides",
+            OP_CONTRACT_DEPLOYER_OVERRIDES,
         )
 
     plan.print("Sanity check for OP package passed")


### PR DESCRIPTION
This adds the ability to override the vmType as part of op-deployer operations.

main use-case will probably be to use CANNON-NEXT in some experiments.

We also rename global_deployer_overrides to simply overrides as it
doesn't properly match op-deployer's intent's globalDeployOverrides
concept anymore.

Also rework the overrides mechanism so we can actually specify a subset of the overrides.
