### PR TITLE
chore: Support multiple sequencers: Launchers for EL clients [21/N]

### DIFF
--- a/src/el/op-besu/launcher.star
+++ b/src/el/op-besu/launcher.star
@@ -1,0 +1,231 @@
+_ethereum_package_el_context = import_module(
+    "github.com/ethpandaops/ethereum-package/src/el/el_context.star"
+)
+_ethereum_package_el_admin_node_info = import_module(
+    "github.com/ethpandaops/ethereum-package/src/el/el_admin_node_info.star"
+)
+
+_ethereum_package_input_parser = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/input_parser.star"
+)
+
+_ethereum_package_constants = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
+)
+
+_filter = import_module("/src/util/filter.star")
+_net = import_module("/src/util/net.star")
+_selectors = import_module("/src/l2/selectors.star")
+
+_constants = import_module("../../package_io/constants.star")
+
+_observability = import_module("../../observability/observability.star")
+
+# The dirpath of the execution data directory on the client container
+EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER = "/data/geth/execution-data"
+
+
+ENTRYPOINT_ARGS = ["sh", "-c"]
+
+VERBOSITY_LEVELS = {
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.error: "1",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.warn: "2",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.info: "3",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.debug: "4",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.trace: "5",
+}
+
+
+def launch(
+    plan,
+    params,
+    sequencer_params,
+    network_params,
+    jwt_file,
+    deployment_output,
+    log_level,
+    persistent,
+    tolerations,
+    node_selectors,
+    bootnode_contexts,
+    observability_helper,
+    supervisors_params,
+):
+    el_log_level = _ethereum_package_input_parser.get_client_log_level_or_default(
+        params.log_level, log_level, VERBOSITY_LEVELS
+    )
+
+    config = get_service_config(
+        plan=plan,
+        params=params,
+        network_params=network_params,
+        sequencer_params=sequencer_params,
+        jwt_file=jwt_file,
+        deployment_output=deployment_output,
+        log_level=el_log_level,
+        persistent=persistent,
+        tolerations=tolerations,
+        node_selectors=node_selectors,
+        bootnode_contexts=bootnode_contexts,
+        observability_helper=observability_helper,
+        supervisors_params=supervisors_params,
+    )
+
+    service = plan.add_service(params.service_name, config)
+
+    engine_rpc_port = params.ports[_net.ENGINE_RPC_PORT_NAME]
+    rpc_port = params.ports[_net.RPC_PORT_NAME]
+    ws_port = params.ports[_net.WS_PORT_NAME]
+    rpc_url = _net.service_url(params.service_name, rpc_port)
+
+    enode, enr = _ethereum_package_el_admin_node_info.get_enode_enr_for_node(
+        plan, params.service_name, _net.RPC_PORT_NAME
+    )
+
+    metrics_info = _observability.new_metrics_info(observability_helper, service)
+
+    return struct(
+        service=service,
+        context=_ethereum_package_el_context.new_el_context(
+            client_name="op-besu",
+            enode=enode,
+            ip_addr=service.ip_address,
+            rpc_port_num=rpc_port.number,
+            ws_port_num=ws_port.number,
+            engine_rpc_port_num=engine_rpc_port.number,
+            rpc_http_url=rpc_url,
+            enr=enr,
+            service_name=params.service_name,
+            el_metrics_info=[metrics_info],
+        ),
+    )
+
+
+def get_service_config(
+    plan,
+    params,
+    network_params,
+    sequencer_params,
+    jwt_file,
+    deployment_output,
+    log_level,
+    persistent,
+    tolerations,
+    node_selectors,
+    bootnode_contexts,
+    observability_helper,
+    supervisors_params,
+):
+    ports = _net.ports_to_port_specs(params.ports)
+
+    subcommand_strs = []
+
+    cmd = [
+        "besu",
+        "--genesis-file="
+        + "{0}/genesis-{1}.json".format(
+            _ethereum_package_constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER,
+            network_params.network_id,
+        ),
+        "--network-id={0}".format(network_params.network_id),
+        "--data-path={}".format(EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER),
+        "--host-allowlist=*",
+        "--rpc-http-enabled=true",
+        "--rpc-http-host=0.0.0.0",
+        "--rpc-http-port={0}".format(ports[_net.RPC_PORT_NAME].number),
+        "--rpc-http-api=ADMIN,CLIQUE,ETH,NET,DEBUG,TXPOOL,ENGINE,TRACE,WEB3,MINER",
+        "--rpc-http-cors-origins=*",
+        "--rpc-http-max-active-connections=300",
+        "--rpc-ws-enabled=true",
+        "--rpc-ws-host=0.0.0.0",
+        "--rpc-ws-port={0}".format(ports[_net.WS_PORT_NAME].number),
+        "--rpc-ws-api=ADMIN,CLIQUE,ETH,NET,DEBUG,TXPOOL,ENGINE,TRACE,WEB3,MINER",
+        "--p2p-enabled=true",
+        "--p2p-host={}".format(
+            _ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER
+        ),
+        "--p2p-port={0}".format(ports[_net.TCP_DISCOVERY_PORT_NAME].number),
+        "--engine-rpc-enabled=true",
+        "--engine-jwt-secret={}".format(
+            _ethereum_package_constants.JWT_MOUNT_PATH_ON_CONTAINER
+        ),
+        "--engine-host-allowlist=*",
+        "--engine-rpc-port={0}".format(ports[_net.ENGINE_RPC_PORT_NAME].number),
+        "--sync-mode=FULL",
+        "--bonsai-limit-trie-logs-enabled=false",
+        "--version-compatibility-protection=false",
+    ]
+
+    # configure files
+
+    files = {
+        _ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: deployment_output,
+        _ethereum_package_constants.JWT_MOUNTPOINT_ON_CLIENTS: jwt_file,
+    }
+
+    if persistent:
+        files[EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER] = Directory(
+            persistent_key="data-{0}".format(params.service_name),
+            size=int(params.volume_size)
+            if int(params.volume_size) > 0
+            else _constants.VOLUME_SIZE[network_params.network][
+                _constants.EL_TYPE.op_besu + "_volume_size"
+            ],
+        )
+
+    # configure environment variables
+
+    env_vars = dict(params.extra_env_vars)
+
+    # apply customizations
+
+    if observability_helper.enabled:
+        cmd += [
+            "--metrics",
+            "--metrics.addr=0.0.0.0",
+            "--metrics.port={0}".format(_observability.METRICS_PORT_NUM),
+        ]
+
+        _observability.expose_metrics_port(ports)
+
+    if len(bootnode_contexts) > 0:
+        cmd.append(
+            "--bootnodes="
+            + ",".join(
+                [
+                    ctx.enode
+                    for ctx in bootnode_contexts[
+                        : _ethereum_package_constants.MAX_ENODE_ENTRIES
+                    ]
+                ]
+            )
+        )
+
+    # construct command string
+
+    cmd += params.extra_params
+
+    config_args = {
+        "image": params.image,
+        "ports": ports,
+        "cmd": cmd,
+        "files": files,
+        "private_ip_address_placeholder": _ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+        "env_vars": env_vars,
+        "labels": params.labels,
+        "tolerations": tolerations,
+        "node_selectors": node_selectors,
+    }
+
+    # configure resources
+
+    if params.min_cpu > 0:
+        config_args["min_cpu"] = params.min_cpu
+    if params.max_cpu > 0:
+        config_args["max_cpu"] = params.max_cpu
+    if params.min_mem > 0:
+        config_args["min_memory"] = params.min_mem
+    if params.max_mem > 0:
+        config_args["max_memory"] = params.max_mem
+
+    return ServiceConfig(**config_args)

--- a/src/el/op-besu/launcher.star
+++ b/src/el/op-besu/launcher.star
@@ -22,12 +22,9 @@ _constants = import_module("../../package_io/constants.star")
 _observability = import_module("../../observability/observability.star")
 
 # The dirpath of the execution data directory on the client container
-EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER = "/data/geth/execution-data"
+_EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER = "/data/geth/execution-data"
 
-
-ENTRYPOINT_ARGS = ["sh", "-c"]
-
-VERBOSITY_LEVELS = {
+_VERBOSITY_LEVELS = {
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.error: "1",
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.warn: "2",
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.info: "3",
@@ -52,7 +49,7 @@ def launch(
     supervisors_params,
 ):
     el_log_level = _ethereum_package_input_parser.get_client_log_level_or_default(
-        params.log_level, log_level, VERBOSITY_LEVELS
+        params.log_level, log_level, _VERBOSITY_LEVELS
     )
 
     config = get_service_config(
@@ -128,7 +125,7 @@ def get_service_config(
             network_params.network_id,
         ),
         "--network-id={0}".format(network_params.network_id),
-        "--data-path={}".format(EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER),
+        "--data-path={}".format(_EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER),
         "--host-allowlist=*",
         "--rpc-http-enabled=true",
         "--rpc-http-host=0.0.0.0",
@@ -164,7 +161,7 @@ def get_service_config(
     }
 
     if persistent:
-        files[EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER] = Directory(
+        files[_EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER] = Directory(
             persistent_key="data-{0}".format(params.service_name),
             size=int(params.volume_size)
             if int(params.volume_size) > 0

--- a/src/el/op-erigon/launcher.star
+++ b/src/el/op-erigon/launcher.star
@@ -25,9 +25,9 @@ _observability = import_module("../../observability/observability.star")
 _EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER = "/data/op-erigon/execution-data"
 
 
-ENTRYPOINT_ARGS = ["sh", "-c"]
+_ENTRYPOINT_ARGS = ["sh", "-c"]
 
-VERBOSITY_LEVELS = {
+_VERBOSITY_LEVELS = {
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.error: "1",
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.warn: "2",
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.info: "3",
@@ -52,7 +52,7 @@ def launch(
     supervisors_params,
 ):
     el_log_level = _ethereum_package_input_parser.get_client_log_level_or_default(
-        params.log_level, log_level, VERBOSITY_LEVELS
+        params.log_level, log_level, _VERBOSITY_LEVELS
     )
 
     config = get_service_config(
@@ -222,7 +222,7 @@ def get_service_config(
         "ports": ports,
         "cmd": [command_str],
         "files": files,
-        "entrypoint": ENTRYPOINT_ARGS,
+        "entrypoint": _ENTRYPOINT_ARGS,
         "private_ip_address_placeholder": _ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
         "env_vars": env_vars,
         "labels": params.labels,

--- a/src/el/op-erigon/launcher.star
+++ b/src/el/op-erigon/launcher.star
@@ -1,0 +1,245 @@
+_ethereum_package_el_context = import_module(
+    "github.com/ethpandaops/ethereum-package/src/el/el_context.star"
+)
+_ethereum_package_el_admin_node_info = import_module(
+    "github.com/ethpandaops/ethereum-package/src/el/el_admin_node_info.star"
+)
+
+_ethereum_package_input_parser = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/input_parser.star"
+)
+
+_ethereum_package_constants = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
+)
+
+_filter = import_module("/src/util/filter.star")
+_net = import_module("/src/util/net.star")
+
+_constants = import_module("../../package_io/constants.star")
+
+_observability = import_module("../../observability/observability.star")
+
+
+# The dirpath of the execution data directory on the client container
+_EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER = "/data/op-erigon/execution-data"
+
+
+ENTRYPOINT_ARGS = ["sh", "-c"]
+
+VERBOSITY_LEVELS = {
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.error: "1",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.warn: "2",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.info: "3",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.debug: "4",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.trace: "5",
+}
+
+
+def launch(
+    plan,
+    params,
+    network_params,
+    sequencer_params,
+    jwt_file,
+    deployment_output,
+    log_level,
+    persistent,
+    tolerations,
+    node_selectors,
+    bootnode_contexts,
+    observability_helper,
+    supervisors_params,
+):
+    el_log_level = _ethereum_package_input_parser.get_client_log_level_or_default(
+        params.log_level, log_level, VERBOSITY_LEVELS
+    )
+
+    config = get_service_config(
+        plan=plan,
+        params=params,
+        network_params=network_params,
+        sequencer_params=sequencer_params,
+        jwt_file=jwt_file,
+        deployment_output=deployment_output,
+        log_level=el_log_level,
+        persistent=persistent,
+        tolerations=tolerations,
+        node_selectors=node_selectors,
+        bootnode_contexts=bootnode_contexts,
+        observability_helper=observability_helper,
+        supervisors_params=supervisors_params,
+    )
+
+    service = plan.add_service(params.service_name, config)
+
+    engine_rpc_port = params.ports[_net.ENGINE_RPC_PORT_NAME]
+    rpc_port = params.ports[_net.RPC_PORT_NAME]
+    ws_port = params.ports[_net.WS_PORT_NAME]
+    rpc_url = _net.service_url(params.service_name, rpc_port)
+
+    enode = _ethereum_package_el_admin_node_info.get_enode_for_node(
+        plan, params.service_name, _net.RPC_PORT_NAME
+    )
+
+    metrics_info = _observability.new_metrics_info(observability_helper, service)
+
+    return struct(
+        service=service,
+        context=_ethereum_package_el_context.new_el_context(
+            client_name="op-erigon",
+            enode=enode,
+            ip_addr=service.ip_address,
+            rpc_port_num=rpc_port.number,
+            ws_port_num=ws_port.number,
+            engine_rpc_port_num=engine_rpc_port.number,
+            rpc_http_url=rpc_url,
+            service_name=params.service_name,
+            el_metrics_info=[metrics_info],
+        ),
+    )
+
+
+def get_service_config(
+    plan,
+    params,
+    network_params,
+    sequencer_params,
+    jwt_file,
+    deployment_output,
+    log_level,
+    persistent,
+    tolerations,
+    node_selectors,
+    bootnode_contexts,
+    observability_helper,
+    supervisors_params,
+):
+    ports = _net.ports_to_port_specs(params.ports)
+
+    subcommand_strs = []
+
+    cmd = [
+        "erigon",
+        "--datadir={}".format(_EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER),
+        "--networkid={0}".format(network_params.network_id),
+        "--http",
+        "--http.port={0}".format(ports[_net.RPC_PORT_NAME].number),
+        "--http.addr=0.0.0.0",
+        "--http.vhosts=*",
+        "--http.corsdomain=*",
+        "--http.api=admin,engine,net,eth,web3,debug,miner",
+        "--ws",
+        "--ws.port={0}".format(ports[_net.WS_PORT_NAME].number),
+        "--allow-insecure-unlock",
+        "--authrpc.port={0}".format(ports[_net.ENGINE_RPC_PORT_NAME].number),
+        "--authrpc.addr=0.0.0.0",
+        "--authrpc.vhosts=*",
+        "--authrpc.jwtsecret={}".format(
+            _ethereum_package_constants.JWT_MOUNT_PATH_ON_CONTAINER
+        ),
+        "--nat=extip:{}".format(
+            _ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER
+        ),
+        "--rpc.allow-unprotected-txs",
+        "--port={0}".format(ports[_net.TCP_DISCOVERY_PORT_NAME].number),
+    ]
+
+    # configure files
+
+    files = {
+        _ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: deployment_output,
+        _ethereum_package_constants.JWT_MOUNTPOINT_ON_CLIENTS: jwt_file,
+    }
+
+    if persistent:
+        files[_EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER] = Directory(
+            persistent_key="data-{0}".format(params.service_name),
+            size=int(params.volume_size)
+            if int(params.volume_size) > 0
+            else _constants.VOLUME_SIZE[network_params.network][
+                _constants.EL_TYPE.op_erigon + "_volume_size"
+            ],
+        )
+
+    if network_params.network not in _ethereum_package_constants.PUBLIC_NETWORKS:
+        init_datadir_cmd_str = "erigon init --datadir={0} {1}".format(
+            _EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER,
+            "{0}/genesis-{1}.json".format(
+                _ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS,
+                network_params.network_id,
+            ),
+        )
+
+        subcommand_strs.append(init_datadir_cmd_str)
+
+    # configure environment variables
+
+    env_vars = dict(params.extra_env_vars)
+
+    # apply customizations
+
+    if observability_helper.enabled:
+        cmd += [
+            "--metrics",
+            "--metrics.addr=0.0.0.0",
+            "--metrics.port={0}".format(_observability.METRICS_PORT_NUM),
+        ]
+
+        _observability.expose_metrics_port(ports)
+
+    if sequencer_params:
+        cmd.append(
+            "--rollup.sequencerhttp={0}".format(
+                _net.service_url(
+                    sequencer_params.service_name,
+                    sequencer_params.ports[_net.RPC_PORT_NAME],
+                )
+            )
+        )
+
+    if len(bootnode_contexts) > 0:
+        cmd.append(
+            "--bootnodes="
+            + ",".join(
+                [
+                    ctx.enode
+                    for ctx in bootnode_contexts[
+                        : _ethereum_package_constants.MAX_ENODE_ENTRIES
+                    ]
+                ]
+            )
+        )
+
+    # construct command string
+
+    cmd += params.extra_params
+    subcommand_strs.append(" ".join(cmd))
+    command_str = " && ".join(subcommand_strs)
+
+    config_args = {
+        "image": params.image,
+        "ports": ports,
+        "cmd": [command_str],
+        "files": files,
+        "entrypoint": ENTRYPOINT_ARGS,
+        "private_ip_address_placeholder": _ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+        "env_vars": env_vars,
+        "labels": params.labels,
+        "tolerations": tolerations,
+        "node_selectors": node_selectors,
+        "user": User(uid=0, gid=0),
+    }
+
+    # configure resources
+
+    if params.min_cpu > 0:
+        config_args["min_cpu"] = params.min_cpu
+    if params.max_cpu > 0:
+        config_args["max_cpu"] = params.max_cpu
+    if params.min_mem > 0:
+        config_args["min_memory"] = params.min_mem
+    if params.max_mem > 0:
+        config_args["max_memory"] = params.max_mem
+
+    return ServiceConfig(**config_args)

--- a/src/el/op-geth/launcher.star
+++ b/src/el/op-geth/launcher.star
@@ -25,9 +25,9 @@ _observability = import_module("../../observability/observability.star")
 EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER = "/data/geth/execution-data"
 
 
-ENTRYPOINT_ARGS = ["sh", "-c"]
+_ENTRYPOINT_ARGS = ["sh", "-c"]
 
-VERBOSITY_LEVELS = {
+_VERBOSITY_LEVELS = {
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.error: "1",
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.warn: "2",
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.info: "3",
@@ -52,7 +52,7 @@ def launch(
     supervisors_params,
 ):
     el_log_level = _ethereum_package_input_parser.get_client_log_level_or_default(
-        params.log_level, log_level, VERBOSITY_LEVELS
+        params.log_level, log_level, _VERBOSITY_LEVELS
     )
 
     config = get_service_config(
@@ -241,7 +241,7 @@ def get_service_config(
         "ports": ports,
         "cmd": [command_str],
         "files": files,
-        "entrypoint": ENTRYPOINT_ARGS,
+        "entrypoint": _ENTRYPOINT_ARGS,
         "private_ip_address_placeholder": _ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
         "env_vars": env_vars,
         "labels": params.labels,

--- a/src/el/op-geth/launcher.star
+++ b/src/el/op-geth/launcher.star
@@ -1,0 +1,263 @@
+_ethereum_package_el_context = import_module(
+    "github.com/ethpandaops/ethereum-package/src/el/el_context.star"
+)
+_ethereum_package_el_admin_node_info = import_module(
+    "github.com/ethpandaops/ethereum-package/src/el/el_admin_node_info.star"
+)
+
+_ethereum_package_input_parser = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/input_parser.star"
+)
+
+_ethereum_package_constants = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
+)
+
+_filter = import_module("/src/util/filter.star")
+_net = import_module("/src/util/net.star")
+_selectors = import_module("/src/l2/selectors.star")
+
+_constants = import_module("../../package_io/constants.star")
+
+_observability = import_module("../../observability/observability.star")
+
+# The dirpath of the execution data directory on the client container
+EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER = "/data/geth/execution-data"
+
+
+ENTRYPOINT_ARGS = ["sh", "-c"]
+
+VERBOSITY_LEVELS = {
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.error: "1",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.warn: "2",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.info: "3",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.debug: "4",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.trace: "5",
+}
+
+
+def launch(
+    plan,
+    params,
+    sequencer_params,
+    network_params,
+    jwt_file,
+    deployment_output,
+    log_level,
+    persistent,
+    tolerations,
+    node_selectors,
+    bootnode_contexts,
+    observability_helper,
+    supervisors_params,
+):
+    el_log_level = _ethereum_package_input_parser.get_client_log_level_or_default(
+        params.log_level, log_level, VERBOSITY_LEVELS
+    )
+
+    config = get_service_config(
+        plan=plan,
+        params=params,
+        network_params=network_params,
+        sequencer_params=sequencer_params,
+        jwt_file=jwt_file,
+        deployment_output=deployment_output,
+        log_level=el_log_level,
+        persistent=persistent,
+        tolerations=tolerations,
+        node_selectors=node_selectors,
+        bootnode_contexts=bootnode_contexts,
+        observability_helper=observability_helper,
+        supervisors_params=supervisors_params,
+    )
+
+    service = plan.add_service(params.service_name, config)
+
+    engine_rpc_port = params.ports[_net.ENGINE_RPC_PORT_NAME]
+    rpc_port = params.ports[_net.RPC_PORT_NAME]
+    ws_port = params.ports[_net.WS_PORT_NAME]
+    rpc_url = _net.service_url(params.service_name, rpc_port)
+
+    enode, enr = _ethereum_package_el_admin_node_info.get_enode_enr_for_node(
+        plan, params.service_name, _net.RPC_PORT_NAME
+    )
+
+    metrics_info = _observability.new_metrics_info(observability_helper, service)
+
+    return struct(
+        service=service,
+        context=_ethereum_package_el_context.new_el_context(
+            client_name="op-geth",
+            enode=enode,
+            ip_addr=service.ip_address,
+            rpc_port_num=rpc_port.number,
+            ws_port_num=ws_port.number,
+            engine_rpc_port_num=engine_rpc_port.number,
+            rpc_http_url=rpc_url,
+            enr=enr,
+            service_name=params.service_name,
+            el_metrics_info=[metrics_info],
+        ),
+    )
+
+
+def get_service_config(
+    plan,
+    params,
+    network_params,
+    sequencer_params,
+    jwt_file,
+    deployment_output,
+    log_level,
+    persistent,
+    tolerations,
+    node_selectors,
+    bootnode_contexts,
+    observability_helper,
+    supervisors_params,
+):
+    ports = _net.ports_to_port_specs(params.ports)
+
+    subcommand_strs = []
+
+    cmd = [
+        "geth",
+        "--networkid={0}".format(network_params.network_id),
+        # "--verbosity=" + verbosity_level,
+        "--datadir={}".format(EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER),
+        "--gcmode=archive",
+        "--state.scheme=hash",
+        "--http",
+        "--http.addr=0.0.0.0",
+        "--http.vhosts=*",
+        "--http.corsdomain=*",
+        "--http.api=admin,engine,net,eth,web3,debug,miner",
+        "--ws",
+        "--ws.addr=0.0.0.0",
+        "--ws.port={0}".format(ports[_net.WS_PORT_NAME].number),
+        "--ws.api=admin,engine,net,eth,web3,debug,miner",
+        "--ws.origins=*",
+        "--allow-insecure-unlock",
+        "--authrpc.port={0}".format(ports[_net.ENGINE_RPC_PORT_NAME].number),
+        "--authrpc.addr=0.0.0.0",
+        "--authrpc.vhosts=*",
+        "--authrpc.jwtsecret={}".format(
+            _ethereum_package_constants.JWT_MOUNT_PATH_ON_CONTAINER
+        ),
+        "--syncmode=full",
+        "--nat=extip:{}".format(
+            _ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER
+        ),
+        "--rpc.allow-unprotected-txs",
+        "--discovery.port={0}".format(ports[_net.TCP_DISCOVERY_PORT_NAME].number),
+        "--port={0}".format(ports[_net.TCP_DISCOVERY_PORT_NAME].number),
+    ]
+
+    # configure files
+
+    files = {
+        _ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: deployment_output,
+        _ethereum_package_constants.JWT_MOUNTPOINT_ON_CLIENTS: jwt_file,
+    }
+
+    if persistent:
+        files[EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER] = Directory(
+            persistent_key="data-{0}".format(params.service_name),
+            size=int(params.volume_size)
+            if int(params.volume_size) > 0
+            else _constants.VOLUME_SIZE[network_params.network][
+                _constants.EL_TYPE.op_geth + "_volume_size"
+            ],
+        )
+
+    if network_params.network not in _ethereum_package_constants.PUBLIC_NETWORKS:
+        init_datadir_cmd_str = "geth init --datadir={0} --state.scheme=hash {1}".format(
+            EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER,
+            "{0}/genesis-{1}.json".format(
+                _ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS,
+                network_params.network_id,
+            ),
+        )
+
+        subcommand_strs.append(init_datadir_cmd_str)
+
+    # configure environment variables
+
+    env_vars = dict(params.extra_env_vars)
+
+    # apply customizations
+
+    if observability_helper.enabled:
+        cmd += [
+            "--metrics",
+            "--metrics.addr=0.0.0.0",
+            "--metrics.port={0}".format(_observability.METRICS_PORT_NUM),
+        ]
+
+        _observability.expose_metrics_port(ports)
+
+    supervisor_params = _filter.first(supervisors_params)
+    if supervisor_params:
+        cmd.append(
+            "--rollup.interoprpc={0}".format(
+                _net.service_url(
+                    supervisor_params.service_name,
+                    supervisor_params.ports[_net.RPC_PORT_NAME],
+                )
+            )
+        )
+
+    if sequencer_params:
+        cmd.append(
+            "--rollup.sequencerhttp={}".format(
+                _net.service_url(
+                    sequencer_params.el.service_name,
+                    sequencer_params.el.ports[_net.RPC_PORT_NAME],
+                )
+            )
+        )
+
+    if len(bootnode_contexts) > 0:
+        cmd.append(
+            "--bootnodes="
+            + ",".join(
+                [
+                    ctx.enode
+                    for ctx in bootnode_contexts[
+                        : _ethereum_package_constants.MAX_ENODE_ENTRIES
+                    ]
+                ]
+            )
+        )
+
+    # construct command string
+
+    cmd += params.extra_params
+    subcommand_strs.append(" ".join(cmd))
+    command_str = " && ".join(subcommand_strs)
+
+    config_args = {
+        "image": params.image,
+        "ports": ports,
+        "cmd": [command_str],
+        "files": files,
+        "entrypoint": ENTRYPOINT_ARGS,
+        "private_ip_address_placeholder": _ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+        "env_vars": env_vars,
+        "labels": params.labels,
+        "tolerations": tolerations,
+        "node_selectors": node_selectors,
+    }
+
+    # configure resources
+
+    if params.min_cpu > 0:
+        config_args["min_cpu"] = params.min_cpu
+    if params.max_cpu > 0:
+        config_args["max_cpu"] = params.max_cpu
+    if params.min_mem > 0:
+        config_args["min_memory"] = params.min_mem
+    if params.max_mem > 0:
+        config_args["max_memory"] = params.max_mem
+
+    return ServiceConfig(**config_args)

--- a/src/el/op-nethermind/launcher.star
+++ b/src/el/op-nethermind/launcher.star
@@ -1,0 +1,231 @@
+_ethereum_package_el_context = import_module(
+    "github.com/ethpandaops/ethereum-package/src/el/el_context.star"
+)
+_ethereum_package_el_admin_node_info = import_module(
+    "github.com/ethpandaops/ethereum-package/src/el/el_admin_node_info.star"
+)
+
+_ethereum_package_input_parser = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/input_parser.star"
+)
+
+_ethereum_package_constants = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
+)
+
+_filter = import_module("/src/util/filter.star")
+_net = import_module("/src/util/net.star")
+
+_constants = import_module("../../package_io/constants.star")
+
+_observability = import_module("../../observability/observability.star")
+
+
+# The dirpath of the execution data directory on the client container
+_EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER = "/data/nethermind/execution-data"
+
+
+VERBOSITY_LEVELS = {
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.error: "1",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.warn: "2",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.info: "3",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.debug: "4",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.trace: "5",
+}
+
+
+def launch(
+    plan,
+    params,
+    network_params,
+    sequencer_params,
+    jwt_file,
+    deployment_output,
+    log_level,
+    persistent,
+    tolerations,
+    node_selectors,
+    bootnode_contexts,
+    observability_helper,
+    supervisors_params,
+):
+    el_log_level = _ethereum_package_input_parser.get_client_log_level_or_default(
+        params.log_level, log_level, VERBOSITY_LEVELS
+    )
+
+    config = get_service_config(
+        plan=plan,
+        params=params,
+        network_params=network_params,
+        sequencer_params=sequencer_params,
+        jwt_file=jwt_file,
+        deployment_output=deployment_output,
+        log_level=el_log_level,
+        persistent=persistent,
+        tolerations=tolerations,
+        node_selectors=node_selectors,
+        bootnode_contexts=bootnode_contexts,
+        observability_helper=observability_helper,
+        supervisors_params=supervisors_params,
+    )
+
+    service = plan.add_service(params.service_name, config)
+
+    engine_rpc_port = params.ports[_net.ENGINE_RPC_PORT_NAME]
+    rpc_port = params.ports[_net.RPC_PORT_NAME]
+    ws_port = params.ports[_net.WS_PORT_NAME]
+    rpc_url = _net.service_url(params.service_name, rpc_port)
+
+    enode = _ethereum_package_el_admin_node_info.get_enode_for_node(
+        plan, params.service_name, _net.RPC_PORT_NAME
+    )
+
+    metrics_info = _observability.new_metrics_info(observability_helper, service)
+
+    return struct(
+        service=service,
+        context=_ethereum_package_el_context.new_el_context(
+            client_name="op-nethermind",
+            enode=enode,
+            ip_addr=service.ip_address,
+            rpc_port_num=rpc_port.number,
+            ws_port_num=ws_port.number,
+            engine_rpc_port_num=engine_rpc_port.number,
+            rpc_http_url=rpc_url,
+            service_name=params.service_name,
+            el_metrics_info=[metrics_info],
+        ),
+    )
+
+
+def get_service_config(
+    plan,
+    params,
+    network_params,
+    sequencer_params,
+    jwt_file,
+    deployment_output,
+    log_level,
+    persistent,
+    tolerations,
+    node_selectors,
+    bootnode_contexts,
+    observability_helper,
+    supervisors_params,
+):
+    ports = _net.ports_to_port_specs(params.ports)
+
+    cmd = [
+        "--log=debug",
+        "--datadir={}".format(_EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER),
+        "--Init.WebSocketsEnabled=true",
+        "--JsonRpc.Enabled=true",
+        "--JsonRpc.EnabledModules=net,eth,consensus,subscribe,web3,admin,miner",
+        "--JsonRpc.Host=0.0.0.0",
+        "--JsonRpc.Port={0}".format(ports[_net.RPC_PORT_NAME].number),
+        "--JsonRpc.WebSocketsPort={0}".format(ports[_net.WS_PORT_NAME].number),
+        "--JsonRpc.EngineHost=0.0.0.0",
+        "--JsonRpc.EnginePort={0}".format(ports[_net.ENGINE_RPC_PORT_NAME].number),
+        "--Network.ExternalIp={}".format(
+            _ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER
+        ),
+        "--Network.DiscoveryPort={0}".format(
+            ports[_net.TCP_DISCOVERY_PORT_NAME].number
+        ),
+        "--Network.P2PPort={0}".format(ports[_net.TCP_DISCOVERY_PORT_NAME].number),
+        "--JsonRpc.JwtSecretFile={}".format(
+            _ethereum_package_constants.JWT_MOUNT_PATH_ON_CONTAINER
+        ),
+    ]
+
+    # configure files
+
+    files = {
+        _ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: deployment_output,
+        _ethereum_package_constants.JWT_MOUNTPOINT_ON_CLIENTS: jwt_file,
+    }
+
+    if persistent:
+        files[_EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER] = Directory(
+            persistent_key="data-{0}".format(params.service_name),
+            size=int(params.volume_size)
+            if int(params.volume_size) > 0
+            else _constants.VOLUME_SIZE[network_params.network][
+                _constants.EL_TYPE.op_nethermind + "_volume_size"
+            ],
+        )
+
+    # configure environment variables
+
+    env_vars = dict(params.extra_env_vars)
+
+    # apply customizations
+
+    if observability_helper.enabled:
+        cmd += [
+            "--Metrics.Enabled=true",
+            "--Metrics.ExposeHost=0.0.0.0",
+            "--Metrics.ExposePort={0}".format(_observability.METRICS_PORT_NUM),
+        ]
+
+        _observability.expose_metrics_port(ports)
+
+    if sequencer_params:
+        cmd.append(
+            "--Optimism.SequencerUrl={0}".format(
+                _net.service_url(
+                    sequencer_params.service_name,
+                    sequencer_params.ports[_net.RPC_PORT_NAME],
+                )
+            )
+        )
+
+    if len(bootnode_contexts) > 0:
+        cmd.append(
+            "--Discovery.Bootnodes="
+            + ",".join(
+                [
+                    ctx.enode
+                    for ctx in bootnode_contexts[
+                        : _ethereum_package_constants.MAX_ENODE_ENTRIES
+                    ]
+                ]
+            )
+        )
+
+    # TODO: Adding the chainspec and config separately as we may want to have support for public networks and shadowforks
+    cmd.append("--config=none.cfg")
+    cmd.append(
+        "--Init.ChainSpecPath="
+        + "{0}/chainspec-{1}.json".format(
+            _ethereum_package_constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER,
+            network_params.network_id,
+        ),
+    )
+
+    cmd += params.extra_params
+
+    config_args = {
+        "image": params.image,
+        "ports": ports,
+        "cmd": cmd,
+        "files": files,
+        "private_ip_address_placeholder": _ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+        "env_vars": env_vars,
+        "labels": params.labels,
+        "tolerations": tolerations,
+        "node_selectors": node_selectors,
+    }
+
+    # configure resources
+
+    if params.min_cpu > 0:
+        config_args["min_cpu"] = params.min_cpu
+    if params.max_cpu > 0:
+        config_args["max_cpu"] = params.max_cpu
+    if params.min_mem > 0:
+        config_args["min_memory"] = params.min_mem
+    if params.max_mem > 0:
+        config_args["max_memory"] = params.max_mem
+
+    return ServiceConfig(**config_args)

--- a/src/el/op-nethermind/launcher.star
+++ b/src/el/op-nethermind/launcher.star
@@ -25,7 +25,7 @@ _observability = import_module("../../observability/observability.star")
 _EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER = "/data/nethermind/execution-data"
 
 
-VERBOSITY_LEVELS = {
+_VERBOSITY_LEVELS = {
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.error: "1",
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.warn: "2",
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.info: "3",
@@ -50,7 +50,7 @@ def launch(
     supervisors_params,
 ):
     el_log_level = _ethereum_package_input_parser.get_client_log_level_or_default(
-        params.log_level, log_level, VERBOSITY_LEVELS
+        params.log_level, log_level, _VERBOSITY_LEVELS
     )
 
     config = get_service_config(

--- a/src/el/op-reth/launcher.star
+++ b/src/el/op-reth/launcher.star
@@ -27,7 +27,7 @@ _METRICS_PATH = "/metrics"
 _EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER = "/data/op-reth/execution-data"
 
 
-VERBOSITY_LEVELS = {
+_VERBOSITY_LEVELS = {
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.error: "v",
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.warn: "vv",
     _ethereum_package_constants.GLOBAL_LOG_LEVEL.info: "vvv",
@@ -52,7 +52,7 @@ def launch(
     supervisors_params,
 ):
     el_log_level = _ethereum_package_input_parser.get_client_log_level_or_default(
-        params.log_level, log_level, VERBOSITY_LEVELS
+        params.log_level, log_level, _VERBOSITY_LEVELS
     )
 
     config = get_service_config(

--- a/src/el/op-reth/launcher.star
+++ b/src/el/op-reth/launcher.star
@@ -1,0 +1,233 @@
+_ethereum_package_el_context = import_module(
+    "github.com/ethpandaops/ethereum-package/src/el/el_context.star"
+)
+_ethereum_package_el_admin_node_info = import_module(
+    "github.com/ethpandaops/ethereum-package/src/el/el_admin_node_info.star"
+)
+
+_ethereum_package_input_parser = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/input_parser.star"
+)
+
+_ethereum_package_constants = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
+)
+
+_filter = import_module("/src/util/filter.star")
+_net = import_module("/src/util/net.star")
+
+_constants = import_module("../../package_io/constants.star")
+
+_observability = import_module("../../observability/observability.star")
+
+# Paths
+_METRICS_PATH = "/metrics"
+
+# The dirpath of the execution data directory on the client container
+_EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER = "/data/op-reth/execution-data"
+
+
+VERBOSITY_LEVELS = {
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.error: "v",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.warn: "vv",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.info: "vvv",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.debug: "vvvv",
+    _ethereum_package_constants.GLOBAL_LOG_LEVEL.trace: "vvvvv",
+}
+
+
+def launch(
+    plan,
+    params,
+    network_params,
+    sequencer_params,
+    jwt_file,
+    deployment_output,
+    log_level,
+    persistent,
+    tolerations,
+    node_selectors,
+    bootnode_contexts,
+    observability_helper,
+    supervisors_params,
+):
+    el_log_level = _ethereum_package_input_parser.get_client_log_level_or_default(
+        params.log_level, log_level, VERBOSITY_LEVELS
+    )
+
+    config = get_service_config(
+        plan=plan,
+        params=params,
+        network_params=network_params,
+        sequencer_params=sequencer_params,
+        jwt_file=jwt_file,
+        deployment_output=deployment_output,
+        log_level=el_log_level,
+        persistent=persistent,
+        tolerations=tolerations,
+        node_selectors=node_selectors,
+        bootnode_contexts=bootnode_contexts,
+        observability_helper=observability_helper,
+        supervisors_params=supervisors_params,
+    )
+
+    service = plan.add_service(params.service_name, config)
+
+    engine_rpc_port = params.ports[_net.ENGINE_RPC_PORT_NAME]
+    rpc_port = params.ports[_net.RPC_PORT_NAME]
+    ws_port = params.ports[_net.WS_PORT_NAME]
+    rpc_url = _net.service_url(params.service_name, rpc_port)
+
+    enode = _ethereum_package_el_admin_node_info.get_enode_for_node(
+        plan, params.service_name, _net.RPC_PORT_NAME
+    )
+
+    metrics_info = _observability.new_metrics_info(
+        observability_helper, service, _METRICS_PATH
+    )
+
+    return struct(
+        service=service,
+        context=_ethereum_package_el_context.new_el_context(
+            client_name="reth",
+            enode=enode,
+            ip_addr=service.ip_address,
+            rpc_port_num=rpc_port.number,
+            ws_port_num=ws_port.number,
+            engine_rpc_port_num=engine_rpc_port.number,
+            rpc_http_url=rpc_url,
+            service_name=params.service_name,
+            el_metrics_info=[metrics_info],
+        ),
+    )
+
+
+def get_service_config(
+    plan,
+    params,
+    network_params,
+    sequencer_params,
+    jwt_file,
+    deployment_output,
+    log_level,
+    persistent,
+    tolerations,
+    node_selectors,
+    bootnode_contexts,
+    observability_helper,
+    supervisors_params,
+):
+    ports = _net.ports_to_port_specs(params.ports)
+
+    cmd = [
+        "node",
+        "-{0}".format(log_level),
+        "--datadir={}".format(_EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER),
+        "--chain={0}".format(
+            network_params.network
+            if network_params.network in _ethereum_package_constants.PUBLIC_NETWORKS
+            else _ethereum_package_constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER
+            + "/genesis-{0}.json".format(network_params.network_id)
+        ),
+        "--http",
+        "--http.port={0}".format(ports[_net.RPC_PORT_NAME].number),
+        "--http.addr=0.0.0.0",
+        "--http.corsdomain=*",
+        # WARNING: The admin info endpoint is enabled so that we can easily get ENR/enode, which means
+        #  that users should NOT store private information in these Kurtosis nodes!
+        "--http.api=admin,net,eth,web3,debug,trace",
+        "--ws",
+        "--ws.addr=0.0.0.0",
+        "--ws.port={0}".format(ports[_net.WS_PORT_NAME].number),
+        "--ws.api=net,eth",
+        "--ws.origins=*",
+        "--nat=extip:{}".format(
+            _ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER
+        ),
+        "--authrpc.port={0}".format(ports[_net.ENGINE_RPC_PORT_NAME].number),
+        "--authrpc.jwtsecret={}".format(
+            _ethereum_package_constants.JWT_MOUNT_PATH_ON_CONTAINER
+        ),
+        "--authrpc.addr=0.0.0.0",
+        "--discovery.port={0}".format(ports[_net.TCP_DISCOVERY_PORT_NAME].number),
+        "--port={0}".format(ports[_net.TCP_DISCOVERY_PORT_NAME].number),
+        "--rpc.eth-proof-window=302400",
+    ]
+
+    # configure files
+
+    files = {
+        _ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: deployment_output,
+        _ethereum_package_constants.JWT_MOUNTPOINT_ON_CLIENTS: jwt_file,
+    }
+
+    if persistent:
+        files[_EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER] = Directory(
+            persistent_key="data-{0}".format(params.service_name),
+            size=int(params.volume_size)
+            if int(params.volume_size) > 0
+            else _constants.VOLUME_SIZE[network_params.network][
+                _constants.EL_TYPE.op_reth + "_volume_size"
+            ],
+        )
+
+    # configure environment variables
+
+    env_vars = dict(params.extra_env_vars)
+
+    # apply customizations
+
+    if observability_helper.enabled:
+        cmd.append("--metrics=0.0.0.0:{0}".format(_observability.METRICS_PORT_NUM))
+
+        _observability.expose_metrics_port(ports)
+
+    if sequencer_params:
+        cmd.append(
+            "--rollup.sequencer-http={0}".format(
+                _net.service_url(
+                    sequencer_params.service_name,
+                    sequencer_params.ports[_net.RPC_PORT_NAME],
+                )
+            )
+        )
+
+    if len(bootnode_contexts) > 0:
+        cmd.append(
+            "--bootnodes="
+            + ",".join(
+                [
+                    ctx.enode
+                    for ctx in bootnode_contexts[
+                        : _ethereum_package_constants.MAX_ENODE_ENTRIES
+                    ]
+                ]
+            )
+        )
+
+    cmd += params.extra_params
+
+    config_args = {
+        "image": params.image,
+        "ports": ports,
+        "cmd": cmd,
+        "files": files,
+        "private_ip_address_placeholder": _ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+        "env_vars": env_vars,
+        "labels": params.labels,
+        "tolerations": tolerations,
+        "node_selectors": node_selectors,
+    }
+
+    # configure resources
+
+    if params.min_cpu > 0:
+        config_args["min_cpu"] = params.min_cpu
+    if params.max_cpu > 0:
+        config_args["max_cpu"] = params.max_cpu
+    if params.min_mem > 0:
+        config_args["min_memory"] = params.min_mem
+    if params.max_mem > 0:
+        config_args["max_memory"] = params.max_mem
+
+    return ServiceConfig(**config_args)

--- a/src/l2/launcher.star
+++ b/src/l2/launcher.star
@@ -1,0 +1,193 @@
+_cl_launcher = import_module("./participant/cl/launcher.star")
+_el_launcher = import_module("./participant/el/launcher.star")
+_da_server_launcher = import_module("/src/da/da-server/launcher.star")
+_op_batcher_launcher = import_module("/src/batcher/op-batcher/launcher.star")
+_op_proposer_launcher = import_module("/src/proposer/op-proposer/launcher.star")
+_proxyd_launcher = import_module("/src/proxyd/launcher.star")
+_tx_fuzzer_launcher = import_module("/src/tx-fuzzer/launcher.star")
+
+_selectors = import_module("./selectors.star")
+
+
+def launch(
+    plan,
+    params,
+    supervisors_params,
+    jwt_file,
+    deployment_output,
+    l1_config_env_vars,
+    log_level,
+    persistent,
+    tolerations,
+    node_selectors,
+    observability_helper,
+):
+    network_params = params.network_params
+    network_name = network_params.name
+    network_log_prefix = "L2 network {}".format(network_name)
+
+    plan.print(
+        "{}: Launching (network ID {})".format(
+            network_log_prefix, network_params.network_id
+        )
+    )
+
+    _launch_da_maybe(
+        plan=plan, da_params=params.da_params, log_prefix=network_log_prefix
+    )
+
+    #
+    # Launch CL & EL clients
+    #
+
+    participants = []
+
+    # Here we create a selector function that will take participant params and return sequencer params for that participant
+    #
+    # Encpasulating the params.participants in a curried function like this seems nicer than having to pass them around
+    get_sequencer_params_for = _selectors.create_get_sequencer_params_for(
+        params.participants
+    )
+
+    for participant_params in params.participants:
+        participant_name = participant_params.name
+        participant_log_prefix = "{}: Participant {}".format(
+            network_log_prefix, participant_name
+        )
+
+        plan.print("{}: Launching".format(participant_log_prefix))
+
+        # We let the user know if this node is a sequencer
+        is_sequencer = _selectors.is_sequencer(participant_params)
+        if is_sequencer:
+            plan.print("{}: Participant is a sequencer".format(participant_log_prefix))
+
+        # Now we get the sequencer params
+        #
+        # If the node itself is a sequencer, we don't want it to refer to itself as a sequencer
+        # so we pass None instead
+        sequencer_params = (
+            None if is_sequencer else get_sequencer_params_for(participant_params)
+        )
+
+        #
+        # Launch the EL client
+        #
+
+        el_params = participant_params.el
+        bootnode_contexts = [p.el.context for p in participants]
+
+        plan.print(
+            "{}: Launching EL ({})".format(participant_log_prefix, el_params.type)
+        )
+
+        el = _el_launcher.launch(
+            plan=plan,
+            params=el_params,
+            network_params=network_params,
+            sequencer_params=sequencer_params,
+            jwt_file=jwt_file,
+            deployment_output=deployment_output,
+            log_level=log_level,
+            persistent=persistent,
+            tolerations=tolerations,
+            node_selectors=node_selectors,
+            bootnode_contexts=bootnode_contexts,
+            observability_helper=observability_helper,
+            # FIXME
+            supervisors_params=[],
+        )
+
+        #
+        # Launch the CL client
+        #
+
+        cl_params = participant_params.cl
+        cl_contexts = [p.cl.context for p in participants]
+
+        plan.print(
+            "{}: Launching CL ({})".format(participant_log_prefix, cl_params.type)
+        )
+
+        cl = _cl_launcher.launch(
+            plan=plan,
+            params=cl_params,
+            network_params=network_params,
+            da_params=params.da_params,
+            supervisors_params=supervisors_params,
+            is_sequencer=is_sequencer,
+            el_context=el.context,
+            cl_contexts=cl_contexts,
+            jwt_file=jwt_file,
+            deployment_output=deployment_output,
+            l1_config_env_vars=l1_config_env_vars,
+            log_level=log_level,
+            persistent=persistent,
+            tolerations=tolerations,
+            node_selectors=node_selectors,
+            observability_helper=observability_helper,
+        )
+
+        # Add the EL/CL pair to the list of launched participants
+        participants.append(struct(el=el, cl=cl, name=participant_name))
+
+    _launch_proxyd_maybe(
+        plan=plan,
+        proxyd_params=params.proxyd_params,
+        participants=participants,
+        network_params=network_params,
+        observability_helper=observability_helper,
+        log_prefix=network_log_prefix,
+    )
+    _launch_tx_fuzzer_maybe(
+        plan=plan,
+        tx_fuzzer_params=params.tx_fuzzer_params,
+        participants=participants,
+        node_selectors=node_selectors,
+        log_prefix=network_log_prefix,
+    )
+
+
+def _launch_da_maybe(plan, da_params, log_prefix):
+    if da_params:
+        plan.print("{}: Launching DA".format(log_prefix))
+
+        _da_server_launcher.launch(
+            plan=plan,
+            params=da_params,
+        ).context
+
+        plan.print("{}: Successfully launched DA".format(log_prefix))
+
+
+def _launch_proxyd_maybe(
+    plan, proxyd_params, participants, network_params, observability_helper, log_prefix
+):
+    if proxyd_params:
+        plan.print("{}: Launching proxyd".format(log_prefix))
+
+        _proxyd_launcher.launch(
+            plan=plan,
+            params=proxyd_params,
+            network_params=network_params,
+            observability_helper=observability_helper,
+        )
+
+        plan.print("{}: Successfully launched proxyd".format(log_prefix))
+
+
+def _launch_tx_fuzzer_maybe(
+    plan, tx_fuzzer_params, participants, node_selectors, log_prefix
+):
+    if tx_fuzzer_params:
+        plan.print("{}: Launching tx fuzzer".format(log_prefix))
+
+        _tx_fuzzer_launcher.launch(
+            plan=plan,
+            params=tx_fuzzer_params,
+            # FIXME
+            el_context=participants[0].el.context,
+            node_selectors=node_selectors,
+        )
+
+        plan.print("{}: Successfully launched tx fuzzer".format(log_prefix))

--- a/src/l2/participant/el/launcher.star
+++ b/src/l2/participant/el/launcher.star
@@ -1,0 +1,124 @@
+_observability = import_module("/src/observability/observability.star")
+_op_besu_launcher = import_module("/src/el/op-besu/launcher.star")
+_op_erigon_launcher = import_module("/src/el/op-erigon/launcher.star")
+_op_geth_launcher = import_module("/src/el/op-geth/launcher.star")
+_op_nethermind_launcher = import_module("/src/el/op-nethermind/launcher.star")
+_op_reth_launcher = import_module("/src/el/op-reth/launcher.star")
+
+_filter = import_module("/src/util/filter.star")
+
+
+def launch(
+    plan,
+    params,
+    network_params,
+    sequencer_params,
+    jwt_file,
+    deployment_output,
+    log_level,
+    persistent,
+    tolerations,
+    node_selectors,
+    bootnode_contexts,
+    observability_helper,
+    supervisors_params,
+):
+    el = None
+
+    if params.type == "op-besu":
+        el = _op_besu_launcher.launch(
+            plan=plan,
+            params=params,
+            network_params=network_params,
+            sequencer_params=sequencer_params,
+            jwt_file=jwt_file,
+            deployment_output=deployment_output,
+            log_level=log_level,
+            persistent=persistent,
+            tolerations=tolerations,
+            node_selectors=node_selectors,
+            bootnode_contexts=bootnode_contexts,
+            observability_helper=observability_helper,
+            supervisors_params=supervisors_params,
+        )
+    elif params.type == "op-erigon":
+        el = _op_erigon_launcher.launch(
+            plan=plan,
+            params=params,
+            network_params=network_params,
+            sequencer_params=sequencer_params,
+            jwt_file=jwt_file,
+            deployment_output=deployment_output,
+            log_level=log_level,
+            persistent=persistent,
+            tolerations=tolerations,
+            node_selectors=node_selectors,
+            bootnode_contexts=bootnode_contexts,
+            observability_helper=observability_helper,
+            supervisors_params=supervisors_params,
+        )
+    elif params.type == "op-geth":
+        el = _op_geth_launcher.launch(
+            plan=plan,
+            params=params,
+            network_params=network_params,
+            sequencer_params=sequencer_params,
+            jwt_file=jwt_file,
+            deployment_output=deployment_output,
+            log_level=log_level,
+            persistent=persistent,
+            tolerations=tolerations,
+            node_selectors=node_selectors,
+            bootnode_contexts=bootnode_contexts,
+            observability_helper=observability_helper,
+            supervisors_params=supervisors_params,
+        )
+    elif params.type == "op-nethermind":
+        el = _op_nethermind_launcher.launch(
+            plan=plan,
+            params=params,
+            network_params=network_params,
+            sequencer_params=sequencer_params,
+            jwt_file=jwt_file,
+            deployment_output=deployment_output,
+            log_level=log_level,
+            persistent=persistent,
+            tolerations=tolerations,
+            node_selectors=node_selectors,
+            bootnode_contexts=bootnode_contexts,
+            observability_helper=observability_helper,
+            supervisors_params=supervisors_params,
+        )
+    elif params.type == "op-reth":
+        el = _op_geth_launcher.launch(
+            plan=plan,
+            params=params,
+            network_params=network_params,
+            sequencer_params=sequencer_params,
+            jwt_file=jwt_file,
+            deployment_output=deployment_output,
+            log_level=log_level,
+            persistent=persistent,
+            tolerations=tolerations,
+            node_selectors=node_selectors,
+            bootnode_contexts=bootnode_contexts,
+            observability_helper=observability_helper,
+            supervisors_params=supervisors_params,
+        )
+    else:
+        # This should never happen since we asserted that the type is valid in the input parser
+        # but in untyped/imperfectly typed languages we are doomed to repreat ourselves
+        # or resort to implicit knowledge
+        fail("Unknown EL type: {}".format(params.type))
+
+    # Register metrics
+    for metrics_info in _filter.remove_none(el.context.el_metrics_info):
+        _observability.register_node_metrics_job(
+            observability_helper,
+            params.type,
+            "execution",
+            network_params.network,
+            metrics_info,
+        )
+
+    return el

--- a/src/l2/selectors.star
+++ b/src/l2/selectors.star
@@ -1,5 +1,35 @@
+_filter = import_module("/src/util/filter.star")
+
+
 def get_sequencers_params(participants_params):
     return [p for p in participants_params if is_sequencer(p)]
+
+
+def create_get_sequencer_params_for(participants_params):
+    def get_sequencer_params_for(participant_params):
+        if not participant_params.sequencer:
+            fail(
+                "Empty sequencer property on participant params for {} - this property should always contain a string name of the associated sequencer".format(
+                    participant_params.name
+                )
+            )
+
+        sequencer_params = _filter.first(
+            get_sequencers_params(participants_params),
+            lambda p: p.name == participant_params.sequencer,
+        )
+
+        return (
+            sequencer_params
+            if sequencer_params
+            else fail(
+                "Failed to get sequencer for {}: missing sequencer {}".format(
+                    participant_params.name, participant_params.sequencer
+                )
+            )
+        )
+
+    return get_sequencer_params_for
 
 
 def is_sequencer(participant_params):

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -28,11 +28,11 @@ CLIENT_TYPES = struct(
 )
 VOLUME_SIZE = {
     "kurtosis": {
-        "op_geth_volume_size": 5000,  # 5GB
-        "op_erigon_volume_size": 3000,  # 3GB
-        "op_nethermind_volume_size": 3000,  # 3GB
-        "op_besu_volume_size": 3000,  # 3GB
-        "op_reth_volume_size": 3000,  # 3GB
+        "op-geth_volume_size": 5000,  # 5GB
+        "op-erigon_volume_size": 3000,  # 3GB
+        "op-nethermind_volume_size": 3000,  # 3GB
+        "op-besu_volume_size": 3000,  # 3GB
+        "op-reth_volume_size": 3000,  # 3GB
         "op-node_volume_size": 1000,  # 1GB
         "hildr_volume_size": 1000,  # 1GB
         "kona-node_volume_size": 1000,  # 1GB

--- a/test/l2/participant/el/launcher_test.star
+++ b/test/l2/participant/el/launcher_test.star
@@ -1,0 +1,424 @@
+_ethereum_package_constants = import_module(
+    "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
+)
+_input_parser = import_module("/src/package_io/input_parser.star")
+_l2_input_parser = import_module("/src/l2/input_parser.star")
+_observability = import_module("/src/observability/observability.star")
+_registry = import_module("/src/package_io/registry.star")
+_util = import_module("/src/util.star")
+
+_el_launcher = import_module("/src/l2/participant/el/launcher.star")
+
+_default_registry = _registry.Registry()
+_default_deployment_output = "/deployment.output.json"
+_default_jwt_file = "/jwt.file"
+_default_l1_config_env_vars = {
+    "CL_RPC_URL": "http://l1.cl.rpc",
+    "L1_RPC_URL": "http://l1.rpc",
+    "L1_WS_URL": "wss://l1.rpc",
+    "L1_RPC_KIND": "very.kind",
+}
+_default_log_level = _ethereum_package_constants.GLOBAL_LOG_LEVEL.info
+_default_bootnode_contexts = [
+    struct(
+        enr="enr:001",
+        enode="enode:001",
+    )
+]
+
+
+def test_l2_participant_el_launcher_op_besu(plan):
+    # We'll need the observability params from the legacy parser
+    legacy_params = _input_parser.input_parser(
+        plan=plan,
+        input_args={},
+    )
+    observability_helper = _observability.make_helper(legacy_params.observability)
+
+    l2s_params = _l2_input_parser.parse(
+        {
+            "network0": {
+                "participants": {
+                    "node0": {
+                        "el": {
+                            "type": "op-besu",
+                        }
+                    }
+                }
+            }
+        },
+        registry=_default_registry,
+    )
+
+    l2_params = l2s_params[0]
+    participant_params = l2_params.participants[0]
+    el_params = participant_params.el
+
+    result = _el_launcher.launch(
+        plan=plan,
+        params=el_params,
+        network_params=l2_params.network_params,
+        supervisors_params=[],
+        sequencer_params=None,
+        bootnode_contexts=_default_bootnode_contexts,
+        jwt_file=_default_jwt_file,
+        deployment_output=_default_deployment_output,
+        log_level=_default_log_level,
+        persistent=True,
+        tolerations=[],
+        node_selectors={},
+        observability_helper=observability_helper,
+    )
+
+    service = plan.get_service(el_params.service_name)
+    service_config = kurtosistest.get_service_config(el_params.service_name)
+
+    expect.eq(
+        service_config.cmd,
+        [
+            "besu",
+            "--genesis-file=/network-configs/genesis-2151908.json",
+            "--network-id=2151908",
+            "--data-path=/data/geth/execution-data",
+            "--host-allowlist=*",
+            "--rpc-http-enabled=true",
+            "--rpc-http-host=0.0.0.0",
+            "--rpc-http-port=8545",
+            "--rpc-http-api=ADMIN,CLIQUE,ETH,NET,DEBUG,TXPOOL,ENGINE,TRACE,WEB3,MINER",
+            "--rpc-http-cors-origins=*",
+            "--rpc-http-max-active-connections=300",
+            "--rpc-ws-enabled=true",
+            "--rpc-ws-host=0.0.0.0",
+            "--rpc-ws-port=8546",
+            "--rpc-ws-api=ADMIN,CLIQUE,ETH,NET,DEBUG,TXPOOL,ENGINE,TRACE,WEB3,MINER",
+            "--p2p-enabled=true",
+            "--p2p-host=KURTOSIS_IP_ADDR_PLACEHOLDER",
+            "--p2p-port=30303",
+            "--engine-rpc-enabled=true",
+            "--engine-jwt-secret=/jwt/jwtsecret",
+            "--engine-host-allowlist=*",
+            "--engine-rpc-port=8551",
+            "--sync-mode=FULL",
+            "--bonsai-limit-trie-logs-enabled=false",
+            "--version-compatibility-protection=false",
+            "--metrics",
+            "--metrics.addr=0.0.0.0",
+            "--metrics.port=9001",
+            "--bootnodes=enode:001",
+        ],
+    )
+    expect.eq(
+        service_config.labels,
+        {"op.kind": "el", "op.network.id": "2151908", "op.el.type": "op-besu"},
+    )
+    expect.eq(
+        service_config.files["/network-configs"].artifact_names,
+        [_default_deployment_output],
+    )
+    expect.eq(
+        service_config.files["/jwt"].artifact_names,
+        [_default_jwt_file],
+    )
+
+
+def test_l2_participant_el_launcher_op_erigon(plan):
+    # We'll need the observability params from the legacy parser
+    legacy_params = _input_parser.input_parser(
+        plan=plan,
+        input_args={},
+    )
+    observability_helper = _observability.make_helper(legacy_params.observability)
+
+    l2s_params = _l2_input_parser.parse(
+        {
+            "network0": {
+                "participants": {
+                    "node0": {
+                        "el": {
+                            "type": "op-erigon",
+                        }
+                    }
+                }
+            }
+        },
+        registry=_default_registry,
+    )
+
+    l2_params = l2s_params[0]
+    participant_params = l2_params.participants[0]
+    el_params = participant_params.el
+
+    sequencer_private_key_mock = "sequencer_private_key"
+    kurtosistest.mock(_util, "read_network_config_value").mock_return_value(
+        sequencer_private_key_mock
+    )
+
+    result = _el_launcher.launch(
+        plan=plan,
+        params=el_params,
+        network_params=l2_params.network_params,
+        supervisors_params=[],
+        sequencer_params=None,
+        jwt_file=_default_jwt_file,
+        deployment_output=_default_deployment_output,
+        bootnode_contexts=_default_bootnode_contexts,
+        log_level=_default_log_level,
+        persistent=True,
+        tolerations=[],
+        node_selectors={},
+        observability_helper=observability_helper,
+    )
+
+    service = plan.get_service(el_params.service_name)
+    service_config = kurtosistest.get_service_config(el_params.service_name)
+
+    expect.eq(
+        service_config.cmd,
+        [
+            "erigon init --datadir=/data/op-erigon/execution-data /network-configs/genesis-2151908.json && erigon --datadir=/data/op-erigon/execution-data --networkid=2151908 --http --http.port=8545 --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.api=admin,engine,net,eth,web3,debug,miner --ws --ws.port=8546 --allow-insecure-unlock --authrpc.port=8551 --authrpc.addr=0.0.0.0 --authrpc.vhosts=* --authrpc.jwtsecret=/jwt/jwtsecret --nat=extip:KURTOSIS_IP_ADDR_PLACEHOLDER --rpc.allow-unprotected-txs --port=30303 --metrics --metrics.addr=0.0.0.0 --metrics.port=9001 --bootnodes=enode:001"
+        ],
+    )
+    expect.eq(
+        service_config.labels,
+        {"op.kind": "el", "op.network.id": "2151908", "op.el.type": "op-erigon"},
+    )
+    expect.eq(
+        service_config.files["/network-configs"].artifact_names,
+        [_default_deployment_output],
+    )
+    expect.eq(
+        service_config.files["/jwt"].artifact_names,
+        [_default_jwt_file],
+    )
+
+
+def test_l2_participant_el_launcher_op_geth(plan):
+    # We'll need the observability params from the legacy parser
+    legacy_params = _input_parser.input_parser(
+        plan=plan,
+        input_args={},
+    )
+    observability_helper = _observability.make_helper(legacy_params.observability)
+
+    l2s_params = _l2_input_parser.parse(
+        {
+            "network0": {
+                "participants": {
+                    "node0": {
+                        "el": {
+                            "type": "op-geth",
+                        }
+                    }
+                }
+            }
+        },
+        registry=_default_registry,
+    )
+
+    l2_params = l2s_params[0]
+    participant_params = l2_params.participants[0]
+    el_params = participant_params.el
+
+    sequencer_private_key_mock = "sequencer_private_key"
+    kurtosistest.mock(_util, "read_network_config_value").mock_return_value(
+        sequencer_private_key_mock
+    )
+
+    result = _el_launcher.launch(
+        plan=plan,
+        params=el_params,
+        network_params=l2_params.network_params,
+        supervisors_params=[],
+        sequencer_params=None,
+        jwt_file=_default_jwt_file,
+        deployment_output=_default_deployment_output,
+        bootnode_contexts=_default_bootnode_contexts,
+        log_level=_default_log_level,
+        persistent=True,
+        tolerations=[],
+        node_selectors={},
+        observability_helper=observability_helper,
+    )
+
+    service = plan.get_service(el_params.service_name)
+    service_config = kurtosistest.get_service_config(el_params.service_name)
+
+    expect.eq(
+        service_config.cmd,
+        [
+            "geth init --datadir=/data/geth/execution-data --state.scheme=hash /network-configs/genesis-2151908.json && geth --networkid=2151908 --datadir=/data/geth/execution-data --gcmode=archive --state.scheme=hash --http --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.api=admin,engine,net,eth,web3,debug,miner --ws --ws.addr=0.0.0.0 --ws.port=8546 --ws.api=admin,engine,net,eth,web3,debug,miner --ws.origins=* --allow-insecure-unlock --authrpc.port=8551 --authrpc.addr=0.0.0.0 --authrpc.vhosts=* --authrpc.jwtsecret=/jwt/jwtsecret --syncmode=full --nat=extip:KURTOSIS_IP_ADDR_PLACEHOLDER --rpc.allow-unprotected-txs --discovery.port=30303 --port=30303 --metrics --metrics.addr=0.0.0.0 --metrics.port=9001 --bootnodes=enode:001"
+        ],
+    )
+    expect.eq(
+        service_config.labels,
+        {"op.kind": "el", "op.network.id": "2151908", "op.el.type": "op-geth"},
+    )
+    expect.eq(
+        service_config.files["/network-configs"].artifact_names,
+        [_default_deployment_output],
+    )
+    expect.eq(
+        service_config.files["/jwt"].artifact_names,
+        [_default_jwt_file],
+    )
+
+
+def test_l2_participant_el_launcher_op_nethermind(plan):
+    # We'll need the observability params from the legacy parser
+    legacy_params = _input_parser.input_parser(
+        plan=plan,
+        input_args={},
+    )
+    observability_helper = _observability.make_helper(legacy_params.observability)
+
+    l2s_params = _l2_input_parser.parse(
+        {
+            "network0": {
+                "participants": {
+                    "node0": {
+                        "el": {
+                            "type": "op-nethermind",
+                        }
+                    }
+                }
+            }
+        },
+        registry=_default_registry,
+    )
+
+    l2_params = l2s_params[0]
+    participant_params = l2_params.participants[0]
+    el_params = participant_params.el
+
+    sequencer_private_key_mock = "sequencer_private_key"
+    kurtosistest.mock(_util, "read_network_config_value").mock_return_value(
+        sequencer_private_key_mock
+    )
+
+    result = _el_launcher.launch(
+        plan=plan,
+        params=el_params,
+        network_params=l2_params.network_params,
+        supervisors_params=[],
+        sequencer_params=None,
+        jwt_file=_default_jwt_file,
+        deployment_output=_default_deployment_output,
+        bootnode_contexts=_default_bootnode_contexts,
+        log_level=_default_log_level,
+        persistent=True,
+        tolerations=[],
+        node_selectors={},
+        observability_helper=observability_helper,
+    )
+
+    service = plan.get_service(el_params.service_name)
+    service_config = kurtosistest.get_service_config(el_params.service_name)
+
+    expect.eq(
+        service_config.cmd,
+        [
+            "--log=debug",
+            "--datadir=/data/nethermind/execution-data",
+            "--Init.WebSocketsEnabled=true",
+            "--JsonRpc.Enabled=true",
+            "--JsonRpc.EnabledModules=net,eth,consensus,subscribe,web3,admin,miner",
+            "--JsonRpc.Host=0.0.0.0",
+            "--JsonRpc.Port=8545",
+            "--JsonRpc.WebSocketsPort=8546",
+            "--JsonRpc.EngineHost=0.0.0.0",
+            "--JsonRpc.EnginePort=8551",
+            "--Network.ExternalIp=KURTOSIS_IP_ADDR_PLACEHOLDER",
+            "--Network.DiscoveryPort=30303",
+            "--Network.P2PPort=30303",
+            "--JsonRpc.JwtSecretFile=/jwt/jwtsecret",
+            "--Metrics.Enabled=true",
+            "--Metrics.ExposeHost=0.0.0.0",
+            "--Metrics.ExposePort=9001",
+            "--Discovery.Bootnodes=enode:001",
+            "--config=none.cfg",
+            "--Init.ChainSpecPath=/network-configs/chainspec-2151908.json",
+        ],
+    )
+    expect.eq(
+        service_config.labels,
+        {"op.kind": "el", "op.network.id": "2151908", "op.el.type": "op-nethermind"},
+    )
+    expect.eq(
+        service_config.files["/network-configs"].artifact_names,
+        [_default_deployment_output],
+    )
+    expect.eq(
+        service_config.files["/jwt"].artifact_names,
+        [_default_jwt_file],
+    )
+
+
+def test_l2_participant_el_launcher_op_reth(plan):
+    # We'll need the observability params from the legacy parser
+    legacy_params = _input_parser.input_parser(
+        plan=plan,
+        input_args={},
+    )
+    observability_helper = _observability.make_helper(legacy_params.observability)
+
+    l2s_params = _l2_input_parser.parse(
+        {
+            "network0": {
+                "participants": {
+                    "node0": {
+                        "el": {
+                            "type": "op-reth",
+                        }
+                    }
+                }
+            }
+        },
+        registry=_default_registry,
+    )
+
+    l2_params = l2s_params[0]
+    participant_params = l2_params.participants[0]
+    el_params = participant_params.el
+
+    sequencer_private_key_mock = "sequencer_private_key"
+    kurtosistest.mock(_util, "read_network_config_value").mock_return_value(
+        sequencer_private_key_mock
+    )
+
+    result = _el_launcher.launch(
+        plan=plan,
+        params=el_params,
+        network_params=l2_params.network_params,
+        supervisors_params=[],
+        sequencer_params=None,
+        jwt_file=_default_jwt_file,
+        deployment_output=_default_deployment_output,
+        bootnode_contexts=_default_bootnode_contexts,
+        log_level=_default_log_level,
+        persistent=True,
+        tolerations=[],
+        node_selectors={},
+        observability_helper=observability_helper,
+    )
+
+    service = plan.get_service(el_params.service_name)
+    service_config = kurtosistest.get_service_config(el_params.service_name)
+
+    expect.eq(
+        service_config.cmd,
+        [
+            "geth init --datadir=/data/geth/execution-data --state.scheme=hash /network-configs/genesis-2151908.json && geth --networkid=2151908 --datadir=/data/geth/execution-data --gcmode=archive --state.scheme=hash --http --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.api=admin,engine,net,eth,web3,debug,miner --ws --ws.addr=0.0.0.0 --ws.port=8546 --ws.api=admin,engine,net,eth,web3,debug,miner --ws.origins=* --allow-insecure-unlock --authrpc.port=8551 --authrpc.addr=0.0.0.0 --authrpc.vhosts=* --authrpc.jwtsecret=/jwt/jwtsecret --syncmode=full --nat=extip:KURTOSIS_IP_ADDR_PLACEHOLDER --rpc.allow-unprotected-txs --discovery.port=30303 --port=30303 --metrics --metrics.addr=0.0.0.0 --metrics.port=9001 --bootnodes=enode:001"
+        ],
+    )
+    expect.eq(
+        service_config.labels,
+        {"op.kind": "el", "op.network.id": "2151908", "op.el.type": "op-reth"},
+    )
+    expect.eq(
+        service_config.files["/network-configs"].artifact_names,
+        [_default_deployment_output],
+    )
+    expect.eq(
+        service_config.files["/jwt"].artifact_names,
+        [_default_jwt_file],
+    )

--- a/test/l2/selectors_test.star
+++ b/test/l2/selectors_test.star
@@ -20,3 +20,54 @@ def test_l2_selectors_get_sequencers_params(plan):
 def test_l2_selectors_is_sequencer(plan):
     expect.eq(_selectors.is_sequencer(struct(sequencer="node0", name="node0")), True)
     expect.eq(_selectors.is_sequencer(struct(sequencer="node0", name="node1")), False)
+
+
+def test_l2_selectors_create_get_sequencer_params_for_empty(plan):
+    get_sequencer_params_for = _selectors.create_get_sequencer_params_for([])
+
+    expect.fails(
+        lambda: get_sequencer_params_for(
+            struct(sequencer="a lot", name="node that's there")
+        ),
+        "Failed to get sequencer for node that's there: missing sequencer a lot",
+    )
+
+
+def test_l2_selectors_create_get_sequencer_params_for_no_sequencer(plan):
+    get_sequencer_params_for = _selectors.create_get_sequencer_params_for([])
+
+    expect.fails(
+        lambda: get_sequencer_params_for(
+            struct(sequencer="", name="node that's there")
+        ),
+        "Empty sequencer property on participant params for node that's there - this property should always contain a string name of the associated sequencer",
+    )
+    expect.fails(
+        lambda: get_sequencer_params_for(
+            struct(sequencer=None, name="node that's there")
+        ),
+        "Empty sequencer property on participant params for node that's there - this property should always contain a string name of the associated sequencer",
+    )
+
+
+def test_l2_selectors_create_get_sequencer_params_for_not_a_sequencer(plan):
+    node_params = struct(name="who's not a sequencer", sequencer="somebody else")
+    expect.true(not _selectors.is_sequencer(node_params))
+
+    get_sequencer_params_for = _selectors.create_get_sequencer_params_for([node_params])
+
+    expect.fails(
+        lambda: get_sequencer_params_for(
+            struct(sequencer="who's not a sequencer", name="node that's there")
+        ),
+        "Failed to get sequencer for node that's there: missing sequencer who's not a sequencer",
+    )
+
+
+def test_l2_selectors_create_get_sequencer_params_for_a_sequencer(plan):
+    node_params = struct(name="a sequencer", sequencer="a sequencer")
+    expect.true(_selectors.is_sequencer(node_params))
+
+    get_sequencer_params_for = _selectors.create_get_sequencer_params_for([node_params])
+
+    expect.eq(get_sequencer_params_for(struct(sequencer="a sequencer")), node_params)


### PR DESCRIPTION
**Description**

- Adds new launchers (alongside the old ones, until we migrate the whole thing) for EL nodes. The contents of these launchers have been left as they were, with the changes being only the dynamic ports coming from the parsed params
- Adds a helper selector utility to get sequencer params from participant params. We'll need this since the EL clients receive a CLI flag pointing to their sequencer's URL