### PR TITLE
chore: Support multiple supervisors: Add op-supervisor launcher [13/N]

### DIFF
--- a/src/superchain/input_parser.star
+++ b/src/superchain/input_parser.star
@@ -65,6 +65,7 @@ def _parse_instance(superchain_args, superchain_name, chains):
     # We'll create a dependency set for the superchain based on all the participants
     superchain_params["dependency_set"] = struct(
         name="superchain-depset-{}".format(superchain_name),
+        path="superchain-depset-{}.json".format(superchain_name),
         value=_create_dependency_set(superchain_params["participants"]),
     )
 

--- a/src/superchain/launcher.star
+++ b/src/superchain/launcher.star
@@ -9,18 +9,16 @@ def launch(plan, superchains_params):
 
 
 def _create_dependency_set_artifact(plan, superchain_params):
-    path = "{}.json".format(superchain_params.dependency_set.name)
-
     return struct(
         artifact=_file.from_string(
             plan=plan,
-            path=path,
+            path=superchain_params.dependency_set.path,
             contents=json.encode(superchain_params.dependency_set.value),
             artifact_name=superchain_params.dependency_set.name,
             description="Creating a dependency set file {} for op-superchain {}".format(
-                path, superchain_params.name
+                superchain_params.dependency_set.path, superchain_params.name
             ),
         ),
         superchain=superchain_params.name,
-        path=path,
+        path=superchain_params.dependency_set.path,
     )

--- a/src/supervisor/op-supervisor/launcher.star
+++ b/src/supervisor/op-supervisor/launcher.star
@@ -1,0 +1,94 @@
+_file = import_module("/src/util/file.star")
+_net = import_module("/src/util/net.star")
+
+_ethereum_package_constants = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
+)
+
+_observability = import_module("/src/observability/observability.star")
+_prometheus = import_module("/src/observability/prometheus/prometheus_launcher.star")
+
+
+DATA_DIR = "/etc/op-supervisor"
+DEPENDENCY_SET_FILE_NAME = "dependency_set.json"
+
+
+def launch(
+    plan,
+    params,
+    l1_config_env_vars,
+    l2s,
+    jwt_file,
+    observability_helper,
+):
+    supervisor_l2s = [
+        l2 for l2 in l2s if l2.network_id in params.superchain.participants
+    ]
+
+    config = _get_config(
+        plan=plan,
+        params=params,
+        l1_config_env_vars=l1_config_env_vars,
+        l2s=supervisor_l2s,
+        jwt_file=jwt_file,
+        observability_helper=observability_helper,
+    )
+
+    service = plan.add_service(params.service_name, config)
+
+    _observability.register_op_service_metrics_job(
+        observability_helper,
+        service,
+    )
+
+    return struct(service=service, l2s=supervisor_l2s)
+
+
+def _get_config(
+    plan,
+    params,
+    l1_config_env_vars,
+    l2s,
+    jwt_file,
+    observability_helper,
+):
+    ports = _net.ports_to_port_specs(params.ports)
+
+    cmd = ["op-supervisor"] + params.extra_params
+
+    # apply customizations
+
+    if observability_helper.enabled:
+        _observability.configure_op_service_metrics(cmd, ports)
+
+    return ServiceConfig(
+        image=params.image,
+        ports=ports,
+        files={
+            DATA_DIR: params.superchain.dependency_set.name,
+            _ethereum_package_constants.JWT_MOUNTPOINT_ON_CLIENTS: jwt_file,
+        },
+        env_vars={
+            "OP_SUPERVISOR_DATADIR": "/db",
+            "OP_SUPERVISOR_DEPENDENCY_SET": "{0}/{1}".format(
+                DATA_DIR, params.superchain.dependency_set.path
+            ),
+            "OP_SUPERVISOR_L1_RPC": l1_config_env_vars["L1_RPC_URL"],
+            "OP_SUPERVISOR_L2_CONSENSUS_NODES": ",".join(
+                [
+                    _net.service_url(
+                        participant.cl_context.ip_addr,
+                        params.superchain.ports[_net.INTEROP_RPC_PORT_NAME],
+                    )
+                    for l2 in l2s
+                    for participant in l2.participants
+                ]
+            ),
+            "OP_SUPERVISOR_L2_CONSENSUS_JWT_SECRET": _ethereum_package_constants.JWT_MOUNT_PATH_ON_CONTAINER,
+            "OP_SUPERVISOR_RPC_ADDR": "0.0.0.0",
+            "OP_SUPERVISOR_RPC_PORT": str(params.ports[_net.RPC_PORT_NAME].number),
+            "OP_SUPERVISOR_RPC_ENABLE_ADMIN": "true",
+        },
+        cmd=cmd,
+        private_ip_address_placeholder=_ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+    )

--- a/test/superchain/input_parser_test.star
+++ b/test/superchain/input_parser_test.star
@@ -68,6 +68,7 @@ def test_superchain_input_parser_default_args(plan):
         },
         dependency_set=struct(
             name="superchain-depset-superchain-0",
+            path="superchain-depset-superchain-0.json",
             value={
                 "dependencies": {
                     "1000": {

--- a/test/supervisor/op-supervisor/launcher_test.star
+++ b/test/supervisor/op-supervisor/launcher_test.star
@@ -1,0 +1,82 @@
+_op_supervisor_launcher = import_module("/src/supervisor/op-supervisor/launcher.star")
+
+_input_parser = import_module("/src/package_io/input_parser.star")
+_observability = import_module("/src/observability/observability.star")
+_ethereum_package_constants = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
+)
+
+
+def test_interop_op_supervisor_ports(plan):
+    parsed_input_args = _input_parser.input_parser(
+        plan,
+        {
+            "chains": [
+                {
+                    "network_params": {
+                        "network_id": 1000,
+                    },
+                    "participants": [
+                        {
+                            "el_type": "op-reth",
+                            "el_image": "op-reth:latest",
+                            "cl_type": "op-node",
+                            "cl_image": "op-node:latest",
+                        }
+                    ],
+                }
+            ],
+            "superchains": {"superchain-0": {}},
+            "supervisors": {
+                "supervisor-0": {
+                    "superchain": "superchain-0",
+                }
+            },
+        },
+    )
+
+    # Just to make sure
+    expect.ne(parsed_input_args.supervisors, None)
+
+    supervisor_params = parsed_input_args.supervisors[0]
+    expect.ne(supervisor_params, None)
+
+    observability_helper = _observability.make_helper(parsed_input_args.observability)
+
+    result = _op_supervisor_launcher.launch(
+        plan=plan,
+        l1_config_env_vars={"L1_RPC_URL": "http://l1.rpc"},
+        l2s=[],
+        jwt_file="/jwt_file",
+        params=supervisor_params,
+        observability_helper=observability_helper,
+    )
+
+    service = plan.get_service(supervisor_params.service_name)
+    expect.ne(service, None)
+
+    expect.eq(service.ports["rpc"].number, 8545)
+    expect.eq(service.ports["rpc"].application_protocol, "http")
+
+    service_config = kurtosistest.get_service_config(supervisor_params.service_name)
+    expect.ne(service_config, None)
+
+    expect.eq(service_config.env_vars["OP_SUPERVISOR_RPC_ADDR"], "0.0.0.0")
+    expect.eq(service_config.env_vars["OP_SUPERVISOR_RPC_PORT"], "8545")
+
+    expect.eq(
+        supervisor_params.superchain.dependency_set.name,
+        "superchain-depset-superchain-0",
+    )
+    expect.eq(
+        supervisor_params.superchain.dependency_set.path,
+        "superchain-depset-superchain-0.json",
+    )
+    expect.eq(
+        service_config.env_vars["OP_SUPERVISOR_DEPENDENCY_SET"],
+        "/etc/op-supervisor/superchain-depset-superchain-0.json",
+    )
+    expect.eq(
+        service_config.files["/etc/op-supervisor"].artifact_names,
+        ["superchain-depset-superchain-0"],
+    )


### PR DESCRIPTION
**Description**

- Adds new `op-supervisor` launcher without plugging it in yet
- Adds `path` property to `dependency_set` in `superchain/input_parser` so that we don't need to pass the result of `superchain/launcher` to `op-supervisor/launcher`