### PR TITLE
chore: Support multiple sequencers: Provide default network if nothing was set [22/N]

### DIFF
--- a/src/l2/input_parser.star
+++ b/src/l2/input_parser.star
@@ -51,7 +51,13 @@ def parse(args, registry):
                     l2_id_generator,
                     registry,
                 )
-                for l2_name, l2_args in (args or {}).items()
+                for l2_name, l2_args in (
+                    args
+                    or {
+                        # If we get no networks, we supply a default one
+                        "opkurtosis": None,
+                    }
+                ).items()
             ]
         )
     )

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -13,11 +13,11 @@ _default_registry = _registry.Registry()
 def test_l2_input_parser_empty(plan):
     expect.eq(
         input_parser.parse(None, _default_registry),
-        [],
+        input_parser.parse({"opkurtosis": None}, _default_registry),
     )
     expect.eq(
         input_parser.parse({}, _default_registry),
-        [],
+        input_parser.parse({"opkurtosis": None}, _default_registry),
     )
 
 


### PR DESCRIPTION
**Description**

If there are no networks defined in the args file, we'll create a default network called `opkurtosis`