### PR TITLE
chore: Support multiple supervisors: Move dependency sets under superchains [12/N]

### DIFF
--- a/src/superchain/input_parser.star
+++ b/src/superchain/input_parser.star
@@ -62,4 +62,23 @@ def _parse_instance(superchain_args, superchain_name, chains):
         _net.INTEROP_RPC_PORT_NAME: _net.port(number=9645, application_protocol="ws"),
     }
 
+    # We'll create a dependency set for the superchain based on all the participants
+    superchain_params["dependency_set"] = struct(
+        name="superchain-depset-{}".format(superchain_name),
+        value=_create_dependency_set(superchain_params["participants"]),
+    )
+
     return struct(**superchain_params)
+
+
+def _create_dependency_set(network_ids):
+    return {
+        "dependencies": {
+            str(network_id): {
+                "chainIndex": str(network_id),
+                "activationTime": 0,
+                "historyMinTime": 0,
+            }
+            for network_id in network_ids
+        }
+    }

--- a/src/superchain/launcher.star
+++ b/src/superchain/launcher.star
@@ -1,0 +1,26 @@
+_file = import_module("/src/util/file.star")
+
+
+def launch(plan, superchains_params):
+    return {
+        superchain_params.name: _create_dependency_set_artifact(plan, superchain_params)
+        for superchain_params in (superchains_params or [])
+    }
+
+
+def _create_dependency_set_artifact(plan, superchain_params):
+    path = "{}.json".format(superchain_params.dependency_set.name)
+
+    return struct(
+        artifact=_file.from_string(
+            plan=plan,
+            path=path,
+            contents=json.encode(superchain_params.dependency_set.value),
+            artifact_name=superchain_params.dependency_set.name,
+            description="Creating a dependency set file {} for op-superchain {}".format(
+                path, superchain_params.name
+            ),
+        ),
+        superchain=superchain_params.name,
+        path=path,
+    )

--- a/src/supervisor/input_parser.star
+++ b/src/supervisor/input_parser.star
@@ -6,7 +6,6 @@ _DEFAULT_ARGS = {
     "enabled": True,
     "superchain": None,
     "image": None,
-    "dependency_set": None,
     "extra_params": [],
 }
 
@@ -74,39 +73,4 @@ def _parse_instance(supervisor_args, supervisor_name, superchains, registry):
         )
     }
 
-    participant_network_ids = [str(p) for p in superchain.participants]
-    supervisor_params["dependency_set"] = (
-        supervisor_params["dependency_set"]
-        if supervisor_params["dependency_set"] != None
-        else _create_dependency_set(participant_network_ids)
-    )
-
-    dependency_set_network_ids = (
-        supervisor_params["dependency_set"].get("dependencies", {}).keys()
-    )
-    missing_network_ids = [
-        network_id
-        for network_id in dependency_set_network_ids
-        if network_id not in participant_network_ids
-    ]
-    if len(missing_network_ids) > 0:
-        fail(
-            "Missing networks {} defined in dependency set for supervisor {}".format(
-                ",".join(missing_network_ids), supervisor_name
-            )
-        )
-
     return struct(**supervisor_params)
-
-
-def _create_dependency_set(network_ids):
-    return {
-        "dependencies": {
-            str(network_id): {
-                "chainIndex": str(network_id),
-                "activationTime": 0,
-                "historyMinTime": 0,
-            }
-            for network_id in network_ids
-        }
-    }

--- a/test/superchain/input_parser_test.star
+++ b/test/superchain/input_parser_test.star
@@ -66,6 +66,23 @@ def test_superchain_input_parser_default_args(plan):
                 application_protocol="ws",
             )
         },
+        dependency_set=struct(
+            name="superchain-depset-superchain-0",
+            value={
+                "dependencies": {
+                    "1000": {
+                        "chainIndex": "1000",
+                        "activationTime": 0,
+                        "historyMinTime": 0,
+                    },
+                    "2000": {
+                        "chainIndex": "2000",
+                        "activationTime": 0,
+                        "historyMinTime": 0,
+                    },
+                }
+            },
+        ),
     )
 
     expect.eq(

--- a/test/superchain/launcher_test.star
+++ b/test/superchain/launcher_test.star
@@ -1,0 +1,69 @@
+_launcher = import_module("/src/superchain/launcher.star")
+_input_parser = import_module("/src/superchain/input_parser.star")
+
+_chains = [
+    {"network_params": {"network_id": 1000}},
+    {"network_params": {"network_id": 2000}},
+]
+
+
+def test_superchain_launcher_empty(plan):
+    expect.eq(
+        _launcher.launch(
+            plan=plan,
+            superchains_params=None,
+        ),
+        {},
+    )
+    expect.eq(
+        _launcher.launch(
+            plan=plan,
+            superchains_params=[],
+        ),
+        {},
+    )
+
+
+def test_superchain_launcher_multiple_participants(plan):
+    superchains_params = _input_parser.parse(
+        {
+            "superchain-0": {},
+            "superchain-1": None,
+            "superchain-2": {
+                "participants": [2000],
+            },
+            "superchain-3": {
+                "participants": [1000, 2000],
+            },
+        },
+        _chains,
+    )
+
+    expect.eq(
+        _launcher.launch(
+            plan=plan,
+            superchains_params=superchains_params,
+        ),
+        {
+            "superchain-0": struct(
+                artifact="superchain-depset-superchain-0",
+                path="superchain-depset-superchain-0.json",
+                superchain="superchain-0",
+            ),
+            "superchain-1": struct(
+                artifact="superchain-depset-superchain-1",
+                path="superchain-depset-superchain-1.json",
+                superchain="superchain-1",
+            ),
+            "superchain-2": struct(
+                artifact="superchain-depset-superchain-2",
+                path="superchain-depset-superchain-2.json",
+                superchain="superchain-2",
+            ),
+            "superchain-3": struct(
+                artifact="superchain-depset-superchain-3",
+                path="superchain-depset-superchain-3.json",
+                superchain="superchain-3",
+            ),
+        },
+    )

--- a/test/supervisor/input_parser_test.star
+++ b/test/supervisor/input_parser_test.star
@@ -10,12 +10,6 @@ _superchains = [
 ]
 
 _default_supervisor = struct(
-    dependency_set={
-        "dependencies": {
-            "1000": {"chainIndex": "1000", "activationTime": 0, "historyMinTime": 0},
-            "2000": {"chainIndex": "2000", "activationTime": 0, "historyMinTime": 0},
-        }
-    },
     extra_params=[],
     image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-supervisor:develop",
     name="supervisor",
@@ -81,7 +75,6 @@ def test_supervisor_input_parser_default_args(plan):
                 "supervisor-0": {
                     "enabled": None,
                     "image": None,
-                    "dependency_set": None,
                     "extra_params": None,
                     "superchain": "superchain-0",
                 }
@@ -91,20 +84,6 @@ def test_supervisor_input_parser_default_args(plan):
         ),
         [
             struct(
-                dependency_set={
-                    "dependencies": {
-                        "1000": {
-                            "chainIndex": "1000",
-                            "activationTime": 0,
-                            "historyMinTime": 0,
-                        },
-                        "2000": {
-                            "chainIndex": "2000",
-                            "activationTime": 0,
-                            "historyMinTime": 0,
-                        },
-                    }
-                },
                 enabled=True,
                 extra_params=[],
                 image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-supervisor:develop",
@@ -121,24 +100,25 @@ def test_supervisor_input_parser_default_args(plan):
     )
 
 
-def test_supervisor_input_parser_custom_(plan):
+def test_supervisor_input_parser_custom_params(plan):
     parsed = input_parser.parse(
         {
             "supervisor-0": {
                 "superchain": "superchain-0",
-                "dependency_set": {},
+                "image": "op-supervisor:smallest",
                 "extra_params": ["--hey"],
             },
         },
         _superchains,
         _default_registry,
     )
+
+    expect.eq(parsed[0].image, "op-supervisor:smallest")
     expect.eq(parsed[0].extra_params, ["--hey"])
-    expect.eq(parsed[0].dependency_set, {})
 
 
 def test_supervisor_input_parser_custom_registry(plan):
-    registry = _registry.Registry({_registry.OP_SUPERVISOR: "op-supervisor:latest"})
+    registry = _registry.Registry({_registry.OP_SUPERVISOR: "op-supervisor:greatest"})
 
     parsed = input_parser.parse(
         {
@@ -147,7 +127,7 @@ def test_supervisor_input_parser_custom_registry(plan):
         _superchains,
         registry,
     )
-    expect.eq(parsed[0].image, "op-supervisor:latest")
+    expect.eq(parsed[0].image, "op-supervisor:greatest")
 
     parsed = input_parser.parse(
         {


### PR DESCRIPTION
**Description**

- Moves the `dependency_set` from `supervisors` to `superchains`. For now we'll not allow custom dependency set, we'll add that on demand

Related to https://github.com/ethereum-optimism/optimism/issues/15151