### PR TITLE
fix: default L1 CL to lighthouse

### DIFF
--- a/.github/tests/external-l1/ethereum.yaml
+++ b/.github/tests/external-l1/ethereum.yaml
@@ -1,6 +1,6 @@
 participants:
   - el_type: geth
-    cl_type: teku
+    cl_type: lodestar
 network_params:
   preset: minimal
   genesis_delay: 5

--- a/.github/tests/external-l1/ethereum.yaml
+++ b/.github/tests/external-l1/ethereum.yaml
@@ -1,6 +1,6 @@
 participants:
   - el_type: geth
-    cl_type: lodestar
+    cl_type: lighthouse
 network_params:
   preset: minimal
   genesis_delay: 5

--- a/.github/tests/external-l1/optimism.yaml
+++ b/.github/tests/external-l1/optimism.yaml
@@ -1,7 +1,7 @@
 external_l1_network_params:
   network_id: "3151908"
   rpc_kind: standard
-  el_rpc_url: http://el-1-geth-teku:8545
-  el_ws_url: ws://el-1-geth-teku:8546
-  cl_rpc_url: http://cl-1-teku-geth:4000
+  el_rpc_url: http://el-1-geth-lodestar:8545
+  el_ws_url: ws://el-1-geth-lodestar:8546
+  cl_rpc_url: http://cl-1-lodestar-geth:4000
   priv_key: "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"

--- a/.github/tests/external-l1/optimism.yaml
+++ b/.github/tests/external-l1/optimism.yaml
@@ -1,7 +1,7 @@
 external_l1_network_params:
   network_id: "3151908"
   rpc_kind: standard
-  el_rpc_url: http://el-1-geth-lodestar:8545
-  el_ws_url: ws://el-1-geth-lodestar:8546
-  cl_rpc_url: http://cl-1-lodestar-geth:4000
+  el_rpc_url: http://el-1-geth-lighthouse:8545
+  el_ws_url: ws://el-1-geth-lighthouse:8546
+  cl_rpc_url: http://cl-1-lighthouse-geth:4000
   priv_key: "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -68,7 +68,7 @@ optimism_package:
 ethereum_package:
   participants:
   - el_type: geth
-    cl_type: lodestar
+    cl_type: lighthouse
   network_params:
     preset: minimal
     genesis_delay: 5

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -68,7 +68,7 @@ optimism_package:
 ethereum_package:
   participants:
   - el_type: geth
-    cl_type: teku
+    cl_type: lodestar
   network_params:
     preset: minimal
     genesis_delay: 5

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -630,7 +630,7 @@ def default_ethereum_package_network_params():
         "participants": [
             {
                 "el_type": "geth",
-                "cl_type": "teku",
+                "cl_type": "lodestar",
             }
         ],
         "network_params": {

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -630,7 +630,7 @@ def default_ethereum_package_network_params():
         "participants": [
             {
                 "el_type": "geth",
-                "cl_type": "lodestar",
+                "cl_type": "lighthouse",
             }
         ],
         "network_params": {


### PR DESCRIPTION
Teku currently have some issues with the newly introduced BPO file structure so I suggest to use lighthouse as the default CL for now.