### PR TITLE
refactor: Explicitlly specify rollup-boost socket addr in cli args

### DIFF
--- a/src/mev/rollup-boost/rollup_boost_launcher.star
+++ b/src/mev/rollup-boost/rollup_boost_launcher.star
@@ -99,6 +99,7 @@ def get_config(
         "--l2-url={0}".format(L2_EXECUTION_ENGINE_ENDPOINT),
         "--builder-jwt-path=" + constants.JWT_MOUNT_PATH_ON_CONTAINER,
         "--builder-url={0}".format(BUILDER_EXECUTION_ENGINE_ENDPOINT),
+        "--rpc-host=0.0.0.0",
         "--rpc-port={0}".format(RPC_PORT_NUM),
         "--log-level=debug",
     ]


### PR DESCRIPTION
A recent audit outlined that the default socket address at which rollup-boost establishes the RPC server is `0.0.0.0` which makes it vulnerable to misconfiguration. I'm working on a PR to change the default socket address to `127.0.0.1` but it currently breaks the kurtosis integration tests.

This PR fixes it by explicitly setting the RPC host to `0.0.0.0`