### PR TITLE
chore: Support multiple supervisors: Supervisor parsers [8/N]

### DIFF
--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -417,7 +417,7 @@ def parse_network_params(plan, registry, input_args):
 
     # configure op-sueprvisor
 
-    results["supervisors"] = _sueprvisor_input_parser.parse(
+    results["supervisors"] = _supervisor_input_parser.parse(
         args=input_args.get("supervisors"),
         superchains=results["superchains"],
         registry=registry,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -4,6 +4,7 @@ ethereum_package_input_parser = import_module(
 
 _challenger_input_parser = import_module("/src/challenger/input_parser.star")
 _superchain_input_parser = import_module("/src/superchain/input_parser.star")
+_supervisor_input_parser = import_module("/src/supervisor/input_parser.star")
 
 constants = import_module("../package_io/constants.star")
 sanity_check = import_module("./sanity_check.star")
@@ -226,6 +227,7 @@ def input_parser(
         ],
         challengers=results["challengers"],
         superchains=results["superchains"],
+        supervisors=results["supervisors"],
         op_contract_deployer_params=struct(
             image=results["op_contract_deployer_params"]["image"],
             l1_artifacts_locator=results["op_contract_deployer_params"][
@@ -401,16 +403,24 @@ def parse_network_params(plan, registry, input_args):
 
     results["chains"] = chains
 
-    # configure op-challenger
-
     # configure superchains
 
     results["superchains"] = _superchain_input_parser.parse(
-        input_args.get("superchains"), chains
+        args=input_args.get("superchains"), chains=chains
     )
 
+    # configure op-challenger
+
     results["challengers"] = _challenger_input_parser.parse(
-        input_args.get("challengers"), chains
+        args=input_args.get("challengers"), chains=chains
+    )
+
+    # configure op-sueprvisor
+
+    results["supervisors"] = _sueprvisor_input_parser.parse(
+        args=input_args.get("supervisors"),
+        superchains=results["superchains"],
+        registry=registry,
     )
 
     # configure op-deployer

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -415,7 +415,7 @@ def parse_network_params(plan, registry, input_args):
         args=input_args.get("challengers"), chains=chains
     )
 
-    # configure op-sueprvisor
+    # configure op-supervisor
 
     results["supervisors"] = _supervisor_input_parser.parse(
         args=input_args.get("supervisors"),

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -2,6 +2,7 @@ ROOT_PARAMS = [
     "observability",
     "challengers",
     "superchains",
+    "supervisors",
     "interop",
     "altda_deploy_config",
     "chains",

--- a/src/supervisor/input_parser.star
+++ b/src/supervisor/input_parser.star
@@ -1,0 +1,112 @@
+_filter = import_module("/src/util/filter.star")
+_net = import_module("/src/util/net.star")
+_registry = import_module("/src/package_io/registry.star")
+
+_DEFAULT_ARGS = {
+    "enabled": True,
+    "superchain": None,
+    "image": None,
+    "dependency_set": None,
+    "extra_params": [],
+}
+
+
+def parse(args, superchains, registry):
+    return _filter.remove_none(
+        [
+            _parse_instance(
+                supervisor_args or {}, supervisor_name, superchains, registry
+            )
+            for supervisor_name, supervisor_args in (args or {}).items()
+        ]
+    )
+
+
+def _parse_instance(supervisor_args, supervisor_name, superchains, registry):
+    # Any extra attributes will cause an error
+    extra_keys = _filter.assert_keys(
+        supervisor_args or {},
+        _DEFAULT_ARGS.keys(),
+        "Invalid attributes in supervisor configuration for "
+        + supervisor_name
+        + ": {}",
+    )
+
+    supervisor_params = _DEFAULT_ARGS | _filter.remove_none(supervisor_args or {})
+
+    if not supervisor_params["enabled"]:
+        return None
+
+    # Let's find the superchain that this supervisor is connected to
+    superchain_name = supervisor_params["superchain"]
+    if not superchain_name:
+        fail("Missing superchain name for supervisor {}".format(supervisor_name))
+
+    superchain = _filter.first(superchains, lambda s: s.name == superchain_name)
+    if not superchain:
+        fail(
+            "Missing superchain {} for supervisor {}".format(
+                superchain_name, supervisor_name
+            )
+        )
+
+    # We expand the superchain name to the full object for easier access
+    #
+    # The tradeoff that we are making is the duplication of information
+    # in the parsed config, but this is a tradeoff that we are willing to make
+    supervisor_params["superchain"] = superchain
+
+    # We add name & service name
+    supervisor_params["name"] = supervisor_name
+    supervisor_params["service_name"] = "op-supervisor-{}".format(supervisor_name)
+
+    # And default the image to the one in the registry
+    supervisor_params["image"] = supervisor_params["image"] or registry.get(
+        _registry.OP_SUPERVISOR
+    )
+
+    # We'll also define the ports that this supervisor will expose
+    #
+    # This is so that we can reference them before the service is created
+    supervisor_params["ports"] = {
+        _net.RPC_PORT_NAME: _net.port(
+            number=8545,
+        )
+    }
+
+    participant_network_ids = [str(p) for p in superchain.participants]
+    supervisor_params["dependency_set"] = (
+        supervisor_params["dependency_set"]
+        if supervisor_params["dependency_set"] != None
+        else _create_dependency_set(participant_network_ids)
+    )
+
+    dependency_set_network_ids = (
+        supervisor_params["dependency_set"].get("dependencies", {}).keys()
+    )
+    missing_network_ids = [
+        network_id
+        for network_id in dependency_set_network_ids
+        if network_id not in participant_network_ids
+    ]
+    if len(missing_network_ids) > 0:
+        fail(
+            "Missing networks {} defined in dependency set for supervisor {}".format(
+                ",".join(missing_network_ids), supervisor_name
+            )
+        )
+
+    return struct(**supervisor_params)
+
+
+def _create_dependency_set(network_ids):
+    return {
+        "dependencies": {
+            str(network_id): {
+                "chainIndex": str(network_id),
+                "activationTime": 0,
+                "historyMinTime": 0,
+            }
+            for network_id in network_ids
+        }
+    }

--- a/src/util/filter.star
+++ b/src/util/filter.star
@@ -32,3 +32,11 @@ def assert_keys(p, keys, message="Invalid attributes specified: {}"):
 
     if len(extra_keys) > 0:
         fail(message.format(",".join(extra_keys)))
+
+
+# Returns the first element in a list that matches the predicate, or the default value if no element matches.
+def first(p, predicate=lambda v: v, default=None):
+    for item in p:
+        if predicate(item):
+            return item
+    return default

--- a/test/supervisor/input_parser_test.star
+++ b/test/supervisor/input_parser_test.star
@@ -1,0 +1,162 @@
+input_parser = import_module("/src/supervisor/input_parser.star")
+
+_net = import_module("/src/util/net.star")
+_registry = import_module("/src/package_io/registry.star")
+
+_superchains = [
+    struct(participants=[1000, 2000], name="superchain-0"),
+    struct(participants=[3000], name="superchain-1"),
+    struct(participants=[1000, 4000], name="superchain-2"),
+]
+
+_default_supervisor = struct(
+    dependency_set={
+        "dependencies": {
+            "1000": {"chainIndex": "1000", "activationTime": 0, "historyMinTime": 0},
+            "2000": {"chainIndex": "2000", "activationTime": 0, "historyMinTime": 0},
+        }
+    },
+    extra_params=[],
+    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-supervisor:develop",
+    name="supervisor",
+    ports={
+        "rpc": _net.port(
+            number=8545,
+        )
+    },
+    service_name="op-supervisor-supervisor",
+)
+
+_default_registry = _registry.Registry()
+
+
+def test_supervisor_input_parser_empty(plan):
+    expect.eq(
+        input_parser.parse(None, _superchains, _default_registry),
+        [],
+    )
+    expect.eq(
+        input_parser.parse({}, _superchains, _default_registry),
+        [],
+    )
+
+
+def test_supervisor_input_parser_extra_attrbutes(plan):
+    expect.fails(
+        lambda: input_parser.parse(
+            {"supervisor-0": {"extra": None, "name": "x"}},
+            _superchains,
+            _default_registry,
+        ),
+        "Invalid attributes in supervisor configuration for supervisor-0: extra,name",
+    )
+
+
+def test_supervisor_input_parser_missing_superchain_name(plan):
+    expect.fails(
+        lambda: input_parser.parse(
+            {"supervisor-0": {}},
+            _superchains,
+            _default_registry,
+        ),
+        "Missing superchain name for supervisor supervisor-0",
+    )
+
+
+def test_supervisor_input_parser_missing_superchain(plan):
+    expect.fails(
+        lambda: input_parser.parse(
+            {"supervisor-0": {"superchain": "superchain-hallucinated"}},
+            _superchains,
+            _default_registry,
+        ),
+        "Missing superchain superchain-hallucinated for supervisor supervisor-0",
+    )
+
+
+def test_supervisor_input_parser_default_args(plan):
+    expect.eq(
+        input_parser.parse(
+            {
+                "supervisor-0": {
+                    "enabled": None,
+                    "image": None,
+                    "dependency_set": None,
+                    "extra_params": None,
+                    "superchain": "superchain-0",
+                }
+            },
+            _superchains,
+            _default_registry,
+        ),
+        [
+            struct(
+                dependency_set={
+                    "dependencies": {
+                        "1000": {
+                            "chainIndex": "1000",
+                            "activationTime": 0,
+                            "historyMinTime": 0,
+                        },
+                        "2000": {
+                            "chainIndex": "2000",
+                            "activationTime": 0,
+                            "historyMinTime": 0,
+                        },
+                    }
+                },
+                enabled=True,
+                extra_params=[],
+                image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-supervisor:develop",
+                name="supervisor-0",
+                ports={
+                    "rpc": _net.port(
+                        number=8545,
+                    )
+                },
+                service_name="op-supervisor-supervisor-0",
+                superchain=_superchains[0],
+            ),
+        ],
+    )
+
+
+def test_supervisor_input_parser_custom_(plan):
+    parsed = input_parser.parse(
+        {
+            "supervisor-0": {
+                "superchain": "superchain-0",
+                "dependency_set": {},
+                "extra_params": ["--hey"],
+            },
+        },
+        _superchains,
+        _default_registry,
+    )
+    expect.eq(parsed[0].extra_params, ["--hey"])
+    expect.eq(parsed[0].dependency_set, {})
+
+
+def test_supervisor_input_parser_custom_registry(plan):
+    registry = _registry.Registry({_registry.OP_SUPERVISOR: "op-supervisor:latest"})
+
+    parsed = input_parser.parse(
+        {
+            "supervisor-0": {"superchain": "superchain-0"},
+        },
+        _superchains,
+        registry,
+    )
+    expect.eq(parsed[0].image, "op-supervisor:latest")
+
+    parsed = input_parser.parse(
+        {
+            "supervisor-0": {
+                "superchain": "superchain-0",
+                "image": "op-supervisor:oldest",
+            },
+        },
+        _superchains,
+        registry,
+    )
+    expect.eq(parsed[0].image, "op-supervisor:oldest")

--- a/test/util/filter_test.star
+++ b/test/util/filter_test.star
@@ -95,3 +95,20 @@ def test_filter_assert_keys(plan):
         ),
         "Invalid attributes in my little object: key",
     )
+
+
+def test_filter_first(plan):
+    # With the default predicate
+    expect.eq(filter.first([]), None)
+    expect.eq(filter.first([None]), None)
+    expect.eq(filter.first([False]), None)
+    expect.eq(filter.first([[]]), None)
+
+    # With custom predicate
+    expect.eq(filter.first([1, 2, 3], lambda v: v == 2), 2)
+    expect.eq(filter.first([4, 5, 6], lambda v: v == 2), None)
+    expect.eq(filter.first([False], lambda v: v != None), False)
+    expect.eq(filter.first([[]], lambda v: v != None), [])
+
+    # With custom default
+    expect.eq(filter.first([False], default=4), 4)


### PR DESCRIPTION
**Description**

- Adds input parsers for new top-level key `supervisors`. The parsers are plugged in but not acted upon.
- Adds a `first` filtering utility that takes the first elements out of the list in a safe way

Builds on top of #254 

Related to https://github.com/ethereum-optimism/optimism/issues/15151