### PR TITLE
chore: Support multiple sequencers: Move MEV under participant [13/N]

### DIFF
--- a/src/l2/participant/input_parser.star
+++ b/src/l2/participant/input_parser.star
@@ -6,6 +6,7 @@ _selectors = import_module("/src/l2/selectors.star")
 
 _el_input_parser = import_module("./el/input_parser.star")
 _cl_input_parser = import_module("./cl/input_parser.star")
+_mev_input_parser = import_module("/src/mev/input_parser.star")
 
 _DEFAULT_ARGS = {
     "el": None,
@@ -13,6 +14,7 @@ _DEFAULT_ARGS = {
     "cl": None,
     "cl_builder": None,
     "sequencer": None,
+    "mev_params": None,
 }
 
 
@@ -89,6 +91,17 @@ def _parse_instance(participant_args, participant_name, network_params, registry
                 )
             )
 
+    # We add the MEV
+    #
+    # TODO MEV only makes sense for the sequencer node so we should decide how to handle this,
+    # whether to log & ignore or fail
+    mev_params = _mev_input_parser.parse(
+        mev_args=participant_params["mev_params"],
+        network_params=network_params,
+        participant_name=participant_name,
+        registry=registry,
+    )
+
     return struct(
         el=_el_input_parser.parse(
             participant_params["el"], participant_name, network_id, registry
@@ -104,6 +117,7 @@ def _parse_instance(participant_args, participant_name, network_params, registry
         ),
         name=participant_name,
         sequencer=sequencer,
+        mev_params=mev_params,
     )
 
 
@@ -189,6 +203,7 @@ def _apply_sequencers(participants_params, network_params):
             if p.name in sequencers
             # We set the value to either an explicitly set sequencer or the default one otherwise
             else p.sequencer or default_sequencer,
+            mev_params=p.mev_params,
         )
         for p in participants_params
     ]

--- a/src/mev/input_parser.star
+++ b/src/mev/input_parser.star
@@ -15,15 +15,18 @@ _IMAGE_IDS = {
 }
 
 
-def parse(mev_args, network_params, registry):
+def parse(mev_args, network_params, participant_name, registry):
     network_id = network_params.network_id
     network_name = network_params.name
+
+    # This string keep repeating in the error messages
+    mev_log_string = "{} on network {}".format(participant_name, network_name)
 
     # Any extra attributes will cause an error
     _filter.assert_keys(
         mev_args or {},
         _DEFAULT_ARGS.keys(),
-        "Invalid attributes in mev configuration for " + network_name + ": {}",
+        "Invalid attributes in MEV configuration for " + mev_log_string + ": {}",
     )
 
     # We filter the None values so that we can merge dicts easily
@@ -31,9 +34,9 @@ def parse(mev_args, network_params, registry):
 
     # Now we check that we either have none or both of builder_host & builder_port
     if mev_params["builder_host"] and not mev_params["builder_port"]:
-        fail("Missing builder_port in mev configuration for {}".format(network_name))
+        fail("Missing builder_port in MEV configuration for {}".format(mev_log_string))
     elif not mev_params["builder_host"] and mev_params["builder_port"]:
-        fail("Missing builder_host in mev configuration for {}".format(network_name))
+        fail("Missing builder_host in MEV configuration for {}".format(mev_log_string))
 
     # And default the image to the one in the registry
     mev_params["image"] = mev_params["image"] or _default_image(
@@ -41,8 +44,8 @@ def parse(mev_args, network_params, registry):
     )
 
     # Add the service name
-    mev_params["service_name"] = "op-mev-{}-{}-{}".format(
-        mev_params["type"], network_id, network_name
+    mev_params["service_name"] = "op-mev-{}-{}-{}-{}".format(
+        mev_params["type"], network_id, network_name, participant_name
     )
 
     # Add a bunch of labels
@@ -50,6 +53,7 @@ def parse(mev_args, network_params, registry):
         "op.kind": "mev",
         "op.network.id": network_id,
         "op.mev.type": mev_params["type"],
+        "op.network.participant.name": participant_name,
     }
 
     # Add ports
@@ -60,8 +64,8 @@ def parse(mev_args, network_params, registry):
     return struct(**mev_params)
 
 
-def _default_image(participant_type, registry):
-    if participant_type in _IMAGE_IDS:
-        return registry.get(_IMAGE_IDS[participant_type])
+def _default_image(mev_type, registry):
+    if mev_type in _IMAGE_IDS:
+        return registry.get(_IMAGE_IDS[mev_type])
     else:
-        fail("Invalid MEV type: {}".format(participant_type))
+        fail("Invalid MEV type: {}".format(mev_type))

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -287,11 +287,16 @@ def parse_network_params(plan, registry, input_args):
             registry,
         )
 
+        # FIXME MEV configuration will move under a participant configuration with multiple sequencers functionality
+        # and will require participant params (of the sequencer) to be passed in
         mev_params = _mev_input_parser.parse(
             # FIXME The network_params will come from the new L2 parser once that's in. Until then they need to be converted to a struct
-            chain.get("mev_params", {}),
-            struct(**network_params),
-            registry,
+            mev_args=chain.get("mev_params", {}),
+            network_params=struct(**network_params),
+            # FIXME At the moment the "name" of the sequencer is just its index in the array
+            # so we pass 0 as the name
+            participant_name="0",
+            registry=registry,
         )
 
         da_params = _da_input_parser.parse(

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -124,6 +124,22 @@ def test_l2_participant_input_parser_defaults(plan):
                     },
                     **_shared_defaults,
                 ),
+                mev_params=struct(
+                    builder_host=None,
+                    builder_port=None,
+                    image="flashbots/rollup-boost:latest",
+                    labels={
+                        "op.kind": "mev",
+                        "op.network.id": 1000,
+                        "op.network.participant.name": "node0",
+                        "op.mev.type": "rollup-boost",
+                    },
+                    ports={
+                        "rpc": _net.port(number=8541),
+                    },
+                    service_name="op-mev-rollup-boost-1000-my-l2-node0",
+                    type="rollup-boost",
+                ),
             ),
             struct(
                 name="node1",

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -204,6 +204,22 @@ def test_l2_participant_input_parser_defaults(plan):
                     },
                     **_shared_defaults,
                 ),
+                mev_params=struct(
+                    builder_host=None,
+                    builder_port=None,
+                    image="flashbots/rollup-boost:latest",
+                    labels={
+                        "op.kind": "mev",
+                        "op.network.id": 1000,
+                        "op.network.participant.name": "node1",
+                        "op.mev.type": "rollup-boost",
+                    },
+                    ports={
+                        "rpc": _net.port(number=8541),
+                    },
+                    service_name="op-mev-rollup-boost-1000-my-l2-node1",
+                    type="rollup-boost",
+                ),
             ),
         ],
     )

--- a/test/mev/input_parser_test.star
+++ b/test/mev/input_parser_test.star
@@ -4,6 +4,7 @@ _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
 _default_network_params = struct(network_id=1000, name="my-l2")
+_default_participant_name = "node0"
 _default_registry = _registry.Registry()
 
 
@@ -12,9 +13,10 @@ def test_mev_input_parser_extra_attributes(plan):
         lambda: _input_parser.parse(
             {"extra": None, "name": "x"},
             _default_network_params,
+            _default_participant_name,
             _default_registry,
         ),
-        "Invalid attributes in mev configuration for my-l2: extra,name",
+        "Invalid attributes in MEV configuration for node0 on network my-l2: extra,name",
     )
 
 
@@ -23,18 +25,20 @@ def test_mev_input_parser_invalid_builder_params(plan):
         lambda: _input_parser.parse(
             {"builder_port": "7"},
             _default_network_params,
+            _default_participant_name,
             _default_registry,
         ),
-        "Missing builder_host in mev configuration for my-l2",
+        "Missing builder_host in MEV configuration for node0 on network my-l2",
     )
 
     expect.fails(
         lambda: _input_parser.parse(
             {"builder_host": "localhost"},
             _default_network_params,
+            _default_participant_name,
             _default_registry,
         ),
-        "Missing builder_port in mev configuration for my-l2",
+        "Missing builder_port in MEV configuration for node0 on network my-l2",
     )
 
 
@@ -44,10 +48,11 @@ def test_mev_input_parser_default_args(plan):
         type="rollup-boost",
         builder_host=None,
         builder_port=None,
-        service_name="op-mev-rollup-boost-1000-my-l2",
+        service_name="op-mev-rollup-boost-1000-my-l2-node0",
         labels={
             "op.kind": "mev",
             "op.network.id": 1000,
+            "op.network.participant.name": "node0",
             "op.mev.type": "rollup-boost",
         },
         ports={
@@ -59,6 +64,7 @@ def test_mev_input_parser_default_args(plan):
         _input_parser.parse(
             None,
             _default_network_params,
+            _default_participant_name,
             _default_registry,
         ),
         _default_params,
@@ -68,6 +74,7 @@ def test_mev_input_parser_default_args(plan):
         _input_parser.parse(
             {},
             _default_network_params,
+            _default_participant_name,
             _default_registry,
         ),
         _default_params,
@@ -82,6 +89,7 @@ def test_mev_input_parser_default_args(plan):
                 "builder_port": None,
             },
             _default_network_params,
+            _default_participant_name,
             _default_registry,
         ),
         _default_params,
@@ -96,6 +104,7 @@ def test_mev_input_parser_custom_params(plan):
             "builder_port": 8080,
         },
         _default_network_params,
+        _default_participant_name,
         _default_registry,
     )
 
@@ -106,10 +115,11 @@ def test_mev_input_parser_custom_params(plan):
             type="rollup-boost",
             builder_host="localhost",
             builder_port=8080,
-            service_name="op-mev-rollup-boost-1000-my-l2",
+            service_name="op-mev-rollup-boost-1000-my-l2-node0",
             labels={
                 "op.kind": "mev",
                 "op.network.id": 1000,
+                "op.network.participant.name": "node0",
                 "op.mev.type": "rollup-boost",
             },
             ports={
@@ -125,6 +135,7 @@ def test_mev_input_parser_custom_registry(plan):
     parsed = _input_parser.parse(
         {},
         _default_network_params,
+        _default_participant_name,
         registry,
     )
     expect.eq(parsed.image, "rollup-boost:greatest")
@@ -132,6 +143,7 @@ def test_mev_input_parser_custom_registry(plan):
     parsed = _input_parser.parse(
         {"image": "rollup-boost:oldest"},
         _default_network_params,
+        _default_participant_name,
         registry,
     )
     expect.eq(parsed.image, "rollup-boost:oldest")


### PR DESCRIPTION
**Description**

MEV (rollup boost) is a per-sequencer service and needs to move under the participant configuration if we are to support multiple sequencers.

This PR adjusts the new input parser and plumbs it back into the legacy `package_io/input_parser.star` for the time being.

Related to https://github.com/ethereum-optimism/optimism/issues/15152