### PR TITLE
chore: Support multiple sequencers: Add stub of L2 input parser [3/N]

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 
 # Core dependencies
 just = "1.40.0"
-"ubi:ethereum-optimism/kurtosis-test" = "0.0.3"
+"ubi:ethereum-optimism/kurtosis-test" = "0.0.5"
 "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.6.0"
 "yq" = "v4.44.3"
 

--- a/src/el/input_parser.star
+++ b/src/el/input_parser.star
@@ -1,0 +1,2 @@
+def parse(args):
+    return None

--- a/src/el/input_parser.star
+++ b/src/el/input_parser.star
@@ -1,2 +1,0 @@
-def parse(args):
-    return None

--- a/src/l2/input_parser.star
+++ b/src/l2/input_parser.star
@@ -38,7 +38,11 @@ def _assert_unique_l2_ids(l2s_params):
     l2_ids = [l2_params.network_params.network_id for l2_params in l2s_params]
     duplicated_l2_ids = _filter.get_duplicates(l2_ids)
     if duplicated_l2_ids:
-        fail("L2 IDs must be unique, got duplicates: {}".format(",".join([str(id) for id in duplicated_l2_ids])))
+        fail(
+            "L2 IDs must be unique, got duplicates: {}".format(
+                ",".join([str(id) for id in duplicated_l2_ids])
+            )
+        )
 
     return l2s_params
 

--- a/src/l2/input_parser.star
+++ b/src/l2/input_parser.star
@@ -1,0 +1,103 @@
+_filter = import_module("/src/util/filter.star")
+_id = import_module("/src/util/id.star")
+
+_l2_participant_input_parser = import_module("./participant/input_parser.star")
+
+_DEFAULT_NETWORK_PARAMS = {
+    "network": "kurtosis",
+    "network_id": None,
+    "seconds_per_slot": 2,
+    "fjord_time_offset": 0,
+    "granite_time_offset": 0,
+    "holocene_time_offset": None,
+    "isthmus_time_offset": None,
+    "interop_time_offset": None,
+    "fund_dev_accounts": True,
+}
+
+_DEFAULT_ARGS = {
+    "participants": {},
+    "network_params": _DEFAULT_NETWORK_PARAMS,
+}
+
+
+def parse(args, registry):
+    l2_id_generator = _id.autoincrement(2151908)
+
+    return _assert_unique_l2_ids(
+        _filter.remove_none(
+            [
+                _parse_instance(l2_args or {}, l2_name, l2_id_generator, registry)
+                for l2_name, l2_args in (args or {}).items()
+            ]
+        )
+    )
+
+
+def _assert_unique_l2_ids(l2s_params):
+    l2_ids = [l2_params.network_params.network_id for l2_params in l2s_params]
+    duplicated_l2_ids = _filter.get_duplicates(l2_ids)
+    if duplicated_l2_ids:
+        fail("L2 IDs must be unique, got duplicates: {}".format(",".join([str(id) for id in duplicated_l2_ids])))
+
+    return l2s_params
+
+
+def _parse_instance(l2_args, l2_name, l2_id_generator, registry):
+    # Any extra attributes will cause an error
+    _filter.assert_keys(
+        l2_args or {},
+        _DEFAULT_ARGS.keys(),
+        "Invalid attributes in L2 configuration for " + l2_name + ": {}",
+    )
+
+    # We make sure the L2 name is a valid name
+    _id.assert_id(l2_name)
+
+    # We filter the None values so that we can merge dicts easily
+    l2_params = _DEFAULT_ARGS | _filter.remove_none(l2_args or {})
+
+    # We parse the network params
+    l2_params["network_params"] = _parse_network_params(
+        l2_params["network_params"], l2_name, l2_id_generator
+    )
+
+    l2_params["participants"] = _l2_participant_input_parser.parse(
+        l2_params["participants"], l2_params["network_params"].network_id, registry
+    )
+
+    return struct(
+        **l2_params,
+    )
+
+
+def _assert_l2_id(l2_id):
+    if type(l2_id) == "int":
+        return l2_id
+
+    if type(l2_id) == "string":
+        if l2_id.isdigit():
+            return int(l2_id)
+
+    fail("L2 ID must be a positive integer in decimal base, got {}".format(l2_id))
+
+
+def _parse_network_params(network_args, l2_name, l2_id_generator):
+    # Any extra attributes will cause an error
+    _filter.assert_keys(
+        network_args or {},
+        _DEFAULT_NETWORK_PARAMS.keys(),
+        "Invalid attributes in L2 network_params for " + l2_name + ": {}",
+    )
+
+    # We filter the None values so that we can merge dicts easily
+    network_params = _DEFAULT_NETWORK_PARAMS | _filter.remove_none(network_args or {})
+
+    # We make sure the network_id is a valid id if provided, if not we supply a default one
+    network_params["network_id"] = (
+        _assert_l2_id(network_params["network_id"])
+        if network_params["network_id"]
+        else l2_id_generator()
+    )
+
+    return struct(**network_params)

--- a/src/l2/input_parser.star
+++ b/src/l2/input_parser.star
@@ -67,7 +67,7 @@ def _parse_instance(l2_args, l2_name, l2_id_generator, registry):
     )
 
     l2_params["participants"] = _l2_participant_input_parser.parse(
-        l2_params["participants"], l2_params["network_params"].network_id, registry
+        l2_params["participants"], l2_params["network_params"], registry
     )
 
     return struct(

--- a/src/l2/input_parser.star
+++ b/src/l2/input_parser.star
@@ -104,4 +104,7 @@ def _parse_network_params(network_args, l2_name, l2_id_generator):
         else l2_id_generator()
     )
 
+    # We add the network name to params
+    network_params["name"] = l2_name
+
     return struct(**network_params)

--- a/src/l2/participant/input_parser.star
+++ b/src/l2/participant/input_parser.star
@@ -14,18 +14,21 @@ _DEFAULT_ARGS = {
 }
 
 
-def parse(args, network_id, registry):
+def parse(args, network_params, registry):
     return _filter.remove_none(
         [
             _parse_instance(
-                participant_args or {}, participant_name, network_id, registry
+                participant_args or {}, participant_name, network_params, registry
             )
             for participant_name, participant_args in (args or {}).items()
         ]
     )
 
 
-def _parse_instance(participant_args, participant_name, network_id, registry):
+def _parse_instance(participant_args, participant_name, network_params, registry):
+    network_id = network_params.network_id
+    network_name = network_params.name
+
     # Any extra attributes will cause an error
     _filter.assert_keys(
         participant_args or {},
@@ -33,7 +36,7 @@ def _parse_instance(participant_args, participant_name, network_id, registry):
         "Invalid attributes in participant configuration for "
         + participant_name
         + " on network "
-        + str(network_id)
+        + network_name
         + ": {}",
     )
 

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -72,7 +72,7 @@ def test_l2_input_parser_defaults(plan):
 
     participants = {"node0": {}, "node1": None}
     parsed_participants = participant_input_parser.parse(
-        participants, 2151908, _default_registry
+        participants, _default_network_params, _default_registry
     )
     expect.eq(
         input_parser.parse(

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -62,6 +62,7 @@ def test_l2_input_parser_defaults(plan):
         isthmus_time_offset=None,
         network="kurtosis",
         network_id=2151908,
+        name="network1",
         seconds_per_slot=2,
     )
     expect.eq(

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -120,11 +120,14 @@ def test_l2_input_parser_auto_network_id(plan):
     expect.eq(parsed[1].network_params.network_id, 7)
     expect.eq(parsed[2].network_params.network_id, 2151909)
 
-    expect.fails(lambda: input_parser.parse(
-        {
-            "network0": None,
-            "network1": {"network_params": {"network_id": 2151908}},
-            "network2": None,
-        },
-        _default_registry,
-    ), "L2 IDs must be unique, got duplicates: 2151908")
+    expect.fails(
+        lambda: input_parser.parse(
+            {
+                "network0": None,
+                "network1": {"network_params": {"network_id": 2151908}},
+                "network2": None,
+            },
+            _default_registry,
+        ),
+        "L2 IDs must be unique, got duplicates: 2151908",
+    )

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -1,0 +1,130 @@
+input_parser = import_module("/src/l2/input_parser.star")
+participant_input_parser = import_module("/src/l2/participant/input_parser.star")
+
+_net = import_module("/src/util/net.star")
+_registry = import_module("/src/package_io/registry.star")
+
+_default_network_id = 1000
+_default_registry = _registry.Registry()
+
+_shared_defaults = {
+    "extra_env_vars": {},
+    "extra_labels": {},
+    "extra_params": [],
+    "log_level": None,
+    "max_cpu": 0,
+    "max_mem": 0,
+    "min_cpu": 0,
+    "min_mem": 0,
+    "tolerations": [],
+    "volume_size": 0,
+}
+
+
+def test_l2_input_parser_empty(plan):
+    expect.eq(
+        input_parser.parse(None, _default_registry),
+        [],
+    )
+    expect.eq(
+        input_parser.parse({}, _default_registry),
+        [],
+    )
+
+
+def test_l2_input_parser_extra_attributes(plan):
+    expect.fails(
+        lambda: input_parser.parse(
+            {"network0": {"name": "peter", "extra": None}},
+            _default_registry,
+        ),
+        "Invalid attributes in L2 configuration for network0: name,extra",
+    )
+
+
+def test_l2_input_parser_invalid_name(plan):
+    expect.fails(
+        lambda: input_parser.parse({"network-0": None}, _default_registry),
+        "ID cannot contain '-': network-0",
+    )
+
+
+def test_l2_input_parser_invalid_network_id(plan):
+    expect.fails(
+        lambda: input_parser.parse(
+            {"network0": {"network_params": {"network_id": "x"}}}, _default_registry
+        ),
+        "L2 ID must be a positive integer in decimal base, got x",
+    )
+
+    expect.fails(
+        lambda: input_parser.parse(
+            {"network0": {"network_params": {"network_id": "0x1"}}}, _default_registry
+        ),
+        "L2 ID must be a positive integer in decimal base, got ",
+    )
+
+
+def test_l2_input_parser_defaults(plan):
+    _default_network_params = struct(
+        fjord_time_offset=0,
+        fund_dev_accounts=True,
+        granite_time_offset=0,
+        holocene_time_offset=None,
+        interop_time_offset=None,
+        isthmus_time_offset=None,
+        network="kurtosis",
+        network_id=2151908,
+        seconds_per_slot=2,
+    )
+    expect.eq(
+        input_parser.parse({"network1": None}, _default_registry),
+        [struct(network_params=_default_network_params, participants=[])],
+    )
+
+    participants = {"node0": {}, "node1": None}
+    parsed_participants = participant_input_parser.parse(
+        participants, 2151908, _default_registry
+    )
+    expect.eq(
+        input_parser.parse(
+            {"network1": {"participants": participants}}, _default_registry
+        ),
+        [
+            struct(
+                network_params=_default_network_params, participants=parsed_participants
+            )
+        ],
+    )
+
+
+def test_l2_input_parser_auto_network_id(plan):
+    parsed = input_parser.parse(
+        {"network0": None, "network1": None, "network2": None}, _default_registry
+    )
+
+    expect.eq(parsed[0].network_params.network_id, 2151908)
+    expect.eq(parsed[1].network_params.network_id, 2151909)
+    expect.eq(parsed[2].network_params.network_id, 2151910)
+
+    parsed = input_parser.parse(
+        {
+            "network0": None,
+            "network1": {"network_params": {"network_id": 7}},
+            "network2": None,
+        },
+        _default_registry,
+    )
+
+    expect.eq(parsed[0].network_params.network_id, 2151908)
+    expect.eq(parsed[1].network_params.network_id, 7)
+    expect.eq(parsed[2].network_params.network_id, 2151909)
+
+    expect.fails(lambda: input_parser.parse(
+        {
+            "network0": None,
+            "network1": {"network_params": {"network_id": 2151908}},
+            "network2": None,
+        },
+        _default_registry,
+    ), "L2 IDs must be unique, got duplicates: 2151908")

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -7,19 +7,6 @@ _registry = import_module("/src/package_io/registry.star")
 _default_network_id = 1000
 _default_registry = _registry.Registry()
 
-_shared_defaults = {
-    "extra_env_vars": {},
-    "extra_labels": {},
-    "extra_params": [],
-    "log_level": None,
-    "max_cpu": 0,
-    "max_mem": 0,
-    "min_cpu": 0,
-    "min_mem": 0,
-    "tolerations": [],
-    "volume_size": 0,
-}
-
 
 def test_l2_input_parser_empty(plan):
     expect.eq(

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -3,7 +3,10 @@ input_parser = import_module("/src/l2/participant/input_parser.star")
 _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
-_default_network_id = 1000
+_default_network_params = struct(
+    network_id=1000,
+    name="my-l2",
+)
 _default_registry = _registry.Registry()
 
 _shared_defaults = {
@@ -22,11 +25,11 @@ _shared_defaults = {
 
 def test_l2_participant_input_parser_empty(plan):
     expect.eq(
-        input_parser.parse(None, _default_network_id, _default_registry),
+        input_parser.parse(None, _default_network_params, _default_registry),
         [],
     )
     expect.eq(
-        input_parser.parse({}, _default_network_id, _default_registry),
+        input_parser.parse({}, _default_network_params, _default_registry),
         [],
     )
 
@@ -35,17 +38,17 @@ def test_l2_participant_input_parser_extra_attributes(plan):
     expect.fails(
         lambda: input_parser.parse(
             {"node0": {"name": "peter", "extra": None}},
-            _default_network_id,
+            _default_network_params,
             _default_registry,
         ),
-        "Invalid attributes in participant configuration for node0 on network 1000: name,extra",
+        "Invalid attributes in participant configuration for node0 on network my-l2: name,extra",
     )
 
 
 def test_l2_participant_input_parser_invalid_name(plan):
     expect.fails(
         lambda: input_parser.parse(
-            {"node-0": None}, _default_network_id, _default_registry
+            {"node-0": None}, _default_network_params, _default_registry
         ),
         "ID cannot contain '-': node-0",
     )
@@ -54,7 +57,7 @@ def test_l2_participant_input_parser_invalid_name(plan):
 def test_l2_participant_input_parser_defaults(plan):
     expect.eq(
         input_parser.parse(
-            {"node0": None, "node1": {}}, _default_network_id, _default_registry
+            {"node0": None, "node1": {}}, _default_network_params, _default_registry
         ),
         [
             struct(
@@ -229,7 +232,7 @@ def test_l2_participant_input_parser_custom_registry(plan):
                 "cl_builder": {"image": "op-node:edge"},
             },
         },
-        _default_network_id,
+        _default_network_params,
         registry,
     )
 


### PR DESCRIPTION
**Description**

- Adds an L2 input parser that checks the `network_params` and uses the existing parsers to add `EL` & `CL` params
- Updates `kurtosis-test` to a version that silenced logging a bit when testing using `--test-pattern` - the important logs were getting drowned in the warnings about tests not matching a pattern

Related to https://github.com/ethereum-optimism/optimism/issues/15152