### PR TITLE
chore: Support multiple supervisors: Fix launcher pattern for superchain [15/N]

### DIFF
--- a/src/superchain/launcher.star
+++ b/src/superchain/launcher.star
@@ -1,24 +1,23 @@
 _file = import_module("/src/util/file.star")
 
 
-def launch(plan, superchains_params):
-    return {
-        superchain_params.name: _create_dependency_set_artifact(plan, superchain_params)
-        for superchain_params in (superchains_params or [])
-    }
+def launch(plan, params):
+    return struct(
+        dependency_set=_create_dependency_set_artifact(plan, params),
+    )
 
 
-def _create_dependency_set_artifact(plan, superchain_params):
+def _create_dependency_set_artifact(plan, params):
     return struct(
         artifact=_file.from_string(
             plan=plan,
-            path=superchain_params.dependency_set.path,
-            contents=json.encode(superchain_params.dependency_set.value),
-            artifact_name=superchain_params.dependency_set.name,
+            path=params.dependency_set.path,
+            contents=json.encode(params.dependency_set.value),
+            artifact_name=params.dependency_set.name,
             description="Creating a dependency set file {} for op-superchain {}".format(
-                superchain_params.dependency_set.path, superchain_params.name
+                params.dependency_set.path, params.name
             ),
         ),
-        superchain=superchain_params.name,
-        path=superchain_params.dependency_set.path,
+        superchain=params.name,
+        path=params.dependency_set.path,
     )

--- a/test/superchain/launcher_test.star
+++ b/test/superchain/launcher_test.star
@@ -7,23 +7,6 @@ _chains = [
 ]
 
 
-def test_superchain_launcher_empty(plan):
-    expect.eq(
-        _launcher.launch(
-            plan=plan,
-            superchains_params=None,
-        ),
-        {},
-    )
-    expect.eq(
-        _launcher.launch(
-            plan=plan,
-            superchains_params=[],
-        ),
-        {},
-    )
-
-
 def test_superchain_launcher_multiple_participants(plan):
     superchains_params = _input_parser.parse(
         {
@@ -42,28 +25,55 @@ def test_superchain_launcher_multiple_participants(plan):
     expect.eq(
         _launcher.launch(
             plan=plan,
-            superchains_params=superchains_params,
+            params=superchains_params[0],
         ),
-        {
-            "superchain-0": struct(
+        struct(
+            dependency_set=struct(
                 artifact="superchain-depset-superchain-0",
                 path="superchain-depset-superchain-0.json",
                 superchain="superchain-0",
-            ),
-            "superchain-1": struct(
+            )
+        ),
+    )
+
+    expect.eq(
+        _launcher.launch(
+            plan=plan,
+            params=superchains_params[1],
+        ),
+        struct(
+            dependency_set=struct(
                 artifact="superchain-depset-superchain-1",
                 path="superchain-depset-superchain-1.json",
                 superchain="superchain-1",
-            ),
-            "superchain-2": struct(
+            )
+        ),
+    )
+
+    expect.eq(
+        _launcher.launch(
+            plan=plan,
+            params=superchains_params[2],
+        ),
+        struct(
+            dependency_set=struct(
                 artifact="superchain-depset-superchain-2",
                 path="superchain-depset-superchain-2.json",
                 superchain="superchain-2",
-            ),
-            "superchain-3": struct(
+            )
+        ),
+    )
+
+    expect.eq(
+        _launcher.launch(
+            plan=plan,
+            params=superchains_params[3],
+        ),
+        struct(
+            dependency_set=struct(
                 artifact="superchain-depset-superchain-3",
                 path="superchain-depset-superchain-3.json",
                 superchain="superchain-3",
-            ),
-        },
+            )
+        ),
     )


### PR DESCRIPTION
**Description**

- Launchers should accept single objects, not lists or dicts

Related to https://github.com/ethereum-optimism/optimism/issues/15151