### PR TITLE
chore: Support multiple sequencers: CL ports [14/N]

### DIFF
--- a/src/l2/participant/cl/input_parser.star
+++ b/src/l2/participant/cl/input_parser.star
@@ -70,7 +70,7 @@ def _parse(args, participant_name, network_id, registry, cl_kind):
 
     # We register the CL ports
     cl_params["ports"] = {
-        _net.HTTP_PORT_NAME: _net.port(number=8547),
+        _net.RPC_PORT_NAME: _net.port(number=8547),
         _net.TCP_DISCOVERY_PORT_NAME: _net.port(number=9003),
         _net.UDP_DISCOVERY_PORT_NAME: _net.port(number=9003, transport_protocol="UDP"),
     }

--- a/src/l2/participant/cl/input_parser.star
+++ b/src/l2/participant/cl/input_parser.star
@@ -68,9 +68,11 @@ def _parse(args, participant_name, network_id, registry, cl_kind):
         "op.cl.type": cl_params["type"],
     }
 
-    # We register the beacon port on the CL
+    # We register the CL ports
     cl_params["ports"] = {
-        _net.BEACON_PORT_NAME: _net.port(number=8545),
+        _net.HTTP_PORT_NAME: _net.port(number=8547),
+        _net.TCP_DISCOVERY_PORT_NAME: _net.port(number=9003),
+        _net.UDP_DISCOVERY_PORT_NAME: _net.port(number=9003, transport_protocol="UDP"),
     }
 
     return struct(**cl_params)

--- a/src/util/net.star
+++ b/src/util/net.star
@@ -1,7 +1,8 @@
 HTTP_PORT_NAME = "http"
 RPC_PORT_NAME = "rpc"
-BEACON_PORT_NAME = "beacon"
 INTEROP_RPC_PORT_NAME = "rpc-interop"
+TCP_DISCOVERY_PORT_NAME = "tcp-discovery"
+UDP_DISCOVERY_PORT_NAME = "udp-discovery"
 
 
 # Creates a struct representing a service port configuration

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -75,7 +75,7 @@ def test_l2_participant_input_parser_defaults(plan):
                         "op.cl.type": "op-node",
                     },
                     ports={
-                        "http": _net.port(number=8547),
+                        "rpc": _net.port(number=8547),
                         "tcp-discovery": _net.port(number=9003),
                         "udp-discovery": _net.port(
                             number=9003, transport_protocol="UDP"
@@ -94,7 +94,7 @@ def test_l2_participant_input_parser_defaults(plan):
                         "op.cl.type": "op-node",
                     },
                     ports={
-                        "http": _net.port(number=8547),
+                        "rpc": _net.port(number=8547),
                         "tcp-discovery": _net.port(number=9003),
                         "udp-discovery": _net.port(
                             number=9003, transport_protocol="UDP"
@@ -163,7 +163,7 @@ def test_l2_participant_input_parser_defaults(plan):
                         "op.cl.type": "op-node",
                     },
                     ports={
-                        "http": _net.port(number=8547),
+                        "rpc": _net.port(number=8547),
                         "tcp-discovery": _net.port(number=9003),
                         "udp-discovery": _net.port(
                             number=9003, transport_protocol="UDP"
@@ -182,7 +182,7 @@ def test_l2_participant_input_parser_defaults(plan):
                         "op.cl.type": "op-node",
                     },
                     ports={
-                        "http": _net.port(number=8547),
+                        "rpc": _net.port(number=8547),
                         "tcp-discovery": _net.port(number=9003),
                         "udp-discovery": _net.port(
                             number=9003, transport_protocol="UDP"

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -75,7 +75,11 @@ def test_l2_participant_input_parser_defaults(plan):
                         "op.cl.type": "op-node",
                     },
                     ports={
-                        "beacon": _net.port(number=8545),
+                        "http": _net.port(number=8547),
+                        "tcp-discovery": _net.port(number=9003),
+                        "udp-discovery": _net.port(
+                            number=9003, transport_protocol="UDP"
+                        ),
                     },
                     **_shared_defaults,
                 ),
@@ -90,7 +94,11 @@ def test_l2_participant_input_parser_defaults(plan):
                         "op.cl.type": "op-node",
                     },
                     ports={
-                        "beacon": _net.port(number=8545),
+                        "http": _net.port(number=8547),
+                        "tcp-discovery": _net.port(number=9003),
+                        "udp-discovery": _net.port(
+                            number=9003, transport_protocol="UDP"
+                        ),
                     },
                     **_shared_defaults,
                 ),
@@ -155,7 +163,11 @@ def test_l2_participant_input_parser_defaults(plan):
                         "op.cl.type": "op-node",
                     },
                     ports={
-                        "beacon": _net.port(number=8545),
+                        "http": _net.port(number=8547),
+                        "tcp-discovery": _net.port(number=9003),
+                        "udp-discovery": _net.port(
+                            number=9003, transport_protocol="UDP"
+                        ),
                     },
                     **_shared_defaults,
                 ),
@@ -170,7 +182,11 @@ def test_l2_participant_input_parser_defaults(plan):
                         "op.cl.type": "op-node",
                     },
                     ports={
-                        "beacon": _net.port(number=8545),
+                        "http": _net.port(number=8547),
+                        "tcp-discovery": _net.port(number=9003),
+                        "udp-discovery": _net.port(
+                            number=9003, transport_protocol="UDP"
+                        ),
                     },
                     **_shared_defaults,
                 ),


### PR DESCRIPTION
**Description**

- Add missing CL ports to the input parser
- Rename misnamed "beacon" port to "rpc"

This is a follow up for [a discord discussion here](https://discord.com/channels/1244729134312198194/1377805358487044106)

Related to https://github.com/ethereum-optimism/optimism/issues/15152