### PR TITLE
fix(superchain): encode related chains in service names

### DIFF
--- a/network_params.yaml
+++ b/network_params.yaml
@@ -53,17 +53,17 @@ optimism_package:
   global_tolerations: []
   persistent: false
   challengers:
-    challenger-0: &x-challenger
+    challenger0: &x-challenger
       participants: "*"
       cannon_trace_types: ["super-cannon", "super-permissioned"]
-    challenger-1:
+    challenger1:
       <<: *x-challenger
   superchains:
-    superchain-0:
+    superchain0:
   supervisors:
-    supervisor-0: &x-supervisor
-      superchain: superchain-0
-    supervisor-1:
+    supervisor0: &x-supervisor
+      superchain: superchain0
+    supervisor1:
       <<: *x-supervisor
 ethereum_package:
   participants:

--- a/src/challenger/input_parser.star
+++ b/src/challenger/input_parser.star
@@ -1,5 +1,6 @@
 _expansion = import_module("/src/util/expansion.star")
 _filter = import_module("/src/util/filter.star")
+_id = import_module("/src/util/id.star")
 
 _DEFAULT_ARGS = {
     "enabled": True,
@@ -32,6 +33,8 @@ def _parse_instance(challenger_args, challenger_name, chains):
         + ": {}",
     )
 
+    _id.assert_id(challenger_name)
+
     # We filter the None values so that we can merge dicts easily
     # and merge the config with the defaults
     challenger_params = _DEFAULT_ARGS | _filter.remove_none(challenger_args)
@@ -54,7 +57,10 @@ def _parse_instance(challenger_args, challenger_name, chains):
 
     # We add name & service name
     challenger_params["name"] = challenger_name
-    challenger_params["service_name"] = "op-challenger-{}".format(challenger_name)
+    challenger_params["service_name"] = "op-challenger-{}-{}".format(
+        challenger_name,
+        "-".join([str(p) for p in challenger_params["participants"]]),
+    )
 
     # Now we make sure to cover the prestate arg combinations
     #

--- a/src/superchain/input_parser.star
+++ b/src/superchain/input_parser.star
@@ -1,6 +1,7 @@
 _expansion = import_module("/src/util/expansion.star")
 _filter = import_module("/src/util/filter.star")
 _net = import_module("/src/util/net.star")
+_id = import_module("/src/util/id.star")
 
 _DEFAULT_ARGS = {
     "enabled": True,
@@ -26,6 +27,8 @@ def _parse_instance(superchain_args, superchain_name, chains):
         + superchain_name
         + ": {}",
     )
+
+    _id.assert_id(superchain_name)
 
     # We filter the None values so that we can merge dicts easily
     # and merge the config with the defaults

--- a/src/supervisor/input_parser.star
+++ b/src/supervisor/input_parser.star
@@ -1,5 +1,6 @@
 _filter = import_module("/src/util/filter.star")
 _net = import_module("/src/util/net.star")
+_id = import_module("/src/util/id.star")
 _registry = import_module("/src/package_io/registry.star")
 
 _DEFAULT_ARGS = {
@@ -31,6 +32,8 @@ def _parse_instance(supervisor_args, supervisor_name, superchains, registry):
         + ": {}",
     )
 
+    _id.assert_id(supervisor_name)
+
     supervisor_params = _DEFAULT_ARGS | _filter.remove_none(supervisor_args or {})
 
     if not supervisor_params["enabled"]:
@@ -57,7 +60,10 @@ def _parse_instance(supervisor_args, supervisor_name, superchains, registry):
 
     # We add name & service name
     supervisor_params["name"] = supervisor_name
-    supervisor_params["service_name"] = "op-supervisor-{}".format(supervisor_name)
+    supervisor_params["service_name"] = "op-supervisor-{}-{}".format(
+        supervisor_name,
+        superchain_name,
+    )
 
     # And default the image to the one in the registry
     supervisor_params["image"] = supervisor_params["image"] or registry.get(

--- a/src/util/id.star
+++ b/src/util/id.star
@@ -1,0 +1,4 @@
+# IDs cannot contain '-' as we use '-' to separate elements in naming conventions
+def assert_id(id):
+    if "-" in id:
+        fail("ID cannot contain '-': {}".format(id))

--- a/test/challenger/input_parser_test.star
+++ b/test/challenger/input_parser_test.star
@@ -29,7 +29,7 @@ def test_challenger_input_parser_extra_attributes(plan):
 def test_challenger_input_parser_default_args(plan):
     expected_params = struct(
         name="challenger",
-        service_name="op-challenger-challenger",
+        service_name="op-challenger-challenger-1000-2000",
         enabled=True,
         image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-challenger:develop",
         extra_params=[],

--- a/test/el_cl_launcher_test.star
+++ b/test/el_cl_launcher_test.star
@@ -278,8 +278,8 @@ def test_launch_with_superchains(plan):
                     ]
                 }
             ],
-            "superchains": {"superchain-0": {}},
-            "supervisors": {"supervisor-0": {"superchain": "superchain-0"}},
+            "superchains": {"superchain0": {}},
+            "supervisors": {"supervisor0": {"superchain": "superchain0"}},
         },
     )
 

--- a/test/superchain/input_parser_test.star
+++ b/test/superchain/input_parser_test.star
@@ -28,7 +28,7 @@ def test_superchain_input_parser_empty(plan):
 def test_superchain_input_parser_no_participants(plan):
     expect.eq(
         input_parser.parse(
-            {"superchain-0": {"participants": []}},
+            {"superchain0": {"participants": []}},
             _chains,
         ),
         [],
@@ -38,7 +38,7 @@ def test_superchain_input_parser_no_participants(plan):
 def test_superchain_input_parser_disabled(plan):
     expect.eq(
         input_parser.parse(
-            {"superchain-0": {"enabled": False}},
+            {"superchain0": {"enabled": False}},
             _chains,
         ),
         [],
@@ -48,17 +48,17 @@ def test_superchain_input_parser_disabled(plan):
 def test_superchain_input_parser_extra_attributes(plan):
     expect.fails(
         lambda: input_parser.parse(
-            {"superchain-0": {"extra": None, "name": "x"}},
+            {"superchain0": {"extra": None, "name": "x"}},
             _chains,
         ),
-        "Invalid attributes in superchain configuration for superchain-0: extra,name",
+        "Invalid attributes in superchain configuration for superchain0: extra,name",
     )
 
 
 def test_superchain_input_parser_default_args(plan):
     expected_params = struct(
         enabled=True,
-        name="superchain-0",
+        name="superchain0",
         participants=[1000, 2000],
         ports={
             "rpc-interop": _net.port(
@@ -67,8 +67,8 @@ def test_superchain_input_parser_default_args(plan):
             )
         },
         dependency_set=struct(
-            name="superchain-depset-superchain-0",
-            path="superchain-depset-superchain-0.json",
+            name="superchain-depset-superchain0",
+            path="superchain-depset-superchain0.json",
             value={
                 "dependencies": {
                     "1000": {
@@ -88,21 +88,21 @@ def test_superchain_input_parser_default_args(plan):
 
     expect.eq(
         input_parser.parse(
-            {"superchain-0": None},
+            {"superchain0": None},
             _chains,
         ),
         [expected_params],
     )
     expect.eq(
         input_parser.parse(
-            {"superchain-0": {}},
+            {"superchain0": {}},
             _chains,
         ),
         [expected_params],
     )
     expect.eq(
         input_parser.parse(
-            {"superchain-0": {"enabled": None, "participants": None}},
+            {"superchain0": {"enabled": None, "participants": None}},
             _chains,
         ),
         [expected_params],

--- a/test/superchain/launcher_test.star
+++ b/test/superchain/launcher_test.star
@@ -10,12 +10,12 @@ _chains = [
 def test_superchain_launcher_multiple_participants(plan):
     superchains_params = _input_parser.parse(
         {
-            "superchain-0": {},
-            "superchain-1": None,
-            "superchain-2": {
+            "superchain0": {},
+            "superchain1": None,
+            "superchain2": {
                 "participants": [2000],
             },
-            "superchain-3": {
+            "superchain3": {
                 "participants": [1000, 2000],
             },
         },
@@ -29,9 +29,9 @@ def test_superchain_launcher_multiple_participants(plan):
         ),
         struct(
             dependency_set=struct(
-                artifact="superchain-depset-superchain-0",
-                path="superchain-depset-superchain-0.json",
-                superchain="superchain-0",
+                artifact="superchain-depset-superchain0",
+                path="superchain-depset-superchain0.json",
+                superchain="superchain0",
             )
         ),
     )
@@ -43,9 +43,9 @@ def test_superchain_launcher_multiple_participants(plan):
         ),
         struct(
             dependency_set=struct(
-                artifact="superchain-depset-superchain-1",
-                path="superchain-depset-superchain-1.json",
-                superchain="superchain-1",
+                artifact="superchain-depset-superchain1",
+                path="superchain-depset-superchain1.json",
+                superchain="superchain1",
             )
         ),
     )
@@ -57,9 +57,9 @@ def test_superchain_launcher_multiple_participants(plan):
         ),
         struct(
             dependency_set=struct(
-                artifact="superchain-depset-superchain-2",
-                path="superchain-depset-superchain-2.json",
-                superchain="superchain-2",
+                artifact="superchain-depset-superchain2",
+                path="superchain-depset-superchain2.json",
+                superchain="superchain2",
             )
         ),
     )
@@ -71,9 +71,9 @@ def test_superchain_launcher_multiple_participants(plan):
         ),
         struct(
             dependency_set=struct(
-                artifact="superchain-depset-superchain-3",
-                path="superchain-depset-superchain-3.json",
-                superchain="superchain-3",
+                artifact="superchain-depset-superchain3",
+                path="superchain-depset-superchain3.json",
+                superchain="superchain3",
             )
         ),
     )

--- a/test/supervisor/input_parser_test.star
+++ b/test/supervisor/input_parser_test.star
@@ -4,9 +4,9 @@ _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
 _superchains = [
-    struct(participants=[1000, 2000], name="superchain-0"),
-    struct(participants=[3000], name="superchain-1"),
-    struct(participants=[1000, 4000], name="superchain-2"),
+    struct(participants=[1000, 2000], name="superchain0"),
+    struct(participants=[3000], name="superchain1"),
+    struct(participants=[1000, 4000], name="superchain2"),
 ]
 
 _default_supervisor = struct(
@@ -38,33 +38,33 @@ def test_supervisor_input_parser_empty(plan):
 def test_supervisor_input_parser_extra_attrbutes(plan):
     expect.fails(
         lambda: input_parser.parse(
-            {"supervisor-0": {"extra": None, "name": "x"}},
+            {"supervisor0": {"extra": None, "name": "x"}},
             _superchains,
             _default_registry,
         ),
-        "Invalid attributes in supervisor configuration for supervisor-0: extra,name",
+        "Invalid attributes in supervisor configuration for supervisor0: extra,name",
     )
 
 
 def test_supervisor_input_parser_missing_superchain_name(plan):
     expect.fails(
         lambda: input_parser.parse(
-            {"supervisor-0": {}},
+            {"supervisor0": {}},
             _superchains,
             _default_registry,
         ),
-        "Missing superchain name for supervisor supervisor-0",
+        "Missing superchain name for supervisor supervisor0",
     )
 
 
 def test_supervisor_input_parser_missing_superchain(plan):
     expect.fails(
         lambda: input_parser.parse(
-            {"supervisor-0": {"superchain": "superchain-hallucinated"}},
+            {"supervisor0": {"superchain": "superchain-hallucinated"}},
             _superchains,
             _default_registry,
         ),
-        "Missing superchain superchain-hallucinated for supervisor supervisor-0",
+        "Missing superchain superchain-hallucinated for supervisor supervisor0",
     )
 
 
@@ -72,11 +72,11 @@ def test_supervisor_input_parser_default_args(plan):
     expect.eq(
         input_parser.parse(
             {
-                "supervisor-0": {
+                "supervisor0": {
                     "enabled": None,
                     "image": None,
                     "extra_params": None,
-                    "superchain": "superchain-0",
+                    "superchain": "superchain0",
                 }
             },
             _superchains,
@@ -87,13 +87,13 @@ def test_supervisor_input_parser_default_args(plan):
                 enabled=True,
                 extra_params=[],
                 image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-supervisor:develop",
-                name="supervisor-0",
+                name="supervisor0",
                 ports={
                     "rpc": _net.port(
                         number=8545,
                     )
                 },
-                service_name="op-supervisor-supervisor-0",
+                service_name="op-supervisor-supervisor0-superchain0",
                 superchain=_superchains[0],
             ),
         ],
@@ -103,8 +103,8 @@ def test_supervisor_input_parser_default_args(plan):
 def test_supervisor_input_parser_custom_params(plan):
     parsed = input_parser.parse(
         {
-            "supervisor-0": {
-                "superchain": "superchain-0",
+            "supervisor0": {
+                "superchain": "superchain0",
                 "image": "op-supervisor:smallest",
                 "extra_params": ["--hey"],
             },
@@ -122,7 +122,7 @@ def test_supervisor_input_parser_custom_registry(plan):
 
     parsed = input_parser.parse(
         {
-            "supervisor-0": {"superchain": "superchain-0"},
+            "supervisor0": {"superchain": "superchain0"},
         },
         _superchains,
         registry,
@@ -131,8 +131,8 @@ def test_supervisor_input_parser_custom_registry(plan):
 
     parsed = input_parser.parse(
         {
-            "supervisor-0": {
-                "superchain": "superchain-0",
+            "supervisor0": {
+                "superchain": "superchain0",
                 "image": "op-supervisor:oldest",
             },
         },

--- a/test/supervisor/op-supervisor/launcher_test.star
+++ b/test/supervisor/op-supervisor/launcher_test.star
@@ -26,10 +26,10 @@ def test_interop_op_supervisor_ports(plan):
                     ],
                 }
             ],
-            "superchains": {"superchain-0": {}},
+            "superchains": {"superchain0": {}},
             "supervisors": {
-                "supervisor-0": {
-                    "superchain": "superchain-0",
+                "supervisor0": {
+                    "superchain": "superchain0",
                 }
             },
         },
@@ -66,17 +66,17 @@ def test_interop_op_supervisor_ports(plan):
 
     expect.eq(
         supervisor_params.superchain.dependency_set.name,
-        "superchain-depset-superchain-0",
+        "superchain-depset-superchain0",
     )
     expect.eq(
         supervisor_params.superchain.dependency_set.path,
-        "superchain-depset-superchain-0.json",
+        "superchain-depset-superchain0.json",
     )
     expect.eq(
         service_config.env_vars["OP_SUPERVISOR_DEPENDENCY_SET"],
-        "/etc/op-supervisor/superchain-depset-superchain-0.json",
+        "/etc/op-supervisor/superchain-depset-superchain0.json",
     )
     expect.eq(
         service_config.files["/etc/op-supervisor"].artifact_names,
-        ["superchain-depset-superchain-0"],
+        ["superchain-depset-superchain0"],
     )


### PR DESCRIPTION
This ensures that both supervisor and challenger provide enough
information in the service names to figure out which chains they
relate to.

For challenger, a list of participants.
For supervisor, just a reference to the corresponding dependency set.