### PR TITLE
chore: Support multiple supervisors: Add interop RPC port to superchain params [11/N]

### DIFF
--- a/src/superchain/input_parser.star
+++ b/src/superchain/input_parser.star
@@ -1,5 +1,6 @@
 _expansion = import_module("/src/util/expansion.star")
 _filter = import_module("/src/util/filter.star")
+_net = import_module("/src/util/net.star")
 
 _DEFAULT_ARGS = {
     "enabled": True,
@@ -49,5 +50,16 @@ def _parse_instance(superchain_args, superchain_name, chains):
 
     # We add the name to the config
     superchain_params["name"] = superchain_name
+
+    # We add interop RPC port to the superchain config
+    #
+    # This is used for communication between supervisors and CL clients
+    # and since it's not a port exposed on on the supervisor but rather on the CL client,
+    # we put it here (at least temporarily)
+    #
+    # TODO Once the input parsers for CL clients are refactored, this will be moved there
+    superchain_params["ports"] = {
+        _net.INTEROP_RPC_PORT_NAME: _net.port(number=9645, application_protocol="ws"),
+    }
 
     return struct(**superchain_params)

--- a/src/util/net.star
+++ b/src/util/net.star
@@ -1,4 +1,5 @@
 RPC_PORT_NAME = "rpc"
+INTEROP_RPC_PORT_NAME = "rpc-interop"
 
 
 # Creates a struct representing a service port configuration

--- a/test/superchain/input_parser_test.star
+++ b/test/superchain/input_parser_test.star
@@ -1,5 +1,7 @@
 input_parser = import_module("/src/superchain/input_parser.star")
 
+_net = import_module("/src/util/net.star")
+
 _chains = [
     {"network_params": {"network_id": 1000}},
     {"network_params": {"network_id": 2000}},
@@ -58,6 +60,12 @@ def test_superchain_input_parser_default_args(plan):
         enabled=True,
         name="superchain-0",
         participants=[1000, 2000],
+        ports={
+            "rpc-interop": _net.port(
+                number=9645,
+                application_protocol="ws",
+            )
+        },
     )
 
     expect.eq(


### PR DESCRIPTION
**Description**

- Adds an interop RPC port to the superchain params. This port is exposed on CL clients so eventually it will move there

Related to https://github.com/ethereum-optimism/optimism/issues/15151