### PR TITLE
feat: add overridable registry

### DIFF
--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -28,6 +28,8 @@ op_reth_builder = import_module("./builder/op-reth/op_reth_launcher.star")
 op_rbuilder_builder = import_module("./builder/op-rbuilder/op_rbuilder_launcher.star")
 op_node_builder = import_module("./cl/op-node/op_node_builder_launcher.star")
 
+_registry = import_module("./package_io/registry.star")
+
 
 def launch(
     plan,
@@ -47,6 +49,7 @@ def launch(
     observability_helper,
     interop_params,
     da_server_context,
+    registry=_registry.Registry(),
 ):
     el_launchers = {
         "op-geth": {
@@ -346,17 +349,12 @@ def launch(
                         network_params.network,
                         metrics_info,
                     )
-            rollup_boost_image = (
-                mev_params.rollup_boost_image
-                if mev_params.rollup_boost_image != ""
-                else input_parser.DEFAULT_SIDECAR_IMAGES["rollup-boost"]
-            )
 
             sidecar_context = sidecar_launch_method(
                 plan,
                 sidecar_launcher,
                 sidecar_service_name,
-                rollup_boost_image,
+                mev_params.rollup_boost_image or registry.get(_registry.ROLLUP_BOOST),
                 all_el_contexts,
                 el_context,
                 el_builder_context,

--- a/src/l2.star
+++ b/src/l2.star
@@ -23,6 +23,7 @@ def launch_l2(
     persistent,
     observability_helper,
     interop_params,
+    registry=None,
 ):
     network_params = l2_args.network_params
     proxyd_params = l2_args.proxyd_params
@@ -68,6 +69,7 @@ def launch_l2(
         observability_helper,
         interop_params,
         da_server_context,
+        registry=registry,
     )
 
     all_el_contexts = []

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -6,44 +6,10 @@ challenger_input_parser = import_module("/src/challenger/input_parser.star")
 
 constants = import_module("../package_io/constants.star")
 sanity_check = import_module("./sanity_check.star")
+_registry = import_module("./registry.star")
 
-DEFAULT_EL_IMAGES = {
-    "op-geth": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:latest",
-    "op-reth": "ghcr.io/paradigmxyz/op-reth:latest",
-    "op-erigon": "testinprod/op-erigon:latest",
-    "op-nethermind": "nethermind/nethermind:latest",
-    "op-besu": "ghcr.io/optimism-java/op-besu:latest",
-    "op-rbuilder": "ghcr.io/flashbots/op-rbuilder:latest",
-}
-
-DEFAULT_CL_IMAGES = {
-    "op-node": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop",
-    "kona-node": "ghcr.io/op-rs/kona/kona-node:latest",
-    "hildr": "ghcr.io/optimism-java/hildr:latest",
-}
-
-DEFAULT_BATCHER_IMAGES = {
-    "op-batcher": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:develop",
-}
-
-DEFAULT_CHALLENGER_IMAGES = {
-    "op-challenger": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-challenger:develop",
-}
-
-DEFAULT_SUPERVISOR_IMAGES = {
-    "op-supervisor": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-supervisor:develop",
-}
-
-DEFAULT_PROPOSER_IMAGES = {
-    "op-proposer": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:develop",
-}
-
-DEFAULT_SIDECAR_IMAGES = {
-    "rollup-boost": "flashbots/rollup-boost:latest",
-}
 
 DEFAULT_DA_SERVER_PARAMS = {
-    "image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/da-server:latest",
     "cmd": [
         "da-server",  # uses keccak commitments by default
         # We use the file storage backend instead of s3 for simplicity.
@@ -55,16 +21,6 @@ DEFAULT_DA_SERVER_PARAMS = {
         "--port=3100",
         "--log.level=debug",
     ],
-}
-
-DEFAULT_TX_FUZZER_IMAGES = {
-    "tx-fuzzer": "ethpandaops/tx-fuzz:master",
-}
-
-DEFAULT_FAUCET_IMAGES = {
-    # TODO: update to use a versioned image when available
-    # For now, we'll need users to pass the image explicitly
-    "op-faucet": "",
 }
 
 DEFAULT_ADDITIONAL_SERVICES = []
@@ -82,9 +38,13 @@ def external_l1_network_params_input_parser(plan, input_args):
     )
 
 
-def input_parser(plan, input_args):
+def input_parser(
+    plan,
+    input_args,
+    registry=_registry.Registry(),
+):
     sanity_check.sanity_check(plan, input_args)
-    results = parse_network_params(plan, input_args)
+    results = parse_network_params(plan, registry, input_args)
 
     return struct(
         observability=struct(
@@ -231,7 +191,6 @@ def input_parser(plan, input_args):
                 ),
                 proxyd_params=struct(
                     image=result["proxyd_params"]["image"],
-                    tag=result["proxyd_params"]["tag"],
                     extra_params=result["proxyd_params"]["extra_params"],
                 ),
                 batcher_params=struct(
@@ -282,7 +241,7 @@ def input_parser(plan, input_args):
     )
 
 
-def parse_network_params(plan, input_args):
+def parse_network_params(plan, registry, input_args):
     results = {}
 
     # configure observability
@@ -290,25 +249,25 @@ def parse_network_params(plan, input_args):
     results["observability"] = default_observability_params()
     results["observability"].update(input_args.get("observability", {}))
 
-    results["faucet"] = default_faucet_params()
+    results["faucet"] = _default_faucet_params(registry)
     results["faucet"].update(input_args.get("faucet", {}))
 
-    results["observability"]["prometheus_params"] = default_prometheus_params()
+    results["observability"]["prometheus_params"] = default_prometheus_params(registry)
     results["observability"]["prometheus_params"].update(
         input_args.get("observability", {}).get("prometheus_params", {})
     )
 
-    results["observability"]["loki_params"] = default_loki_params()
+    results["observability"]["loki_params"] = default_loki_params(registry)
     results["observability"]["loki_params"].update(
         input_args.get("observability", {}).get("loki_params", {})
     )
 
-    results["observability"]["promtail_params"] = default_promtail_params()
+    results["observability"]["promtail_params"] = default_promtail_params(registry)
     results["observability"]["promtail_params"].update(
         input_args.get("observability", {}).get("promtail_params", {})
     )
 
-    results["observability"]["grafana_params"] = default_grafana_params()
+    results["observability"]["grafana_params"] = default_grafana_params(registry)
     results["observability"]["grafana_params"].update(
         input_args.get("observability", {}).get("grafana_params", {})
     )
@@ -318,7 +277,7 @@ def parse_network_params(plan, input_args):
     results["interop"] = default_interop_params()
     results["interop"].update(input_args.get("interop", {}))
 
-    results["interop"]["supervisor_params"] = default_supervisor_params()
+    results["interop"]["supervisor_params"] = default_supervisor_params(registry)
     results["interop"]["supervisor_params"].update(
         input_args.get("interop", {}).get("supervisor_params", {})
     )
@@ -334,22 +293,22 @@ def parse_network_params(plan, input_args):
 
     seen_names = {}
     seen_network_ids = {}
-    for chain in input_args.get("chains", default_chains()):
+    for chain in input_args.get("chains", default_chains(registry)):
         network_params = default_network_params()
         network_params.update(chain.get("network_params", {}))
 
-        proxyd_params = default_proxyd_params()
+        proxyd_params = _default_proxyd_params(registry)
         proxyd_params.update(chain.get("proxyd_params", {}))
 
-        batcher_params = default_batcher_params()
+        batcher_params = _default_batcher_params(registry)
         batcher_params.update(chain.get("batcher_params", {}))
 
-        proposer_params = default_proposer_params()
+        proposer_params = _default_proposer_params(registry)
         proposer_params.update(chain.get("proposer_params", {}))
 
         mev_params = default_mev_params()
         mev_params.update(chain.get("mev_params", {}))
-        da_server_params = default_da_server_params()
+        da_server_params = default_da_server_params(registry)
         da_server_params.update(chain.get("da_server_params", {}))
 
         network_name = network_params["name"]
@@ -370,7 +329,7 @@ def parse_network_params(plan, input_args):
             cl_type = participant["cl_type"]
             el_image = participant["el_image"]
             if el_image == "":
-                default_image = DEFAULT_EL_IMAGES.get(el_type, "")
+                default_image = registry.get(el_type, "")
                 if default_image == "":
                     fail(
                         "{0} received an empty image name and we don't have a default for it".format(
@@ -381,7 +340,7 @@ def parse_network_params(plan, input_args):
 
             cl_image = participant["cl_image"]
             if cl_image == "":
-                default_image = DEFAULT_CL_IMAGES.get(cl_type, "")
+                default_image = registry.get(cl_type, "")
                 if default_image == "":
                     fail(
                         "{0} received an empty image name and we don't have a default for it".format(
@@ -393,7 +352,7 @@ def parse_network_params(plan, input_args):
             el_builder_type = participant["el_builder_type"]
             el_builder_image = participant["el_builder_image"]
             if el_builder_image == "":
-                default_image = DEFAULT_EL_IMAGES.get(el_builder_type, "")
+                default_image = registry.get(el_builder_type, "")
                 if default_image == "":
                     fail(
                         "{0} received an empty image name and we don't have a default for it".format(
@@ -405,7 +364,7 @@ def parse_network_params(plan, input_args):
             cl_builder_type = participant["cl_builder_type"]
             cl_builder_image = participant["cl_builder_image"]
             if cl_builder_image == "":
-                default_image = DEFAULT_CL_IMAGES.get(cl_builder_type, "")
+                default_image = registry.get(cl_builder_type, "")
                 if default_image == "":
                     fail(
                         "{0} received an empty image name and we don't have a default for it".format(
@@ -420,7 +379,7 @@ def parse_network_params(plan, input_args):
                 )
                 participants.append(participant_copy)
 
-        tx_fuzzer_params = default_tx_fuzzer_params()
+        tx_fuzzer_params = default_tx_fuzzer_params(registry)
         tx_fuzzer_params.update(chain.get("tx_fuzzer_params", {}))
 
         result = {
@@ -448,7 +407,9 @@ def parse_network_params(plan, input_args):
 
     # configure op-deployer
 
-    results["op_contract_deployer_params"] = default_op_contract_deployer_params()
+    results["op_contract_deployer_params"] = default_op_contract_deployer_params(
+        registry
+    )
     results["op_contract_deployer_params"].update(
         input_args.get("op_contract_deployer_params", {})
     )
@@ -475,16 +436,16 @@ def default_observability_params():
     }
 
 
-def default_faucet_params():
+def _default_faucet_params(registry):
     return {
         "enabled": False,
-        "image": DEFAULT_FAUCET_IMAGES["op-faucet"],
+        "image": registry.get(_registry.OP_FAUCET),
     }
 
 
-def default_prometheus_params():
+def default_prometheus_params(registry):
     return {
-        "image": "prom/prometheus:v3.1.0",
+        "image": registry.get(_registry.PROMETHEUS),
         "storage_tsdb_retention_time": "1d",
         "storage_tsdb_retention_size": "512MB",
         "min_cpu": 10,
@@ -494,9 +455,9 @@ def default_prometheus_params():
     }
 
 
-def default_grafana_params():
+def default_grafana_params(registry):
     return {
-        "image": "grafana/grafana:11.5.0",
+        "image": registry.get(_registry.GRAFANA),
         "dashboard_sources": [
             "github.com/ethereum-optimism/grafana-dashboards-public/resources"
         ],
@@ -507,9 +468,9 @@ def default_grafana_params():
     }
 
 
-def default_loki_params():
+def default_loki_params(registry):
     return {
-        "image": "grafana/loki:3.3.2",
+        "image": registry.get(_registry.LOKI),
         "min_cpu": 10,
         "max_cpu": 1000,
         "min_mem": 128,
@@ -517,9 +478,9 @@ def default_loki_params():
     }
 
 
-def default_promtail_params():
+def default_promtail_params(registry):
     return {
-        "image": "grafana/promtail:3.3.2",
+        "image": registry.get(_registry.PROMTAIL),
         "min_cpu": 10,
         "max_cpu": 1000,
         "min_mem": 128,
@@ -544,9 +505,9 @@ def default_altda_deploy_config():
     }
 
 
-def default_supervisor_params():
+def default_supervisor_params(registry):
     return {
-        "image": DEFAULT_SUPERVISOR_IMAGES["op-supervisor"],
+        "image": registry.get(_registry.OP_SUPERVISOR),
         "dependency_set": "",
         "extra_params": [],
     }
@@ -560,18 +521,18 @@ def default_mev_params():
     }
 
 
-def default_chains():
+def default_chains(registry):
     return [
         {
             "participants": [default_participant()],
             "network_params": default_network_params(),
-            "proxyd_params": default_proxyd_params(),
-            "batcher_params": default_batcher_params(),
-            "proposer_params": default_proposer_params(),
+            "proxyd_params": _default_proxyd_params(registry),
+            "batcher_params": _default_batcher_params(registry),
+            "proposer_params": _default_proposer_params(registry),
             "mev_params": default_mev_params(),
-            "da_server_params": default_da_server_params(),
+            "da_server_params": default_da_server_params(registry),
             "additional_services": DEFAULT_ADDITIONAL_SERVICES,
-            "tx_fuzzer_params": default_tx_fuzzer_params(),
+            "tx_fuzzer_params": default_tx_fuzzer_params(registry),
         }
     ]
 
@@ -591,24 +552,23 @@ def default_network_params():
     }
 
 
-def default_batcher_params():
+def _default_batcher_params(registry):
     return {
-        "image": DEFAULT_BATCHER_IMAGES["op-batcher"],
+        "image": registry.get(_registry.OP_BATCHER),
         "extra_params": [],
     }
 
 
-def default_proxyd_params():
+def _default_proxyd_params(registry):
     return {
-        "image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/proxyd",
-        "tag": "v4.14.2",
+        "image": registry.get(_registry.PROXYD),
         "extra_params": [],
     }
 
 
-def default_proposer_params():
+def _default_proposer_params(registry):
     return {
-        "image": DEFAULT_PROPOSER_IMAGES["op-proposer"],
+        "image": registry.get(_registry.OP_PROPOSER),
         "extra_params": [],
         "game_type": 1,
         "proposal_interval": "10m",
@@ -672,9 +632,9 @@ def default_participant():
     }
 
 
-def default_op_contract_deployer_params():
+def default_op_contract_deployer_params(registry):
     return {
-        "image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.4.0-rc.2",
+        "image": registry.get(_registry.OP_DEPLOYER),
         "l1_artifacts_locator": "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-02024c5a26c16fc1a5c716fff1c46b5bf7f23890d431bb554ddbad60971211d4.tar.gz",
         "l2_artifacts_locator": "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-02024c5a26c16fc1a5c716fff1c46b5bf7f23890d431bb554ddbad60971211d4.tar.gz",
         "overrides": {},
@@ -707,16 +667,16 @@ def default_ethereum_package_network_params():
     }
 
 
-def default_da_server_params():
+def default_da_server_params(registry):
     return {
         "enabled": False,
-        "image": DEFAULT_DA_SERVER_PARAMS["image"],
+        "image": registry.get(_registry.DA_SERVER),
         "cmd": DEFAULT_DA_SERVER_PARAMS["cmd"],
     }
 
 
-def default_tx_fuzzer_params():
+def default_tx_fuzzer_params(registry):
     return {
-        "image": "ethpandaops/tx-fuzz:master",
+        "image": registry.get(_registry.TX_FUZZER),
         "tx_fuzzer_extra_args": [],
     }

--- a/src/package_io/registry.star
+++ b/src/package_io/registry.star
@@ -1,0 +1,107 @@
+"""Registry for docker images used throughout the package."""
+
+# Image IDs, just to avoid magic strings in the codebase
+OP_GETH = "op-geth"
+OP_RETH = "op-reth"
+OP_ERIGON = "op-erigon"
+OP_NETHERMIND = "op-nethermind"
+OP_BESU = "op-besu"
+OP_RBUILDER = "op-rbuilder"
+
+OP_NODE = "op-node"
+KONA_NODE = "kona-node"
+HILDR = "hildr"
+
+OP_BATCHER = "op-batcher"
+OP_CHALLENGER = "op-challenger"
+OP_SUPERVISOR = "op-supervisor"
+OP_PROPOSER = "op-proposer"
+OP_DEPLOYER = "op-deployer"
+OP_FAUCET = "op-faucet"
+
+PROXYD = "proxyd"
+
+ROLLUP_BOOST = "rollup-boost"
+DA_SERVER = "da-server"
+TX_FUZZER = "tx-fuzzer"
+
+DEPLOYMENT_UTILS = "deployment-utils"
+
+PROMETHEUS = "prometheus"
+GRAFANA = "grafana"
+LOKI = "loki"
+PROMTAIL = "promtail"
+
+
+_DEFAULT_IMAGES = {
+    # EL images
+    OP_GETH: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:latest",
+    OP_RETH: "ghcr.io/paradigmxyz/op-reth:latest",
+    OP_ERIGON: "testinprod/op-erigon:latest",
+    OP_NETHERMIND: "nethermind/nethermind:latest",
+    OP_BESU: "ghcr.io/optimism-java/op-besu:latest",
+    OP_RBUILDER: "ghcr.io/flashbots/op-rbuilder:latest",
+    # CL images
+    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop",
+    KONA_NODE: "ghcr.io/op-rs/kona/kona-node:latest",
+    HILDR: "ghcr.io/optimism-java/hildr:latest",
+    # Batching
+    OP_BATCHER: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:develop",
+    # Challenger
+    OP_CHALLENGER: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-challenger:develop",
+    # Supervisor
+    OP_SUPERVISOR: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-supervisor:develop",
+    # Proposer
+    OP_PROPOSER: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:develop",
+    # deployer
+    OP_DEPLOYER: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.4.0-rc.2",
+    # Faucet
+    # TODO: update to use a versioned image when available
+    # For now, we'll need users to pass the image explicitly
+    OP_FAUCET: "",
+    # Proxyd
+    PROXYD: "us-docker.pkg.dev/oplabs-tools-artifacts/images/proxyd:v4.14.2",
+    # Sidecar
+    ROLLUP_BOOST: "flashbots/rollup-boost:latest",
+    # DA Server
+    DA_SERVER: "us-docker.pkg.dev/oplabs-tools-artifacts/images/da-server:latest",
+    # Tx Fuzzer
+    TX_FUZZER: "ethpandaops/tx-fuzz:master",
+    # utils
+    DEPLOYMENT_UTILS: "mslipper/deployment-utils:latest",
+    # observability
+    PROMETHEUS: "prom/prometheus:v3.1.0",
+    GRAFANA: "grafana/grafana:11.5.0",
+    LOKI: "grafana/loki:3.3.2",
+    PROMTAIL: "grafana/promtail:3.3.2",
+}
+
+
+def Registry(images={}):
+    """Registry for docker images used throughout the package.
+
+    The user-provided images will override the default images.
+
+    Args:
+        images: dict of image IDs to Docker images.
+    Returns:
+        Registry object with a `get` method.
+    """
+    _check_images(images)
+    _images = _DEFAULT_IMAGES | images
+
+    return struct(
+        get=_images.get,
+        as_dict=lambda: dict(_images),
+    )
+
+
+def _check_images(images):
+    images_type = type(images)
+    if images_type != "dict":
+        fail("images must be a dict, got {}".format(images_type))
+
+    for id in images:
+        image_type = type(images[id])
+        if image_type != "string":
+            fail("image {} must be a string, got {}".format(id, image_type))

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -151,7 +151,7 @@ SUBCATEGORY_PARAMS = {
         "interop_time_offset",
         "fund_dev_accounts",
     ],
-    "proxyd_params": ["image", "tag", "extra_params"],
+    "proxyd_params": ["image", "extra_params"],
     "batcher_params": ["image", "extra_params"],
     "proposer_params": ["image", "extra_params", "game_type", "proposal_interval"],
     "mev_params": ["rollup_boost_image", "builder_host", "builder_port"],

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -5,6 +5,7 @@ op_batcher_launcher = import_module("./batcher/op-batcher/op_batcher_launcher.st
 op_proposer_launcher = import_module("./proposer/op-proposer/op_proposer_launcher.star")
 proxyd_launcher = import_module("./proxyd/proxyd_launcher.star")
 util = import_module("./util.star")
+_registry = import_module("./package_io/registry.star")
 
 
 def launch_participant_network(
@@ -28,8 +29,10 @@ def launch_participant_network(
     observability_helper,
     interop_params,
     da_server_context,
+    registry=_registry.Registry(),
 ):
     num_participants = len(participants)
+
     # First EL and sequencer CL
     all_el_contexts, all_cl_contexts = el_cl_client_launcher.launch(
         plan,
@@ -49,6 +52,7 @@ def launch_participant_network(
         observability_helper,
         interop_params,
         da_server_context,
+        registry=registry,
     )
 
     all_participants = []
@@ -82,15 +86,10 @@ def launch_participant_network(
         "batcher-{0}".format(network_params.network_id),
         ".privateKey",
     )
-    op_batcher_image = (
-        batcher_params.image
-        if batcher_params.image != ""
-        else input_parser.DEFAULT_BATCHER_IMAGES["op-batcher"]
-    )
     op_batcher_launcher.launch(
         plan,
         "op-batcher-{0}".format(l2_services_suffix),
-        op_batcher_image,
+        batcher_params.image or registry.get(_registry.OP_BATCHER),
         all_el_contexts[0],
         all_cl_contexts[0],
         l1_config_env_vars,
@@ -113,15 +112,10 @@ def launch_participant_network(
         "proposer-{0}".format(network_params.network_id),
         ".privateKey",
     )
-    op_proposer_image = (
-        proposer_params.image
-        if proposer_params.image != ""
-        else input_parser.DEFAULT_PROPOSER_IMAGES["op-proposer"]
-    )
     op_proposer_launcher.launch(
         plan,
         "op-proposer-{0}".format(l2_services_suffix),
-        op_proposer_image,
+        proposer_params.image or registry.get(_registry.OP_PROPOSER),
         all_cl_contexts[0],
         l1_config_env_vars,
         proposer_key,

--- a/src/proxyd/proxyd_launcher.star
+++ b/src/proxyd/proxyd_launcher.star
@@ -125,7 +125,7 @@ def get_proxyd_config(
     cmd += proxyd_params.extra_params
 
     return ServiceConfig(
-        image="{0}:{1}".format(proxyd_params.image, proxyd_params.tag),
+        image=proxyd_params.image,
         ports=ports,
         cmd=cmd,
         files={

--- a/test/op_faucet_launcher_test.star
+++ b/test/op_faucet_launcher_test.star
@@ -9,7 +9,7 @@ constants = import_module("/src/package_io/constants.star")
 
 def test_launch_with_defaults(plan):
     """Test launching the op-faucet service with default parameters."""
-    faucet_image = input_parser.DEFAULT_FAUCET_IMAGES["op-faucet"]
+    faucet_image = "op-faucet:latest"
     service_name = "op-faucet"
 
     # Create test faucet data

--- a/test/package_io/registry_test.star
+++ b/test/package_io/registry_test.star
@@ -1,0 +1,41 @@
+registry = import_module("/src/package_io/registry.star")
+
+DEFAULT_OP_GETH = "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:latest"
+DEFAULT_OP_NODE = "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop"
+
+
+def test_registry_default_images(_plan):
+    reg = registry.Registry()
+    # Should return the default image for OP_GETH
+    expect.eq(reg.get(registry.OP_GETH), DEFAULT_OP_GETH)
+    # Should return the default image for OP_NODE
+    expect.eq(reg.get(registry.OP_NODE), DEFAULT_OP_NODE)
+
+
+def test_registry_override_images(_plan):
+    custom_image = "custom/op-geth:mytag"
+    reg = registry.Registry({registry.OP_GETH: custom_image})
+    # Should return the overridden image
+    expect.eq(reg.get(registry.OP_GETH), custom_image)
+    # Should still return default for others
+    expect.eq(reg.get(registry.OP_NODE), DEFAULT_OP_NODE)
+
+
+def test_registry_as_dict_returns_copy(_plan):
+    reg = registry.Registry()
+    images1 = reg.as_dict()
+    images2 = reg.as_dict()
+    # Should be equal in value
+    expect.eq(images1, images2)
+    # But not the same object (modifying one doesn't affect the other)
+    images1[registry.OP_GETH] = "modified"
+    expect.ne(images1[registry.OP_GETH], images2[registry.OP_GETH])
+
+
+def test_registry_as_dict_includes_overrides(_plan):
+    custom_image = "custom/op-geth:mytag"
+    reg = registry.Registry({registry.OP_GETH: custom_image})
+    images = reg.as_dict()
+    expect.eq(images[registry.OP_GETH], custom_image)
+    # Should still include other defaults
+    expect.eq(images[registry.OP_NODE], DEFAULT_OP_NODE)

--- a/test/tx_fuzzer_launcher_test.star
+++ b/test/tx_fuzzer_launcher_test.star
@@ -7,8 +7,17 @@ ethereum_package_constants = import_module(
 constants = import_module("/src/package_io/constants.star")
 util = import_module("/src/util.star")
 
+_registry = import_module("/src/package_io/registry.star")
+
 
 def test_launch_with_defaults(plan):
+    tx_fuzzer_image = "tx-fuzz:latest"
+
+    reg = _registry.Registry(
+        {
+            _registry.TX_FUZZER: tx_fuzzer_image,
+        }
+    )
     parsed_input_args = input_parser.input_parser(
         plan,
         {
@@ -28,9 +37,8 @@ def test_launch_with_defaults(plan):
                 }
             ]
         },
+        registry=reg,
     )
-
-    fuzzer_image = input_parser.DEFAULT_TX_FUZZER_IMAGES["tx-fuzzer"]
 
     chains = parsed_input_args.chains
     chain = chains[0]
@@ -47,7 +55,7 @@ def test_launch_with_defaults(plan):
 
     fuzzer_service_config = kurtosistest.get_service_config(service_name=service_name)
     expect.ne(fuzzer_service_config, None)
-    expect.eq(fuzzer_service_config.image, fuzzer_image)
+    expect.eq(fuzzer_service_config.image, tx_fuzzer_image)
     expect.eq(fuzzer_service_config.env_vars, {})
     expect.eq(
         fuzzer_service_config.entrypoint,


### PR DESCRIPTION
This change adds a concept of registry for the various container images we handle.

It has several purposes:
- to centralize the definition of the container images we use
- to make it overridable by a downstream consumer

In particular, this improves the reprodicibility capabilities of the
package, as said downstream consumers can pin specific versions of the
packages being used, in a way that's orthogonal to the arguments
definition that's passed to the package.

See https://github.com/ethereum-optimism/optimism/pull/15697 for an example.
The *defaults* are pinned, without affecting the ability to override
images on a per-component instance basis.