### PR TITLE
chore(mise): upgrade kurtosis to 1.8.1

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@
 # Core dependencies
 just = "1.40.0"
 "ubi:ethereum-optimism/kurtosis-test" = "0.0.5"
-"ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.6.0"
+"ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.8.1"
 "yq" = "v4.44.3"
 
 # lint


### PR DESCRIPTION
to match ethereum-optimism/optimism.