### PR TITLE
fix: Interop timestamp bringing op-node down

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ optimism_package:
 
         # The Docker image that should be used for the CL client; leave blank to use the default for the client type
         # Defaults by client:
-        # - op-node: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop
+        # - op-node: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3
         # - hildr: ghcr.io/optimism-java/hildr:latest
         cl_image: ""
 
@@ -334,7 +334,7 @@ optimism_package:
 
         # The Docker image that should be used for the builder CL client; leave blank to use the default for the client type
         # Defaults by client:
-        # - op-node: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop
+        # - op-node: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3
         # - hildr: ghcr.io/optimism-java/hildr:latest
         cl_builder_image: ""
 

--- a/src/package_io/registry.star
+++ b/src/package_io/registry.star
@@ -42,7 +42,7 @@ _DEFAULT_IMAGES = {
     OP_BESU: "ghcr.io/optimism-java/op-besu:latest",
     OP_RBUILDER: "ghcr.io/flashbots/op-rbuilder:latest",
     # CL images
-    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop",
+    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3",
     KONA_NODE: "ghcr.io/op-rs/kona/kona-node:latest",
     HILDR: "ghcr.io/optimism-java/hildr:latest",
     # Batching

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -66,7 +66,7 @@ def test_l2_participant_input_parser_defaults(plan):
                 sequencer="node0",
                 cl=struct(
                     type="op-node",
-                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3",
                     name="node0",
                     service_name="op-cl-1000-node0-op-node",
                     labels={
@@ -82,7 +82,7 @@ def test_l2_participant_input_parser_defaults(plan):
                 cl_builder=struct(
                     name="node0",
                     type="op-node",
-                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3",
                     service_name="op-cl-1000-node0-op-node",
                     labels={
                         "op.kind": "cl_builder",
@@ -131,7 +131,7 @@ def test_l2_participant_input_parser_defaults(plan):
                 cl=struct(
                     name="node1",
                     type="op-node",
-                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3",
                     service_name="op-cl-1000-node1-op-node",
                     labels={
                         "op.kind": "cl",
@@ -146,7 +146,7 @@ def test_l2_participant_input_parser_defaults(plan):
                 cl_builder=struct(
                     name="node1",
                     type="op-node",
-                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3",
                     service_name="op-cl-1000-node1-op-node",
                     labels={
                         "op.kind": "cl_builder",

--- a/test/package_io/registry_test.star
+++ b/test/package_io/registry_test.star
@@ -1,7 +1,7 @@
 registry = import_module("/src/package_io/registry.star")
 
 DEFAULT_OP_GETH = "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:latest"
-DEFAULT_OP_NODE = "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop"
+DEFAULT_OP_NODE = "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3"
 
 
 def test_registry_default_images(_plan):


### PR DESCRIPTION
**Description**

A recent regression caused the CI workflows to fail on L2 CL (op-node specifically) startup with error `failed to setup: unable to create the rollup node config: the Interop upgrade is scheduled (timestamp = 0) but not dependency set is configured`.

This PR pins the image version to a release tag in interim.