### PR TITLE
chore: Support multiple sequencers: Sequencers assignment [11/N]

### DIFF
--- a/src/l2/participant/input_parser.star
+++ b/src/l2/participant/input_parser.star
@@ -63,14 +63,16 @@ def _parse_instance(participant_args, participant_name, network_params, registry
     if sequencer:
         type_of_sequencer = type(sequencer)
 
-        if type_of_sequencer == "string":
-            if sequencer == participant_name:
-                fail(
-                    "Invalid sequencer value for participant {} on network {}: cannot use self as a sequencer reference".format(
-                        participant_name, network_name
-                    )
-                )
-        elif type_of_sequencer != "bool" and type_of_sequencer != "NoneType":
+        # If we get a boolean True, we'll change it to the name of the node itself
+        # so that it is consistent with the rest
+        if sequencer == True:
+            sequencer = participant_name
+        # We'll fail on any invalid types
+        elif (
+            type_of_sequencer != "string"
+            and type_of_sequencer != "bool"
+            and type_of_sequencer != "NoneType"
+        ):
             fail(
                 "Invalid sequencer value for participant {} on network {}: expected string or bool, got {} {}".format(
                     participant_name, network_name, type_of_sequencer, sequencer
@@ -104,14 +106,36 @@ def _apply_sequencers(participants_params, network_params):
     if len(participants_params) == 0:
         return participants_params
 
+    # Now we make sure that if we specify anything explicitly, we specify everything explicitly
+    #
+    # No half-assed configs around here okay
+    explicit_sequencers = [p.name for p in participants_params if p.sequencer != None]
+    explicit_mode = len(explicit_sequencers) == len(participants_params)
+    implicit_mode = len(explicit_sequencers) == 0
+
+    if not explicit_mode and not implicit_mode:
+        implicit_sequencers = [
+            p.name for p in participants_params if p.name not in explicit_sequencers
+        ]
+
+        fail(
+            "Invalid participants configuration on network {}: sequencers explicitly defined for nodes {} but left implicit for {}. Only fully implicit/fully explicit configurations are allowed, please either remove explicit sequencer values or complete the configuration".format(
+                network_params.name,
+                ",".join(explicit_sequencers),
+                ",".join(implicit_sequencers),
+            )
+        )
+
     # Since copying structs is not super slick in starlark, we keep an array of just the sequencer values since we want to modify them
-    sequencers = [p.name for p in participants_params if p.sequencer == True]
+    #
+    # TODO In the next PR a set of helper functions will be introduced to isolate the p.sequencer == p.name condition
+    sequencers = [p.name for p in participants_params if p.sequencer == p.name]
 
     if len(sequencers) == 0:
         # If there are no participants marked as sequencers, we mark the first available one as a sequencer
-        sequencer = _filter.first(
-            [p.name for p in participants_params if p.sequencer == None]
-        )
+        #
+        # We only do this for the implicit mode though and let it fail for the explicit one
+        sequencer = participants_params[0].name if implicit_mode else None
 
         # There always has to be at least one sequencer
         if not sequencer:

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -195,18 +195,7 @@ def test_l2_participant_input_parser_defaults(plan):
 def test_l2_participant_input_parser_invalid_sequencers(plan):
     expect.fails(
         lambda: input_parser.parse(
-            {
-                "node0": {"sequencer": "node0"},
-            },
-            _default_network_params,
-            _default_registry,
-        ),
-        "Invalid sequencer value for participant node0 on network my-l2: cannot use self as a sequencer reference",
-    )
-
-    expect.fails(
-        lambda: input_parser.parse(
-            {"node0": {"sequencer": "nodeNada"}, "node1": {}},
+            {"node0": {"sequencer": "nodeNada"}, "node1": {"sequencer": True}},
             _default_network_params,
             _default_registry,
         ),
@@ -230,7 +219,9 @@ def test_l2_participant_input_parser_invalid_sequencers(plan):
     expect.fails(
         lambda: input_parser.parse(
             {
-                "node0": {},
+                "node0": {
+                    "sequencer": True,
+                },
                 "node1": {
                     "sequencer": False,
                 },
@@ -240,6 +231,24 @@ def test_l2_participant_input_parser_invalid_sequencers(plan):
             _default_registry,
         ),
         "Invalid sequencer value for participant node2 on network my-l2: participant node1 is not a sequencer",
+    )
+
+    expect.fails(
+        lambda: input_parser.parse(
+            {
+                "node0": {
+                    "sequencer": True,
+                },
+                "node1": {
+                    "sequencer": False,
+                },
+                "node2": {"sequencer": None},
+                "node3": {},
+            },
+            _default_network_params,
+            _default_registry,
+        ),
+        " Invalid participants configuration on network my-l2: sequencers explicitly defined for nodes node0,node1 but left implicit for node2,node3.",
     )
 
 
@@ -255,11 +264,12 @@ def test_l2_participant_input_parser_explicit_sequencers(plan):
                 "sequencer": False
             },
             "node2": {
-                # The third node is not a sequencer implicitly
-                "sequencer": None
+                # The third node is not a sequencer explicitly
+                "sequencer": False
             },
             "node3": {
-                # The fourth node is not a sequencer implicitly
+                # The fourth node is not a sequencer explicitly
+                "sequencer": False
             },
             "node4": {
                 # The fifth node refers to a sequencer explicitly
@@ -288,13 +298,48 @@ def test_l2_participant_input_parser_explicit_sequencers(plan):
             "node0": {"sequencer": True},
             "node1": {"sequencer": True},
             "node2": {"sequencer": True},
-            "node3": {"sequencer": None},
-            "node4": {},
+            "node3": {"sequencer": False},
+            "node4": {"sequencer": False},
             "node5": {"sequencer": "node2"},
-            "node6": {},
-            "node7": {},
-            "node8": {},
-            "node9": {},
+            "node6": {"sequencer": False},
+            "node7": {"sequencer": False},
+            "node8": {"sequencer": False},
+            "node9": {"sequencer": False},
+        },
+        _default_network_params,
+        _default_registry,
+    )
+
+    parsed_sequencers = {p.name: p.sequencer for p in parsed}
+    expect.eq(
+        parsed_sequencers,
+        {
+            "node0": True,
+            "node1": True,
+            "node2": True,
+            "node3": "node0",
+            "node4": "node0",
+            "node5": "node2",
+            "node6": "node0",
+            "node7": "node0",
+            "node8": "node0",
+            "node9": "node0",
+        },
+    )
+
+    # Now we test with sequencer value pointing to self
+    parsed = input_parser.parse(
+        {
+            "node0": {"sequencer": "node0"},
+            "node1": {"sequencer": "node1"},
+            "node2": {"sequencer": "node2"},
+            "node3": {"sequencer": False},
+            "node4": {"sequencer": False},
+            "node5": {"sequencer": "node2"},
+            "node6": {"sequencer": False},
+            "node7": {"sequencer": False},
+            "node8": {"sequencer": False},
+            "node9": {"sequencer": False},
         },
         _default_network_params,
         _default_registry,


### PR DESCRIPTION
**Description**

Introduces a new `sequencer` property of a network participant. Having thought long and hard about the naming and purpose I decided this property to be heterogenous, type-wise speaking.

The property accepts three kinds of values:

- `bool True` means that this node is a sequencer
- `bool False/None/falsy value` means that this node is **not** a sequencer
- `string` means that this node is not a sequencer and the string refers to a name of a node that is a sequencer and that this node will use when starting the EL client (look for `--rollup.sequencerhttp` CLI flag)

The reason behind keeping it in one property instead of having a property called `is_sequencer` and another one called e.g. `sequencer-name` is the fact that two-property setup is redundant (information-content-wise) and means that the pieces of information stored in the two properties can be calculated based on one another which also means they can drift apart.

If sequencers are not explicitly set, round-robin is used to select them for the nodes. I am not set on this approach, we can go for something else.

Related to https://github.com/ethereum-optimism/optimism/issues/15152