### PR TITLE
chore: Support multiple sequencers: Additional filter & ID utilities [2/N]

### DIFF
--- a/src/el/input_parser.star
+++ b/src/el/input_parser.star
@@ -1,0 +1,2 @@
+def parse(args):
+    return None

--- a/src/el/input_parser.star
+++ b/src/el/input_parser.star
@@ -1,2 +1,0 @@
-def parse(args):
-    return None

--- a/src/util/filter.star
+++ b/src/util/filter.star
@@ -40,3 +40,23 @@ def first(p, predicate=lambda v: v, default=None):
         if predicate(item):
             return item
     return default
+
+
+def get_duplicates(p):
+    # Just a quick sanity check
+    if type(p) != "list":
+        fail("Argument to get_duplicates must be a list, got {}".format(p))
+
+    # Unfortunately, kurtosis starlark does not support sets
+    # so we have to resort to less efficient lists
+    # to keep track of duplicates
+    seen = []
+    duplicates = []
+    for item in p:
+        if item in seen:
+            if item not in duplicates:
+                duplicates.append(item)
+        else:
+            seen.append(item)
+
+    return duplicates

--- a/src/util/id.star
+++ b/src/util/id.star
@@ -2,3 +2,17 @@
 def assert_id(id):
     if "-" in id:
         fail("ID cannot contain '-': {}".format(id))
+
+
+# Returns a autoincrementing ID generator function whose first value will be the `initial` argument
+def autoincrement(initial=1):
+    # Starlark does not seem to support mutable variables so we store the couter as the first element of a list
+    bucket = [initial]
+
+    def next():
+        id = bucket[0]
+        bucket[0] += 1
+
+        return id
+
+    return next

--- a/test/util/filter_test.star
+++ b/test/util/filter_test.star
@@ -112,3 +112,13 @@ def test_filter_first(plan):
 
     # With custom default
     expect.eq(filter.first([False], default=4), 4)
+
+
+def test_filter_get_duplicates(plan):
+    expect.eq(filter.get_duplicates([]), [])
+    expect.eq(filter.get_duplicates([1]), [])
+    expect.eq(filter.get_duplicates([1, 2]), [])
+    expect.eq(filter.get_duplicates([1, 2, 1]), [1])
+    expect.eq(filter.get_duplicates([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]), [])
+    expect.eq(filter.get_duplicates([1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0]), [0])
+    expect.eq(filter.get_duplicates([1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 2]), [0, 2])

--- a/test/util/id_test.star
+++ b/test/util/id_test.star
@@ -1,0 +1,20 @@
+_id = import_module("/src/util/id.star")
+
+
+def test_id_autoincrement_default_initial_value(plan):
+    id = _id.autoincrement()
+
+    expect.eq(id(), 1)
+    expect.eq(id(), 2)
+    expect.eq(id(), 3)
+    expect.eq(id(), 4)
+
+
+def test_id_autoincrement_custom_initial_value(plan):
+    id = _id.autoincrement(1000)
+
+    expect.eq(id(), 1000)
+    expect.eq(id(), 1001)
+    expect.eq(id(), 1002)
+    expect.eq(id(), 1003)
+    expect.eq(id(), 1004)


### PR DESCRIPTION
**Description**

- Adds `get_duplicates` helper utility to isolate e.g. network ID duplicate detection from the massive launcher files
- Adds `autoincrement` ID generator to isolate network ID generation from the very same massive launcher

Related to https://github.com/ethereum-optimism/optimism/issues/15152