### PR TITLE
chore: Support multiple sequencers: Stub of L2 network participant input parsers [1/N]

### DIFF
--- a/src/el/input_parser.star
+++ b/src/el/input_parser.star
@@ -1,0 +1,2 @@
+def parse(args):
+    return None

--- a/src/el/input_parser.star
+++ b/src/el/input_parser.star
@@ -1,2 +1,0 @@
-def parse(args):
-    return None

--- a/src/l2/participant/cl/input_parser.star
+++ b/src/l2/participant/cl/input_parser.star
@@ -58,7 +58,7 @@ def _parse(args, participant_name, network_id, registry, cl_kind):
     # Draft of what the labels could look like
     cl_params["labels"] = {
         "op.kind": cl_kind,
-        "ep.network.id": network_id,
+        "op.network.id": network_id,
         "op.cl.type": cl_params["type"],
     }
 

--- a/src/l2/participant/cl/input_parser.star
+++ b/src/l2/participant/cl/input_parser.star
@@ -1,0 +1,81 @@
+_registry = import_module("/src/package_io/registry.star")
+_filter = import_module("/src/util/filter.star")
+_net = import_module("/src/util/net.star")
+_id = import_module("/src/util/id.star")
+
+_DEFAULT_ARGS = {
+    "type": "op-node",
+    "image": None,
+    "log_level": None,
+    "extra_env_vars": {},
+    "extra_labels": {},
+    "extra_params": [],
+    "tolerations": [],
+    "volume_size": 0,
+    "min_cpu": 0,
+    "max_cpu": 0,
+    "min_mem": 0,
+    "max_mem": 0,
+}
+
+
+def parse(args, participant_name, network_id, registry):
+    return _parse(args, participant_name, network_id, registry, "cl")
+
+
+def parse_builder(args, participant_name, network_id, registry):
+    return _parse(args, participant_name, network_id, registry, "cl_builder")
+
+
+def _parse(args, participant_name, network_id, registry, cl_kind):
+    # Any extra attributes will cause an error
+    _filter.assert_keys(
+        args,
+        _DEFAULT_ARGS.keys(),
+        "Invalid attributes in CL configuration for "
+        + participant_name
+        + " on network "
+        + str(network_id)
+        + ": {}",
+    )
+
+    # We filter the None values so that we can merge dicts easily
+    # and merge the config with the defaults
+    cl_params = _DEFAULT_ARGS | _filter.remove_none(args)
+
+    # We default the image to the one in the registry
+    #
+    # This step, as a side effect, also verifies the CL type
+    cl_params["image"] = cl_params["image"] or _default_image(
+        cl_params["type"], registry
+    )
+
+    cl_params["name"] = participant_name
+    cl_params["service_name"] = "op-cl-{}-{}-{}".format(
+        network_id, participant_name, cl_params["type"]
+    )
+
+    # Draft of what the labels could look like
+    cl_params["labels"] = {
+        "op.kind": cl_kind,
+        "ep.network.id": network_id,
+        "op.cl.type": cl_params["type"],
+    }
+
+    # We register the beacon port on the CL
+    cl_params["ports"] = {
+        _net.BEACON_PORT_NAME: _net.port(number=8545),
+    }
+
+    return struct(**cl_params)
+
+
+def _default_image(participant_type, registry):
+    if participant_type == "op-node":
+        return registry.get(_registry.OP_NODE)
+    elif participant_type == "kona-node":
+        return registry.get(_registry.KONA_NODE)
+    elif participant_type == "hildr":
+        return registry.get(_registry.HILDR)
+    else:
+        fail("Invalid CL type: {}".format(participant_type))

--- a/src/l2/participant/cl/input_parser.star
+++ b/src/l2/participant/cl/input_parser.star
@@ -30,7 +30,7 @@ def parse_builder(args, participant_name, network_id, registry):
 def _parse(args, participant_name, network_id, registry, cl_kind):
     # Any extra attributes will cause an error
     _filter.assert_keys(
-        args,
+        args or {},
         _DEFAULT_ARGS.keys(),
         "Invalid attributes in CL configuration for "
         + participant_name
@@ -41,7 +41,7 @@ def _parse(args, participant_name, network_id, registry, cl_kind):
 
     # We filter the None values so that we can merge dicts easily
     # and merge the config with the defaults
-    cl_params = _DEFAULT_ARGS | _filter.remove_none(args)
+    cl_params = _DEFAULT_ARGS | _filter.remove_none(args or {})
 
     # We default the image to the one in the registry
     #

--- a/src/l2/participant/cl/input_parser.star
+++ b/src/l2/participant/cl/input_parser.star
@@ -18,6 +18,12 @@ _DEFAULT_ARGS = {
     "max_mem": 0,
 }
 
+_IMAGE_IDS = {
+    "op-node": _registry.OP_NODE,
+    "kona-node": _registry.KONA_NODE,
+    "hildr": _registry.HILDR,
+}
+
 
 def parse(args, participant_name, network_id, registry):
     return _parse(args, participant_name, network_id, registry, "cl")
@@ -71,11 +77,7 @@ def _parse(args, participant_name, network_id, registry, cl_kind):
 
 
 def _default_image(participant_type, registry):
-    if participant_type == "op-node":
-        return registry.get(_registry.OP_NODE)
-    elif participant_type == "kona-node":
-        return registry.get(_registry.KONA_NODE)
-    elif participant_type == "hildr":
-        return registry.get(_registry.HILDR)
+    if participant_type in _IMAGE_IDS:
+        return registry.get(_IMAGE_IDS[participant_type])
     else:
         fail("Invalid CL type: {}".format(participant_type))

--- a/src/l2/participant/el/input_parser.star
+++ b/src/l2/participant/el/input_parser.star
@@ -30,7 +30,7 @@ def parse_builder(args, participant_name, network_id, registry):
 def _parse(args, participant_name, network_id, registry, el_kind):
     # Any extra attributes will cause an error
     _filter.assert_keys(
-        args,
+        args or {},
         _DEFAULT_ARGS.keys(),
         "Invalid attributes in EL configuration for "
         + participant_name
@@ -41,7 +41,7 @@ def _parse(args, participant_name, network_id, registry, el_kind):
 
     # We filter the None values so that we can merge dicts easily
     # and merge the config with the defaults
-    el_params = _DEFAULT_ARGS | _filter.remove_none(args)
+    el_params = _DEFAULT_ARGS | _filter.remove_none(args or {})
 
     # We default the image to the one in the registry
     #

--- a/src/l2/participant/el/input_parser.star
+++ b/src/l2/participant/el/input_parser.star
@@ -18,6 +18,16 @@ _DEFAULT_ARGS = {
     "max_mem": 0,
 }
 
+# EL clients have a type property that maps to an image
+_IMAGE_IDS = {
+    "op-geth": _registry.OP_GETH,
+    "op-reth": _registry.OP_RETH,
+    "op-erigon": _registry.OP_ERIGON,
+    "op-nethermind": _registry.OP_NETHERMIND,
+    "op-besu": _registry.OP_BESU,
+    "op-rbuilder": _registry.OP_RBUILDER,
+}
+
 
 def parse(args, participant_name, network_id, registry):
     return _parse(args, participant_name, network_id, registry, "el")
@@ -71,17 +81,7 @@ def _parse(args, participant_name, network_id, registry, el_kind):
 
 
 def _default_image(participant_type, registry):
-    if participant_type == "op-geth":
-        return registry.get(_registry.OP_GETH)
-    elif participant_type == "op-reth":
-        return registry.get(_registry.OP_RETH)
-    elif participant_type == "op-erigon":
-        return registry.get(_registry.OP_ERIGON)
-    elif participant_type == "op-nethermind":
-        return registry.get(_registry.OP_NETHERMIND)
-    elif participant_type == "op-besu":
-        return registry.get(_registry.OP_BESU)
-    elif participant_type == "op-rbuilder":
-        return registry.get(_registry.OP_RBUILDER)
+    if participant_type in _IMAGE_IDS:
+        return registry.get(_IMAGE_IDS[participant_type])
     else:
         fail("Invalid EL type: {}".format(participant_type))

--- a/src/l2/participant/el/input_parser.star
+++ b/src/l2/participant/el/input_parser.star
@@ -58,7 +58,7 @@ def _parse(args, participant_name, network_id, registry, el_kind):
     # Draft of what the labels could look like
     el_params["labels"] = {
         "op.kind": el_kind,
-        "ep.network.id": network_id,
+        "op.network.id": network_id,
         "op.el.type": el_params["type"],
     }
 

--- a/src/l2/participant/el/input_parser.star
+++ b/src/l2/participant/el/input_parser.star
@@ -1,0 +1,87 @@
+_registry = import_module("/src/package_io/registry.star")
+_filter = import_module("/src/util/filter.star")
+_net = import_module("/src/util/net.star")
+_id = import_module("/src/util/id.star")
+
+_DEFAULT_ARGS = {
+    "type": "op-geth",
+    "image": None,
+    "log_level": None,
+    "extra_env_vars": {},
+    "extra_labels": {},
+    "extra_params": [],
+    "tolerations": [],
+    "volume_size": 0,
+    "min_cpu": 0,
+    "max_cpu": 0,
+    "min_mem": 0,
+    "max_mem": 0,
+}
+
+
+def parse(args, participant_name, network_id, registry):
+    return _parse(args, participant_name, network_id, registry, "el")
+
+
+def parse_builder(args, participant_name, network_id, registry):
+    return _parse(args, participant_name, network_id, registry, "el_builder")
+
+
+def _parse(args, participant_name, network_id, registry, el_kind):
+    # Any extra attributes will cause an error
+    _filter.assert_keys(
+        args,
+        _DEFAULT_ARGS.keys(),
+        "Invalid attributes in EL configuration for "
+        + participant_name
+        + " on network "
+        + str(network_id)
+        + ": {}",
+    )
+
+    # We filter the None values so that we can merge dicts easily
+    # and merge the config with the defaults
+    el_params = _DEFAULT_ARGS | _filter.remove_none(args)
+
+    # We default the image to the one in the registry
+    #
+    # This step, as a side effect, also verifies the EL type
+    el_params["image"] = el_params["image"] or _default_image(
+        el_params["type"], registry
+    )
+
+    el_params["name"] = participant_name
+    el_params["service_name"] = "op-el-{}-{}-{}".format(
+        network_id, participant_name, el_params["type"]
+    )
+
+    # Draft of what the labels could look like
+    el_params["labels"] = {
+        "op.kind": el_kind,
+        "ep.network.id": network_id,
+        "op.el.type": el_params["type"],
+    }
+
+    # We register the RPC port on the EL
+    el_params["ports"] = {
+        _net.RPC_PORT_NAME: _net.port(number=8545),
+    }
+
+    return struct(**el_params)
+
+
+def _default_image(participant_type, registry):
+    if participant_type == "op-geth":
+        return registry.get(_registry.OP_GETH)
+    elif participant_type == "op-reth":
+        return registry.get(_registry.OP_RETH)
+    elif participant_type == "op-erigon":
+        return registry.get(_registry.OP_ERIGON)
+    elif participant_type == "op-nethermind":
+        return registry.get(_registry.OP_NETHERMIND)
+    elif participant_type == "op-besu":
+        return registry.get(_registry.OP_BESU)
+    elif participant_type == "op-rbuilder":
+        return registry.get(_registry.OP_RBUILDER)
+    else:
+        fail("Invalid EL type: {}".format(participant_type))

--- a/src/l2/participant/input_parser.star
+++ b/src/l2/participant/input_parser.star
@@ -1,0 +1,55 @@
+_registry = import_module("/src/package_io/registry.star")
+_filter = import_module("/src/util/filter.star")
+_net = import_module("/src/util/net.star")
+_id = import_module("/src/util/id.star")
+
+_el_input_parser = import_module("./el/input_parser.star")
+_cl_input_parser = import_module("./cl/input_parser.star")
+
+_DEFAULT_PARTICIPANT_ARGS = {
+    "el": None,
+    "el_builder": None,
+    "cl": None,
+    "cl_builder": None,
+}
+
+
+def parse(args, network_id, registry):
+    return _filter.remove_none(
+        [
+            _parse_instance(
+                participant_args or {}, participant_name, network_id, registry
+            )
+            for participant_name, participant_args in (args or {}).items()
+        ]
+    )
+
+
+def _parse_instance(participant_args, participant_name, network_id, registry):
+    # Any extra attributes will cause an error
+    _filter.assert_keys(
+        participant_args,
+        _DEFAULT_PARTICIPANT_ARGS.keys(),
+        "Invalid attributes in participant configuration for "
+        + participant_name
+        + " on network "
+        + str(network_id)
+        + ": {}",
+    )
+
+    # We make sure the name adheres to our standards
+    _id.assert_id(participant_name)
+
+    el_args = participant_args.get("el", {})
+    cl_args = participant_args.get("cl", {})
+
+    return struct(
+        el=_el_input_parser.parse(el_args, participant_name, network_id, registry),
+        el_builder=_el_input_parser.parse_builder(
+            el_args, participant_name, network_id, registry
+        ),
+        cl=_cl_input_parser.parse(cl_args, participant_name, network_id, registry),
+        cl_builder=_cl_input_parser.parse_builder(
+            cl_args, participant_name, network_id, registry
+        ),
+    )

--- a/src/l2/participant/input_parser.star
+++ b/src/l2/participant/input_parser.star
@@ -6,7 +6,7 @@ _id = import_module("/src/util/id.star")
 _el_input_parser = import_module("./el/input_parser.star")
 _cl_input_parser = import_module("./cl/input_parser.star")
 
-_DEFAULT_PARTICIPANT_ARGS = {
+_DEFAULT_ARGS = {
     "el": None,
     "el_builder": None,
     "cl": None,
@@ -28,8 +28,8 @@ def parse(args, network_id, registry):
 def _parse_instance(participant_args, participant_name, network_id, registry):
     # Any extra attributes will cause an error
     _filter.assert_keys(
-        participant_args,
-        _DEFAULT_PARTICIPANT_ARGS.keys(),
+        participant_args or {},
+        _DEFAULT_ARGS.keys(),
         "Invalid attributes in participant configuration for "
         + participant_name
         + " on network "
@@ -37,19 +37,23 @@ def _parse_instance(participant_args, participant_name, network_id, registry):
         + ": {}",
     )
 
+    # We filter the None values so that we can merge dicts easily
+    participant_params = _DEFAULT_ARGS | _filter.remove_none(participant_args or {})
+
     # We make sure the name adheres to our standards
     _id.assert_id(participant_name)
 
-    el_args = participant_args.get("el", {})
-    cl_args = participant_args.get("cl", {})
-
     return struct(
-        el=_el_input_parser.parse(el_args, participant_name, network_id, registry),
-        el_builder=_el_input_parser.parse_builder(
-            el_args, participant_name, network_id, registry
+        el=_el_input_parser.parse(
+            participant_params["el"], participant_name, network_id, registry
         ),
-        cl=_cl_input_parser.parse(cl_args, participant_name, network_id, registry),
+        el_builder=_el_input_parser.parse_builder(
+            participant_params["el_builder"], participant_name, network_id, registry
+        ),
+        cl=_cl_input_parser.parse(
+            participant_params["cl"], participant_name, network_id, registry
+        ),
         cl_builder=_cl_input_parser.parse_builder(
-            cl_args, participant_name, network_id, registry
+            participant_params["cl_builder"], participant_name, network_id, registry
         ),
     )

--- a/src/util/net.star
+++ b/src/util/net.star
@@ -1,4 +1,5 @@
 RPC_PORT_NAME = "rpc"
+BEACON_PORT_NAME = "beacon"
 INTEROP_RPC_PORT_NAME = "rpc-interop"
 
 

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -65,7 +65,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     service_name="op-cl-1000-node0-op-node",
                     labels={
                         "op.kind": "cl",
-                        "ep.network.id": 1000,
+                        "op.network.id": 1000,
                         "op.cl.type": "op-node",
                     },
                     ports={
@@ -80,7 +80,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     service_name="op-cl-1000-node0-op-node",
                     labels={
                         "op.kind": "cl_builder",
-                        "ep.network.id": 1000,
+                        "op.network.id": 1000,
                         "op.cl.type": "op-node",
                     },
                     ports={
@@ -95,7 +95,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:latest",
                     labels={
                         "op.kind": "el",
-                        "ep.network.id": 1000,
+                        "op.network.id": 1000,
                         "op.el.type": "op-geth",
                     },
                     ports={
@@ -110,7 +110,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     service_name="op-el-1000-node0-op-geth",
                     labels={
                         "op.kind": "el_builder",
-                        "ep.network.id": 1000,
+                        "op.network.id": 1000,
                         "op.el.type": "op-geth",
                     },
                     ports={
@@ -127,7 +127,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     service_name="op-cl-1000-node1-op-node",
                     labels={
                         "op.kind": "cl",
-                        "ep.network.id": 1000,
+                        "op.network.id": 1000,
                         "op.cl.type": "op-node",
                     },
                     ports={
@@ -142,7 +142,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     service_name="op-cl-1000-node1-op-node",
                     labels={
                         "op.kind": "cl_builder",
-                        "ep.network.id": 1000,
+                        "op.network.id": 1000,
                         "op.cl.type": "op-node",
                     },
                     ports={
@@ -157,7 +157,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     service_name="op-el-1000-node1-op-geth",
                     labels={
                         "op.kind": "el",
-                        "ep.network.id": 1000,
+                        "op.network.id": 1000,
                         "op.el.type": "op-geth",
                     },
                     ports={
@@ -172,7 +172,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     service_name="op-el-1000-node1-op-geth",
                     labels={
                         "op.kind": "el_builder",
-                        "ep.network.id": 1000,
+                        "op.network.id": 1000,
                         "op.el.type": "op-geth",
                     },
                     ports={

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -1,0 +1,251 @@
+input_parser = import_module("/src/l2/participant/input_parser.star")
+
+_net = import_module("/src/util/net.star")
+_registry = import_module("/src/package_io/registry.star")
+
+_default_network_id = 1000
+_default_registry = _registry.Registry()
+
+_shared_defaults = {
+    "extra_env_vars": {},
+    "extra_labels": {},
+    "extra_params": [],
+    "log_level": None,
+    "max_cpu": 0,
+    "max_mem": 0,
+    "min_cpu": 0,
+    "min_mem": 0,
+    "tolerations": [],
+    "volume_size": 0,
+}
+
+
+def test_l2_participant_input_parser_empty(plan):
+    expect.eq(
+        input_parser.parse(None, _default_network_id, _default_registry),
+        [],
+    )
+    expect.eq(
+        input_parser.parse({}, _default_network_id, _default_registry),
+        [],
+    )
+
+
+def test_l2_participant_input_parser_extra_attributes(plan):
+    expect.fails(
+        lambda: input_parser.parse(
+            {"node0": {"name": "peter", "extra": None}},
+            _default_network_id,
+            _default_registry,
+        ),
+        "Invalid attributes in participant configuration for node0 on network 1000: name,extra",
+    )
+
+
+def test_l2_participant_input_parser_invalid_name(plan):
+    expect.fails(
+        lambda: input_parser.parse(
+            {"node-0": None}, _default_network_id, _default_registry
+        ),
+        "ID cannot contain '-': node-0",
+    )
+
+
+def test_l2_participant_input_parser_defaults(plan):
+    expect.eq(
+        input_parser.parse(
+            {"node0": None, "node1": {}}, _default_network_id, _default_registry
+        ),
+        [
+            struct(
+                cl=struct(
+                    type="op-node",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop",
+                    name="node0",
+                    service_name="op-cl-1000-node0-op-node",
+                    labels={
+                        "op.kind": "cl",
+                        "ep.network.id": 1000,
+                        "op.cl.type": "op-node",
+                    },
+                    ports={
+                        "beacon": _net.port(number=8545),
+                    },
+                    **_shared_defaults,
+                ),
+                cl_builder=struct(
+                    name="node0",
+                    type="op-node",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop",
+                    service_name="op-cl-1000-node0-op-node",
+                    labels={
+                        "op.kind": "cl_builder",
+                        "ep.network.id": 1000,
+                        "op.cl.type": "op-node",
+                    },
+                    ports={
+                        "beacon": _net.port(number=8545),
+                    },
+                    **_shared_defaults,
+                ),
+                el=struct(
+                    name="node0",
+                    type="op-geth",
+                    service_name="op-el-1000-node0-op-geth",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:latest",
+                    labels={
+                        "op.kind": "el",
+                        "ep.network.id": 1000,
+                        "op.el.type": "op-geth",
+                    },
+                    ports={
+                        "rpc": _net.port(number=8545),
+                    },
+                    **_shared_defaults,
+                ),
+                el_builder=struct(
+                    name="node0",
+                    type="op-geth",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:latest",
+                    service_name="op-el-1000-node0-op-geth",
+                    labels={
+                        "op.kind": "el_builder",
+                        "ep.network.id": 1000,
+                        "op.el.type": "op-geth",
+                    },
+                    ports={
+                        "rpc": _net.port(number=8545),
+                    },
+                    **_shared_defaults,
+                ),
+            ),
+            struct(
+                cl=struct(
+                    name="node1",
+                    type="op-node",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop",
+                    service_name="op-cl-1000-node1-op-node",
+                    labels={
+                        "op.kind": "cl",
+                        "ep.network.id": 1000,
+                        "op.cl.type": "op-node",
+                    },
+                    ports={
+                        "beacon": _net.port(number=8545),
+                    },
+                    **_shared_defaults,
+                ),
+                cl_builder=struct(
+                    name="node1",
+                    type="op-node",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop",
+                    service_name="op-cl-1000-node1-op-node",
+                    labels={
+                        "op.kind": "cl_builder",
+                        "ep.network.id": 1000,
+                        "op.cl.type": "op-node",
+                    },
+                    ports={
+                        "beacon": _net.port(number=8545),
+                    },
+                    **_shared_defaults,
+                ),
+                el=struct(
+                    name="node1",
+                    type="op-geth",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:latest",
+                    service_name="op-el-1000-node1-op-geth",
+                    labels={
+                        "op.kind": "el",
+                        "ep.network.id": 1000,
+                        "op.el.type": "op-geth",
+                    },
+                    ports={
+                        "rpc": _net.port(number=8545),
+                    },
+                    **_shared_defaults,
+                ),
+                el_builder=struct(
+                    name="node1",
+                    type="op-geth",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:latest",
+                    service_name="op-el-1000-node1-op-geth",
+                    labels={
+                        "op.kind": "el_builder",
+                        "ep.network.id": 1000,
+                        "op.el.type": "op-geth",
+                    },
+                    ports={
+                        "rpc": _net.port(number=8545),
+                    },
+                    **_shared_defaults,
+                ),
+            ),
+        ],
+    )
+
+
+def test_l2_participant_input_parser_custom_registry(plan):
+    registry = _registry.Registry(
+        {
+            _registry.OP_GETH: "op-geth:greatest",
+            _registry.OP_RETH: "op-reth:slightest",
+            _registry.OP_BESU: "op-besu:roundest",
+            _registry.OP_ERIGON: "op-erigon:longest",
+            _registry.OP_NETHERMIND: "op-nethermind:sunniest",
+            _registry.OP_NODE: "op-node:smallest",
+            _registry.KONA_NODE: "kona-node:widest",
+            _registry.HILDR: "hildr:shortest",
+        }
+    )
+
+    parsed = input_parser.parse(
+        {
+            "node0": {"el": {"type": "op-geth"}, "cl": {"type": "op-node"}},
+            "node1": {"el": {"type": "op-reth"}, "cl": {"type": "hildr"}},
+            "node2": {"el": {"type": "op-besu"}, "cl": {"type": "kona-node"}},
+            "node3": {"el": {"type": "op-erigon"}},
+            "node4": {"el": {"type": "op-nethermind"}},
+            "node5": {"el": {"image": "op-geth:edge"}, "cl": {"image": "op-node:edge"}},
+        },
+        _default_network_id,
+        registry,
+    )
+
+    # node0
+    node0 = parsed[0]
+    expect.eq(node0.el.image, "op-geth:greatest")
+    expect.eq(node0.el_builder.image, "op-geth:greatest")
+    expect.eq(node0.cl.image, "op-node:smallest")
+    expect.eq(node0.cl_builder.image, "op-node:smallest")
+
+    # node1
+    node1 = parsed[1]
+    expect.eq(node1.el.image, "op-reth:slightest")
+    expect.eq(node1.el_builder.image, "op-reth:slightest")
+    expect.eq(node1.cl.image, "hildr:shortest")
+    expect.eq(node1.cl_builder.image, "hildr:shortest")
+
+    # node2
+    node2 = parsed[2]
+    expect.eq(node2.el.image, "op-besu:roundest")
+    expect.eq(node2.el_builder.image, "op-besu:roundest")
+    expect.eq(node2.cl.image, "kona-node:widest")
+    expect.eq(node2.cl_builder.image, "kona-node:widest")
+
+    # node3
+    node3 = parsed[3]
+    expect.eq(node3.el.image, "op-erigon:longest")
+    expect.eq(node3.el_builder.image, "op-erigon:longest")
+
+    # node4
+    node4 = parsed[4]
+    expect.eq(node4.el.image, "op-nethermind:sunniest")
+    expect.eq(node4.el_builder.image, "op-nethermind:sunniest")
+
+    # node5
+    node5 = parsed[5]
+    expect.eq(node5.el.image, "op-geth:edge")
+    expect.eq(node5.el_builder.image, "op-geth:edge")
+    expect.eq(node5.cl.image, "op-node:edge")
+    expect.eq(node5.cl_builder.image, "op-node:edge")

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -202,11 +202,32 @@ def test_l2_participant_input_parser_custom_registry(plan):
     parsed = input_parser.parse(
         {
             "node0": {"el": {"type": "op-geth"}, "cl": {"type": "op-node"}},
-            "node1": {"el": {"type": "op-reth"}, "cl": {"type": "hildr"}},
-            "node2": {"el": {"type": "op-besu"}, "cl": {"type": "kona-node"}},
-            "node3": {"el": {"type": "op-erigon"}},
-            "node4": {"el": {"type": "op-nethermind"}},
-            "node5": {"el": {"image": "op-geth:edge"}, "cl": {"image": "op-node:edge"}},
+            "node1": {
+                "el_builder": {"type": "op-geth"},
+                "cl_builder": {"type": "op-node"},
+            },
+            "node2": {"el": {"type": "op-reth"}, "cl": {"type": "hildr"}},
+            "node3": {
+                "el_builder": {"type": "op-reth"},
+                "cl_builder": {"type": "hildr"},
+            },
+            "node4": {"el": {"type": "op-besu"}, "cl": {"type": "kona-node"}},
+            "node5": {
+                "el_builder": {"type": "op-besu"},
+                "cl_builder": {"type": "kona-node"},
+            },
+            "node6": {"el": {"type": "op-erigon"}},
+            "node7": {"el_builder": {"type": "op-erigon"}},
+            "node8": {"el": {"type": "op-nethermind"}},
+            "node9": {"el_builder": {"type": "op-nethermind"}},
+            "node10": {
+                "el": {"image": "op-geth:edge"},
+                "cl": {"image": "op-node:edge"},
+            },
+            "node11": {
+                "el_builder": {"image": "op-geth:edge"},
+                "cl_builder": {"image": "op-node:edge"},
+            },
         },
         _default_network_id,
         registry,
@@ -215,37 +236,55 @@ def test_l2_participant_input_parser_custom_registry(plan):
     # node0
     node0 = parsed[0]
     expect.eq(node0.el.image, "op-geth:greatest")
-    expect.eq(node0.el_builder.image, "op-geth:greatest")
     expect.eq(node0.cl.image, "op-node:smallest")
-    expect.eq(node0.cl_builder.image, "op-node:smallest")
 
     # node1
     node1 = parsed[1]
-    expect.eq(node1.el.image, "op-reth:slightest")
-    expect.eq(node1.el_builder.image, "op-reth:slightest")
-    expect.eq(node1.cl.image, "hildr:shortest")
-    expect.eq(node1.cl_builder.image, "hildr:shortest")
+    expect.eq(node1.el_builder.image, "op-geth:greatest")
+    expect.eq(node1.cl_builder.image, "op-node:smallest")
 
     # node2
     node2 = parsed[2]
-    expect.eq(node2.el.image, "op-besu:roundest")
-    expect.eq(node2.el_builder.image, "op-besu:roundest")
-    expect.eq(node2.cl.image, "kona-node:widest")
-    expect.eq(node2.cl_builder.image, "kona-node:widest")
+    expect.eq(node2.el.image, "op-reth:slightest")
+    expect.eq(node2.cl.image, "hildr:shortest")
 
     # node3
     node3 = parsed[3]
-    expect.eq(node3.el.image, "op-erigon:longest")
-    expect.eq(node3.el_builder.image, "op-erigon:longest")
+    expect.eq(node3.el_builder.image, "op-reth:slightest")
+    expect.eq(node3.cl_builder.image, "hildr:shortest")
 
     # node4
     node4 = parsed[4]
-    expect.eq(node4.el.image, "op-nethermind:sunniest")
-    expect.eq(node4.el_builder.image, "op-nethermind:sunniest")
+    expect.eq(node4.el.image, "op-besu:roundest")
+    expect.eq(node4.cl.image, "kona-node:widest")
 
     # node5
     node5 = parsed[5]
-    expect.eq(node5.el.image, "op-geth:edge")
-    expect.eq(node5.el_builder.image, "op-geth:edge")
-    expect.eq(node5.cl.image, "op-node:edge")
-    expect.eq(node5.cl_builder.image, "op-node:edge")
+    expect.eq(node5.el_builder.image, "op-besu:roundest")
+    expect.eq(node5.cl_builder.image, "kona-node:widest")
+
+    # node6
+    node6 = parsed[6]
+    expect.eq(node6.el.image, "op-erigon:longest")
+
+    # node7
+    node7 = parsed[7]
+    expect.eq(node7.el_builder.image, "op-erigon:longest")
+
+    # node8
+    node8 = parsed[8]
+    expect.eq(node8.el.image, "op-nethermind:sunniest")
+
+    # node9
+    node9 = parsed[9]
+    expect.eq(node9.el_builder.image, "op-nethermind:sunniest")
+
+    # node10
+    node10 = parsed[10]
+    expect.eq(node10.el.image, "op-geth:edge")
+    expect.eq(node10.cl.image, "op-node:edge")
+
+    # node11
+    node11 = parsed[11]
+    expect.eq(node11.el_builder.image, "op-geth:edge")
+    expect.eq(node11.cl_builder.image, "op-node:edge")


### PR DESCRIPTION
**Description**

- Adds new input parsers for EL, CL and adds them under a participant parser. The prefixed version (`el_something_something`, `c_something_something`) has been replaced by nested objects (prefixes typically point to a lack of nesting), which simplifies the parsing logic
- Despite the EL & CL parsing being quite similar, I kept them in separate parsers to allow them to diverge and not to obscure simple parsing with complex abstractions. We'll see if this stands the test of time
- `labels` have been added to the parsed params to see whether we could use those

The names of the services have changed and should be more readable (which will incur a cost on the devnet SDK parsing side). I am not set on this particular format, but improvement is necessary, feel free to suggest different format.

The participant config does not yet support anything else besides EL & CL and is not connected to the main parser.

Related to https://github.com/ethereum-optimism/optimism/issues/15152