### PR TITLE
chore: Support multiple supervisors: Superchains input parsers [7/N]

### DIFF
--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2,7 +2,8 @@ ethereum_package_input_parser = import_module(
     "github.com/ethpandaops/ethereum-package/src/package_io/input_parser.star"
 )
 
-challenger_input_parser = import_module("/src/challenger/input_parser.star")
+_challenger_input_parser = import_module("/src/challenger/input_parser.star")
+_superchain_input_parser = import_module("/src/superchain/input_parser.star")
 
 constants = import_module("../package_io/constants.star")
 sanity_check = import_module("./sanity_check.star")
@@ -224,6 +225,7 @@ def input_parser(
             for result in results["chains"]
         ],
         challengers=results["challengers"],
+        superchains=results["superchains"],
         op_contract_deployer_params=struct(
             image=results["op_contract_deployer_params"]["image"],
             l1_artifacts_locator=results["op_contract_deployer_params"][
@@ -401,7 +403,13 @@ def parse_network_params(plan, registry, input_args):
 
     # configure op-challenger
 
-    results["challengers"] = challenger_input_parser.parse(
+    # configure superchains
+
+    results["superchains"] = _superchain_input_parser.parse(
+        input_args.get("superchains"), chains
+    )
+
+    results["challengers"] = _challenger_input_parser.parse(
         input_args.get("challengers"), chains
     )
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -1,6 +1,7 @@
 ROOT_PARAMS = [
     "observability",
     "challengers",
+    "superchains",
     "interop",
     "altda_deploy_config",
     "chains",

--- a/src/superchain/input_parser.star
+++ b/src/superchain/input_parser.star
@@ -1,0 +1,53 @@
+_expansion = import_module("/src/util/expansion.star")
+_filter = import_module("/src/util/filter.star")
+
+_DEFAULT_ARGS = {
+    "enabled": True,
+    "participants": "*",
+}
+
+
+def parse(args, chains):
+    return _filter.remove_none(
+        [
+            _parse_instance(superchain_args or {}, superchain_name, chains)
+            for superchain_name, superchain_args in (args or {}).items()
+        ]
+    )
+
+
+def _parse_instance(superchain_args, superchain_name, chains):
+    # Any extra attributes will cause an error
+    _filter.assert_keys(
+        superchain_args,
+        _DEFAULT_ARGS.keys(),
+        "Invalid attributes in superchain configuration for "
+        + superchain_name
+        + ": {}",
+    )
+
+    # We filter the None values so that we can merge dicts easily
+    # and merge the config with the defaults
+    superchain_params = _DEFAULT_ARGS | _filter.remove_none(superchain_args)
+
+    # We return early if the set is disabled
+    if not superchain_params["enabled"]:
+        return None
+
+    # We expand the list of participants since we support a special "*" value to include all networks
+    network_ids = [c["network_params"]["network_id"] for c in chains]
+    superchain_params["participants"] = _expansion.expand_asterisc(
+        superchain_params["participants"],
+        network_ids,
+        missing_value_message="network ID {0} does not exist, please check configuration for superchain "
+        + superchain_name,
+    )
+
+    # No participants means that the superchain is disabled
+    if len(superchain_params["participants"]) == 0:
+        return None
+
+    # We add the name to the config
+    superchain_params["name"] = superchain_name
+
+    return struct(**superchain_params)

--- a/test/superchain/input_parser_test.star
+++ b/test/superchain/input_parser_test.star
@@ -46,7 +46,7 @@ def test_superchain_input_parser_disabled(plan):
 def test_superchain_input_parser_extra_attributes(plan):
     expect.fails(
         lambda: input_parser.parse(
-            {"superchain-0": {"name": "x", "extra": None}},
+            {"superchain-0": {"extra": None, "name": "x"}},
             _chains,
         ),
         "Invalid attributes in superchain configuration for superchain-0: extra,name",

--- a/test/superchain/input_parser_test.star
+++ b/test/superchain/input_parser_test.star
@@ -1,0 +1,82 @@
+input_parser = import_module("/src/interop/input_parser.star")
+
+_chains = [
+    {"network_params": {"network_id": 1000}},
+    {"network_params": {"network_id": 2000}},
+]
+
+
+def test_superchain_input_parser_empty(plan):
+    expect.eq(
+        input_parser.parse(
+            None,
+            _chains,
+        ),
+        [],
+    )
+    expect.eq(
+        input_parser.parse(
+            {},
+            _chains,
+        ),
+        [],
+    )
+
+
+def test_superchain_input_parser_no_participants(plan):
+    expect.eq(
+        input_parser.parse(
+            {"superchain-0": {"participants": []}},
+            _chains,
+        ),
+        [],
+    )
+
+
+def test_superchain_input_parser_disabled(plan):
+    expect.eq(
+        input_parser.parse(
+            {"superchain-0": {"enabled": False}},
+            _chains,
+        ),
+        [],
+    )
+
+
+def test_superchain_input_parser_extra_attributes(plan):
+    expect.fails(
+        lambda: input_parser.parse(
+            {"superchain-0": {"name": "x", "extra": None}},
+        ),
+        "Invalid attributes in superchain configuration for superchain-0: extra,name",
+    )
+
+
+def test_superchain_input_parser_default_args(plan):
+    expected_params = struct(
+        enabled=True,
+        name="superchain-0",
+        participants=[1000, 2000],
+    )
+
+    expect.eq(
+        input_parser.parse(
+            {"superchain-0": None},
+            _chains,
+        ),
+        [expected_params],
+    )
+    expect.eq(
+        input_parser.parse(
+            {"superchain-0": {}},
+            _chains,
+        ),
+        [expected_params],
+    )
+    expect.eq(
+        input_parser.parse(
+            {"superchain-0": {"enabled": None, "participants": None}},
+            _chains,
+        ),
+        [expected_params],
+    )

--- a/test/superchain/input_parser_test.star
+++ b/test/superchain/input_parser_test.star
@@ -1,4 +1,4 @@
-input_parser = import_module("/src/interop/input_parser.star")
+input_parser = import_module("/src/superchain/input_parser.star")
 
 _chains = [
     {"network_params": {"network_id": 1000}},

--- a/test/superchain/input_parser_test.star
+++ b/test/superchain/input_parser_test.star
@@ -47,6 +47,7 @@ def test_superchain_input_parser_extra_attributes(plan):
     expect.fails(
         lambda: input_parser.parse(
             {"superchain-0": {"name": "x", "extra": None}},
+            _chains,
         ),
         "Invalid attributes in superchain configuration for superchain-0: extra,name",
     )


### PR DESCRIPTION
**Description**

Adds new input parsers for superchain configuration, to be plugged in in the next steps. Builds on top of #255 

Related to https://github.com/ethereum-optimism/optimism/issues/15151