### PR TITLE
chore: Conductor support: Add op-conductor image to the registry [1/N]

### DIFF
--- a/src/package_io/registry.star
+++ b/src/package_io/registry.star
@@ -16,6 +16,7 @@ OP_BATCHER = "op-batcher"
 OP_CHALLENGER = "op-challenger"
 OP_SUPERVISOR = "op-supervisor"
 OP_PROPOSER = "op-proposer"
+OP_CONDUCTOR = "op-conductor"
 OP_DEPLOYER = "op-deployer"
 OP_FAUCET = "op-faucet"
 
@@ -53,6 +54,8 @@ _DEFAULT_IMAGES = {
     OP_SUPERVISOR: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-supervisor:develop",
     # Proposer
     OP_PROPOSER: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:develop",
+    # Conductor
+    OP_CONDUCTOR: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-conductor:develop",
     # deployer
     OP_DEPLOYER: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.4.0-rc.2",
     # Faucet


### PR DESCRIPTION
**Description**

In parallel with the multiple sequencers support, this series of PRs will introduce functionality required to run `op-conductor`.

As soon as the multiple sequencers series is finished, we can plumb this in.