### PR TITLE
chore: Support multiple supervisors: Network utilities [6/N]

### DIFF
--- a/src/util/net.star
+++ b/src/util/net.star
@@ -1,0 +1,34 @@
+RPC_PORT_NAME = "rpc"
+
+
+# Creates a struct representing a service port configuration
+#
+# This is useful especially for testing purposes since the assertion library does not work great with PortSpec
+# (or any custom object for that matter)
+def port(number, transport_protocol="TCP", application_protocol="http"):
+    return struct(
+        number=number,
+        transport_protocol=transport_protocol,
+        application_protocol=application_protocol,
+    )
+
+
+# Converts port struct to a PortSpec object for service creation
+def port_to_port_spec(port):
+    return PortSpec(
+        number=port.number,
+        transport_protocol=port.transport_protocol,
+        application_protocol=port.application_protocol,
+    )
+
+
+# Converts a dictionary of port objects into a dictionary of PortSpec objects
+def ports_to_port_specs(ports_dict):
+    return {k: port_to_port_spec(v) for k, v in ports_dict.items()}
+
+
+# Creates a service URL (on the internal network) from service name and a port object
+def service_url(service_name, service_port):
+    return "{}://{}:{}".format(
+        service_port.application_protocol, service_name, service_port.number
+    )

--- a/test/util/net_test.star
+++ b/test/util/net_test.star
@@ -1,0 +1,63 @@
+_net = import_module("/src/util/net.star")
+
+
+def test_net_port(plan):
+    expect.eq(
+        _net.port(number=1),
+        struct(number=1, application_protocol="http", transport_protocol="TCP"),
+    )
+    expect.eq(
+        _net.port(number=1, application_protocol="ws"),
+        struct(number=1, application_protocol="ws", transport_protocol="TCP"),
+    )
+
+
+def test_net_port_to_port_spec(plan):
+    port = _net.port(number=1)
+    port_spec = _net.port_to_port_spec(port)
+
+    expect.eq(port.number, port_spec.number)
+    expect.eq(port.application_protocol, port_spec.application_protocol)
+    expect.eq(port.transport_protocol, port_spec.transport_protocol)
+
+
+def test_net_ports_to_port_specs(plan):
+    ports = {
+        "a": _net.port(number=1),
+        "b": _net.port(number=2),
+    }
+    port_specs = _net.ports_to_port_specs(ports)
+
+    expect.eq(ports.keys(), port_specs.keys())
+
+    expect.eq(ports["a"].number, port_specs["a"].number)
+    expect.eq(ports["a"].application_protocol, port_specs["a"].application_protocol)
+    expect.eq(ports["a"].transport_protocol, port_specs["a"].transport_protocol)
+
+    expect.eq(ports["b"].number, port_specs["b"].number)
+    expect.eq(ports["b"].application_protocol, port_specs["b"].application_protocol)
+    expect.eq(ports["b"].transport_protocol, port_specs["b"].transport_protocol)
+
+
+def test_net_service_url(plan):
+    http_port = _net.port(number=8888)
+    http_port_spec = _net.port_to_port_spec(http_port)
+    expect.eq(
+        _net.service_url(service_name="local", service_port=http_port),
+        "http://local:8888",
+    )
+    expect.eq(
+        _net.service_url(service_name="local", service_port=http_port_spec),
+        "http://local:8888",
+    )
+
+    wss_port = _net.port(number=9999, application_protocol="wss")
+    wss_port_spec = _net.port_to_port_spec(wss_port)
+    expect.eq(
+        _net.service_url(service_name="local", service_port=wss_port),
+        "wss://local:9999",
+    )
+    expect.eq(
+        _net.service_url(service_name="local", service_port=wss_port_spec),
+        "wss://local:9999",
+    )


### PR DESCRIPTION
**Description**

Adds a collection of network utilities to support the multiple supervisor logic to come:

- `port` function that creates a struct similar to `PortSpec` - with the advantage of it being compatible with deep equality from `assert` module (`assert` does not handle comparisons of custom objects). Config parsers create these objects before the services are launched which comes handy when there is a network-based circular dependency between services
- `port_to_port_spec` and `ports_to_port_specs` to convert `port` structs to `PortSpec` objects for when a service is created from config
- `service_url` to create a URL from a service name and a `port`/`PortSpec` object.

Related to https://github.com/ethereum-optimism/optimism/issues/15151