### PR TITLE
chore: Support multiple sequencers: Typos in new EL launchers [23/N]

### DIFF
--- a/src/el/op-erigon/launcher.star
+++ b/src/el/op-erigon/launcher.star
@@ -192,8 +192,8 @@ def get_service_config(
         cmd.append(
             "--rollup.sequencerhttp={0}".format(
                 _net.service_url(
-                    sequencer_params.service_name,
-                    sequencer_params.ports[_net.RPC_PORT_NAME],
+                    sequencer_params.el.service_name,
+                    sequencer_params.el.ports[_net.RPC_PORT_NAME],
                 )
             )
         )

--- a/src/el/op-nethermind/launcher.star
+++ b/src/el/op-nethermind/launcher.star
@@ -174,8 +174,8 @@ def get_service_config(
         cmd.append(
             "--Optimism.SequencerUrl={0}".format(
                 _net.service_url(
-                    sequencer_params.service_name,
-                    sequencer_params.ports[_net.RPC_PORT_NAME],
+                    sequencer_params.el.service_name,
+                    sequencer_params.el.ports[_net.RPC_PORT_NAME],
                 )
             )
         )

--- a/src/el/op-reth/launcher.star
+++ b/src/el/op-reth/launcher.star
@@ -186,8 +186,8 @@ def get_service_config(
         cmd.append(
             "--rollup.sequencer-http={0}".format(
                 _net.service_url(
-                    sequencer_params.service_name,
-                    sequencer_params.ports[_net.RPC_PORT_NAME],
+                    sequencer_params.el.service_name,
+                    sequencer_params.el.ports[_net.RPC_PORT_NAME],
                 )
             )
         )


### PR DESCRIPTION
**Description**

Lint failed to catch these typos unfortunately and the launchers are still not connected.