### PR TITLE
chore: Support multiple sequencers: Add EL URLs to parsed proxyd params [16/N]

### DIFF
--- a/src/l2/input_parser.star
+++ b/src/l2/input_parser.star
@@ -99,7 +99,10 @@ def _parse_instance(l2_args, l2_name, l2_id_generator, registry):
 
     # We add the proxyd params
     l2_params["proxyd_params"] = _proxyd_input_parser.parse(
-        l2_params["proxyd_params"], l2_params["network_params"], registry
+        proxyd_args=l2_params["proxyd_params"],
+        network_params=l2_params["network_params"],
+        participants_params=l2_params["participants"],
+        registry=registry,
     )
 
     return struct(

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -391,7 +391,7 @@ def parse_network_params(plan, registry, input_args):
                                 index + 1, len(str(len(participants)))
                             ),
                             p["el_type"],
-                            p.["cl_type"],
+                            p["cl_type"],
                             network_name,
                         ),
                         ports={

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -385,6 +385,8 @@ def parse_network_params(plan, registry, input_args):
             participants_params=[
                 struct(
                     el=struct(
+                        # Name is something we don't have in the legacy params, we only have aray indices
+                        name=str(index),
                         service_name="op-el-{0}-{1}-{2}-{3}-{4}".format(
                             network_id,
                             _ethereum_package_shared_utils.zfill_custom(

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -377,8 +377,6 @@ def parse_network_params(plan, registry, input_args):
                 )
                 participants.append(participant_copy)
 
-        participants_params_new = [struct(el)]
-
         proxyd_params = _proxyd_input_parser.parse(
             # FIXME The network_params will come from the new L2 parser once that's in. Until then they need to be converted to a struct
             proxyd_args=chain.get("proxyd_params", {}),

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -384,9 +384,9 @@ def parse_network_params(plan, registry, input_args):
             # FIXME The participants params will come from the new L2 parser once that's in. Until then we need to convert the old ones to the new format
             participants_params=[
                 struct(
+                    # Name is something we don't have in the legacy params, we only have array indices
                     name=str(index),
                     el=struct(
-                        # Name is something we don't have in the legacy params, we only have array indices
                         service_name="op-el-{0}-{1}-{2}-{3}-{4}".format(
                             network_id,
                             _ethereum_package_shared_utils.zfill_custom(

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -390,8 +390,8 @@ def parse_network_params(plan, registry, input_args):
                             _ethereum_package_shared_utils.zfill_custom(
                                 index + 1, len(str(len(participants)))
                             ),
-                            p.el_type,
-                            p.cl_type,
+                            p["el_type"],
+                            p.["cl_type"],
                             network_name,
                         ),
                         ports={

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2,6 +2,10 @@ ethereum_package_input_parser = import_module(
     "github.com/ethpandaops/ethereum-package/src/package_io/input_parser.star"
 )
 
+_ethereum_package_shared_utils = import_module(
+    "github.com/ethpandaops/ethereum-package/src/shared_utils/shared_utils.star"
+)
+
 _batcher_input_parser = import_module("/src/batcher/input_parser.star")
 _da_input_parser = import_module("/src/da/input_parser.star")
 _challenger_input_parser = import_module("/src/challenger/input_parser.star")
@@ -15,6 +19,8 @@ _tx_fuzzer_parser = import_module("/src/tx-fuzzer/input_parser.star")
 constants = import_module("../package_io/constants.star")
 sanity_check = import_module("./sanity_check.star")
 _registry = import_module("./registry.star")
+
+_net = import_module("/src/util/net.star")
 
 
 DEFAULT_DA_SERVER_PARAMS = {
@@ -266,13 +272,6 @@ def parse_network_params(plan, registry, input_args):
         network_name = network_params["name"]
         network_id = network_params["network_id"]
 
-        proxyd_params = _proxyd_input_parser.parse(
-            # FIXME The network_params will come from the new L2 parser once that's in. Until then they need to be converted to a struct
-            chain.get("proxyd_params", {}),
-            struct(**network_params),
-            registry,
-        )
-
         batcher_params = _batcher_input_parser.parse(
             # FIXME The network_params will come from the new L2 parser once that's in. Until then they need to be converted to a struct
             chain.get("batcher_params", {}),
@@ -377,6 +376,35 @@ def parse_network_params(plan, registry, input_args):
                     participant
                 )
                 participants.append(participant_copy)
+
+        participants_params_new = [struct(el)]
+
+        proxyd_params = _proxyd_input_parser.parse(
+            # FIXME The network_params will come from the new L2 parser once that's in. Until then they need to be converted to a struct
+            proxyd_args=chain.get("proxyd_params", {}),
+            network_params=struct(**network_params),
+            # FIXME The participants params will come from the new L2 parser once that's in. Until then we need to convert the old ones to the new format
+            participants_params=[
+                struct(
+                    el=struct(
+                        service_name="op-el-{0}-{1}-{2}-{3}-{4}".format(
+                            network_id,
+                            _ethereum_package_shared_utils.zfill_custom(
+                                index + 1, len(str(len(participants)))
+                            ),
+                            p.el_type,
+                            p.cl_type,
+                            network_name,
+                        ),
+                        ports={
+                            _net.RPC_PORT_NAME: _net.port(number=8545),
+                        },
+                    )
+                )
+                for index, p in participants
+            ],
+            registry=registry,
+        )
 
         result = {
             "participants": participants,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -399,7 +399,7 @@ def parse_network_params(plan, registry, input_args):
                         },
                     )
                 )
-                for index, p in participants
+                for index, p in enumerate(participants)
             ],
             registry=registry,
         )

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -384,9 +384,9 @@ def parse_network_params(plan, registry, input_args):
             # FIXME The participants params will come from the new L2 parser once that's in. Until then we need to convert the old ones to the new format
             participants_params=[
                 struct(
+                    name=str(index),
                     el=struct(
                         # Name is something we don't have in the legacy params, we only have array indices
-                        name=str(index),
                         service_name="op-el-{0}-{1}-{2}-{3}-{4}".format(
                             network_id,
                             _ethereum_package_shared_utils.zfill_custom(

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -399,7 +399,7 @@ def parse_network_params(plan, registry, input_args):
                         ports={
                             _net.RPC_PORT_NAME: _net.port(number=8545),
                         },
-                    )
+                    ),
                 )
                 for index, p in enumerate(participants)
             ],

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -385,7 +385,7 @@ def parse_network_params(plan, registry, input_args):
             participants_params=[
                 struct(
                     el=struct(
-                        # Name is something we don't have in the legacy params, we only have aray indices
+                        # Name is something we don't have in the legacy params, we only have array indices
                         name=str(index),
                         service_name="op-el-{0}-{1}-{2}-{3}-{4}".format(
                             network_id,

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -75,7 +75,6 @@ def launch_participant_network(
         plan=plan,
         params=proxyd_params,
         network_params=network_params,
-        el_contexts=all_el_contexts,
         observability_helper=observability_helper,
     )
 

--- a/src/proxyd/input_parser.star
+++ b/src/proxyd/input_parser.star
@@ -8,7 +8,7 @@ _DEFAULT_ARGS = {
 }
 
 
-def parse(proxyd_args, network_params, registry):
+def parse(proxyd_args, network_params, participants_params, registry):
     network_id = network_params.network_id
     network_name = network_params.name
 
@@ -31,6 +31,12 @@ def parse(proxyd_args, network_params, registry):
     # Add ports
     proxyd_params["ports"] = {
         _net.HTTP_PORT_NAME: _net.port(number=8080),
+    }
+
+    # Add replica URLs (EL RPC URLs, proxy targets)
+    proxyd_params["replicas"] = {
+        p.name: _net.service_url(p.el.service_name, p.el.ports[_net.RPC_PORT_NAME])
+        for p in participants_params
     }
 
     # Add labels

--- a/src/proxyd/launcher.star
+++ b/src/proxyd/launcher.star
@@ -22,14 +22,13 @@ def launch(
     plan,
     params,
     network_params,
-    el_contexts,
     observability_helper,
 ):
     config_artifact_name = create_config_artifact(
         plan=plan,
         params=params,
         network_params=network_params,
-        el_contexts=el_contexts,
+        participants_params=participants_params,
         observability_helper=observability_helper,
     )
 
@@ -53,7 +52,6 @@ def create_config_artifact(
     plan,
     params,
     network_params,
-    el_contexts,
     observability_helper,
 ):
     config_template = read_file(_CONFIG_TEMPLATE_FILEPATH)
@@ -65,10 +63,7 @@ def create_config_artifact(
             "enabled": observability_helper.enabled,
             "port": _METRICS_PORT_NUM,
         },
-        "Replicas": {
-            "{0}-{1}".format(el_context.client_name, num): el_context.rpc_http_url
-            for num, el_context in enumerate(el_contexts)
-        },
+        "Replicas": params["replicas"],
     }
 
     return plan.render_templates(

--- a/src/proxyd/launcher.star
+++ b/src/proxyd/launcher.star
@@ -28,7 +28,6 @@ def launch(
         plan=plan,
         params=params,
         network_params=network_params,
-        participants_params=participants_params,
         observability_helper=observability_helper,
     )
 

--- a/src/proxyd/launcher.star
+++ b/src/proxyd/launcher.star
@@ -62,7 +62,7 @@ def create_config_artifact(
             "enabled": observability_helper.enabled,
             "port": _METRICS_PORT_NUM,
         },
-        "Replicas": params["replicas"],
+        "Replicas": params.replicas,
     }
 
     return plan.render_templates(

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -1,5 +1,6 @@
 input_parser = import_module("/src/l2/input_parser.star")
 _participant_input_parser = import_module("/src/l2/participant/input_parser.star")
+_proxyd_input_parser = import_module("/src/l2/proxyd/input_parser.star")
 _proposer_input_parser = import_module("/src/proposer/input_parser.star")
 
 _net = import_module("/src/util/net.star")
@@ -131,6 +132,13 @@ def test_l2_input_parser_defaults(plan):
         participants, _default_network_params, _default_registry
     )
 
+    parsed_proxyd_params = _proxyd_input_parser.parse(
+        proxyd_args=None,
+        network_params=_default_network_params,
+        participants_params=parsed_participants,
+        registry=_default_registry,
+    )
+
     expect.eq(
         input_parser.parse(
             {"network1": {"participants": participants}}, _default_registry
@@ -141,7 +149,7 @@ def test_l2_input_parser_defaults(plan):
                 participants=parsed_participants,
                 batcher_params=_default_batcher_params,
                 proposer_params=_default_proposer_params,
-                proxyd_params=_default_proxyd_params,
+                proxyd_params=parsed_proxyd_params,
             )
         ],
     )

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -1,6 +1,6 @@
 input_parser = import_module("/src/l2/input_parser.star")
 _participant_input_parser = import_module("/src/l2/participant/input_parser.star")
-_proxyd_input_parser = import_module("/src/l2/proxyd/input_parser.star")
+_proxyd_input_parser = import_module("/src/proxyd/input_parser.star")
 _proposer_input_parser = import_module("/src/proposer/input_parser.star")
 
 _net = import_module("/src/util/net.star")

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -106,6 +106,7 @@ def test_l2_input_parser_defaults(plan):
             "op.kind": "proxyd",
             "op.network.id": "2151908",
         },
+        replicas={"node0": "http://op-el-2151908-node0-op-geth:8545"},
     )
 
     _default_participants = _participant_input_parser.parse(

--- a/test/proxyd/input_parser_test.star
+++ b/test/proxyd/input_parser_test.star
@@ -7,17 +7,27 @@ _default_network_params = struct(
     network_id=1000,
     name="my-l2",
 )
+_default_participants_params = [
+    struct(
+        el=struct(
+            name := "node0",
+            service_name="op-el-node0",
+            ports={_net.RPC_PORT_NAME: _net.port(number=8888)},
+        )
+    )
+]
 _default_registry = _registry.Registry()
 
 
 def test_proxyd_input_parser_extra_attributes(plan):
     expect.fails(
         lambda: _input_parser.parse(
-            {"extra": None, "name": "x"},
-            _default_network_params,
-            _default_registry,
+            proxyd_args={"extra": None, "name": "x"},
+            network_params=_default_network_params,
+            participants_params=_default_participants_params,
+            registry=_default_registry,
         ),
-        " Invalid attributes in proxyd configuration for my-l2: extra,name",
+        "Invalid attributes in proxyd configuration for my-l2: extra,name",
     )
 
 
@@ -33,34 +43,38 @@ def test_proxyd_input_parser_default_args(plan):
             "op.kind": "proxyd",
             "op.network.id": "1000",
         },
+        replicas={"node0": "http://op-el-node0:8888"},
     )
 
     expect.eq(
         _input_parser.parse(
-            None,
-            _default_network_params,
-            _default_registry,
+            proxyd_args=None,
+            network_params=_default_network_params,
+            participants_params=_default_participants_params,
+            registry=_default_registry,
         ),
         _default_params,
     )
 
     expect.eq(
         _input_parser.parse(
-            {},
-            _default_network_params,
-            _default_registry,
+            proxyd_args={},
+            network_params=_default_network_params,
+            participants_params=_default_participants_params,
+            registry=_default_registry,
         ),
         _default_params,
     )
 
     expect.eq(
         _input_parser.parse(
-            {
+            proxyd_args={
                 "image": None,
                 "extra_params": None,
             },
-            _default_network_params,
-            _default_registry,
+            network_params=_default_network_params,
+            participants_params=_default_participants_params,
+            registry=_default_registry,
         ),
         _default_params,
     )
@@ -68,12 +82,13 @@ def test_proxyd_input_parser_default_args(plan):
 
 def test_proxyd_input_parser_custom_params(plan):
     parsed = _input_parser.parse(
-        {
+        proxyd_args={
             "image": "proxyd:brightest",
             "extra_params": ["--hola"],
         },
-        _default_network_params,
-        _default_registry,
+        network_params=_default_network_params,
+        participants_params=_default_participants_params,
+        registry=_default_registry,
     )
 
     expect.eq(
@@ -89,6 +104,7 @@ def test_proxyd_input_parser_custom_params(plan):
                 "op.kind": "proxyd",
                 "op.network.id": "1000",
             },
+            replicas={"node0": "http://op-el-node0:8888"},
         ),
     )
 
@@ -97,15 +113,17 @@ def test_proxyd_input_parser_custom_registry(plan):
     registry = _registry.Registry({_registry.PROXYD: "proxyd:greatest"})
 
     parsed = _input_parser.parse(
-        {},
-        _default_network_params,
-        registry,
+        proxyd_args={},
+        network_params=_default_network_params,
+        participants_params=_default_participants_params,
+        registry=registry,
     )
     expect.eq(parsed.image, "proxyd:greatest")
 
     parsed = _input_parser.parse(
-        {"image": "proxyd:oldest"},
-        _default_network_params,
-        registry,
+        proxyd_args={"image": "proxyd:oldest"},
+        network_params=_default_network_params,
+        participants_params=_default_participants_params,
+        registry=registry,
     )
     expect.eq(parsed.image, "proxyd:oldest")

--- a/test/proxyd/input_parser_test.star
+++ b/test/proxyd/input_parser_test.star
@@ -10,7 +10,7 @@ _default_network_params = struct(
 _default_participants_params = [
     struct(
         el=struct(
-            name := "node0",
+            name="node0",
             service_name="op-el-node0",
             ports={_net.RPC_PORT_NAME: _net.port(number=8888)},
         )

--- a/test/proxyd/input_parser_test.star
+++ b/test/proxyd/input_parser_test.star
@@ -9,8 +9,8 @@ _default_network_params = struct(
 )
 _default_participants_params = [
     struct(
+        name="node0",
         el=struct(
-            name="node0",
             service_name="op-el-node0",
             ports={_net.RPC_PORT_NAME: _net.port(number=8888)},
         )

--- a/test/proxyd/input_parser_test.star
+++ b/test/proxyd/input_parser_test.star
@@ -13,7 +13,7 @@ _default_participants_params = [
         el=struct(
             service_name="op-el-node0",
             ports={_net.RPC_PORT_NAME: _net.port(number=8888)},
-        )
+        ),
     )
 ]
 _default_registry = _registry.Registry()


### PR DESCRIPTION
**Description**

Since we know the EL URLs in advance, we can add them to the proxyd parsed params instead of synthesizing them in the launcher. This makes the launcher thinner and will make the transition from the old to the new input parser a bit slimmer.

It requires a bit of forward plumbing in the current input parser - to map the legacy parsed participants to the new format (only the bits required by the `proxyd` launcher)

Related to https://github.com/ethereum-optimism/optimism/issues/15152