### PR TITLE
fix: Support multiple sequencers: Add op-conductor-ops launcher [27/N]

### DIFF
--- a/src/conductor/op-conductor-ops/config.toml.tmpl
+++ b/src/conductor/op-conductor-ops/config.toml.tmpl
@@ -1,0 +1,18 @@
+[networks]
+
+[networks.{{ .network_name }}]
+sequencers = [
+{{- range $name, $config := .sequencers }}
+"{{ $name }}",
+{{- end }}
+]
+
+[sequencers]
+
+{{- range $name, $sequencer := .sequencers }}
+[sequencers.{{ $name }}]
+raft_addr = "{{ $sequencer.conductor_raft_address }}"
+conductor_rpc_url = "{{ $sequencer.conductor_rpc_url }}"
+node_rpc_url = "{{ $sequencer.cl_rpc_url }}"
+voting = true
+{{- end }}

--- a/src/conductor/op-conductor-ops/launcher.star
+++ b/src/conductor/op-conductor-ops/launcher.star
@@ -1,0 +1,114 @@
+_selectors = import_module("/src/l2/selectors.star")
+_net = import_module("/src/util/net.star")
+_registry = import_module("/src/package_io/registry.star")
+
+_CONFIG_DIRPATH_ON_SERVICE = "/etc/op-conductor-ops"
+_CONFIG_TEMPLATE_FILENAME = "config.toml.tmpl"
+_CONFIG_FILENAME = "config.toml"
+
+
+def launch(
+    plan,
+    l2_params,
+    registry,
+):
+    participants_params = _get_participants_params_with_conductors(l2_params)
+    if not participants_params:
+        plan.print(
+            "No conductors found for network {}, skipping op-conductor-ops launch".format(
+                l2_params.network_params.name
+            )
+        )
+
+        return None
+
+    config_artifact = _create_op_conductor_ops_config_artifact(plan=plan, network_params=l2_params.network_params, participants_params=participants_params)
+
+    _run_op_conductor_ops_command(
+        plan=plan,
+        cmd="bootstrap-cluster {}".format(l2_params.network_params.name),
+        config_artifact=config_artifact,
+        description="Bootstrap conductors for network {} using op-conductor-ops".format(
+            l2_params.network_params.name
+        ),
+        registry=registry,
+    )
+
+    _run_op_conductor_ops_command(
+        plan=plan,
+        cmd="status {}".format(l2_params.network_params.name),
+        config_artifact=config_artifact,
+        description="Get status of conductors for network {} using op-conductor-ops".format(
+            l2_params.network_params.name
+        ),
+        registry=registry,
+    )
+
+
+def _run_op_conductor_ops_command(
+    plan,
+    cmd,
+    config_artifact,
+    description,
+    registry,
+):
+    plan.run_sh(
+        description=description,
+        image=registry.get(_registry.OP_CONDUCTOR_OPS),
+        files={
+            _CONFIG_DIRPATH_ON_SERVICE: config_artifact,
+        },
+        run="./op-conductor-ops {}".format(
+            cmd,
+        ),
+        env_vars={
+            "CONDUCTOR_CONFIG": "{}/{}".format(
+                _CONFIG_DIRPATH_ON_SERVICE, _CONFIG_FILENAME
+            ),
+        },
+        wait=None,
+    )
+
+
+def _get_participants_params_with_conductors(l2_params):
+    return [
+        for participant_params in l2_params.participants
+        if participant_params.conductor_params
+        and _selectors.is_sequencer(participant_params)
+    ]
+
+
+def _create_op_conductor_ops_config_artifact(plan, network_params, participants_params):
+    config_template = read_file(_CONFIG_TEMPLATE_FILENAME)
+    config_data = {
+        "network_name": network_params.name,
+        "sequencers": {
+            participant_params.conductor_params.service_name: {
+                "cl_rpc_url": _net.service_url(
+                    participant_params.cl.service_name,
+                    participant_params.cl.ports[_net.RPC_PORT_NAME],
+                ),
+                "conductor_rpc_url": _net.service_url(
+                    participant_params.conductor_params.service_name,
+                    participant_params.conductor_params.ports[_net.RPC_PORT_NAME],
+                ),
+                "conductor_raft_address": "{0}:{1}".format(
+                    participant_params.conductor_params.service_name,
+                    participant_params.conductor_params.ports[
+                        _net.CONSENSUS_PORT_NAME
+                    ].number,
+                ),
+            }
+            for participant_params in participants_params
+        },
+    }
+
+    return plan.render_templates(
+        {
+            _CONFIG_FILENAME: struct(
+                template=config_template,
+                data=config_data,
+            ),
+        },
+        name="op-conductor-ops-config-{0}".format(network_params.network_id),
+    )

--- a/src/conductor/op-conductor-ops/launcher.star
+++ b/src/conductor/op-conductor-ops/launcher.star
@@ -22,7 +22,11 @@ def launch(
 
         return None
 
-    config_artifact = _create_op_conductor_ops_config_artifact(plan=plan, network_params=l2_params.network_params, participants_params=participants_params)
+    config_artifact = _create_op_conductor_ops_config_artifact(
+        plan=plan,
+        network_params=l2_params.network_params,
+        participants_params=participants_params,
+    )
 
     _run_op_conductor_ops_command(
         plan=plan,
@@ -72,6 +76,7 @@ def _run_op_conductor_ops_command(
 
 def _get_participants_params_with_conductors(l2_params):
     return [
+        participant_params
         for participant_params in l2_params.participants
         if participant_params.conductor_params
         and _selectors.is_sequencer(participant_params)

--- a/src/package_io/registry.star
+++ b/src/package_io/registry.star
@@ -46,7 +46,7 @@ _DEFAULT_IMAGES = {
     OP_BESU: "ghcr.io/optimism-java/op-besu:latest",
     OP_RBUILDER: "ghcr.io/flashbots/op-rbuilder:latest",
     # CL images
-    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.4-dev.1",
+    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3",
     KONA_NODE: "ghcr.io/op-rs/kona/kona-node:latest",
     HILDR: "ghcr.io/optimism-java/hildr:latest",
     # Batching

--- a/src/package_io/registry.star
+++ b/src/package_io/registry.star
@@ -21,6 +21,7 @@ OP_PROPOSER = "op-proposer"
 OP_CONDUCTOR = "op-conductor"
 OP_DEPLOYER = "op-deployer"
 OP_FAUCET = "op-faucet"
+OP_CONDUCTOR_OPS = "op-conductor-ops"
 
 PROXYD = "proxyd"
 
@@ -45,7 +46,7 @@ _DEFAULT_IMAGES = {
     OP_BESU: "ghcr.io/optimism-java/op-besu:latest",
     OP_RBUILDER: "ghcr.io/flashbots/op-rbuilder:latest",
     # CL images
-    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3",
+    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.4-dev.1",
     KONA_NODE: "ghcr.io/op-rs/kona/kona-node:latest",
     HILDR: "ghcr.io/optimism-java/hildr:latest",
     # Batching
@@ -66,6 +67,7 @@ _DEFAULT_IMAGES = {
     # TODO: update to use a versioned image when available
     # For now, we'll need users to pass the image explicitly
     OP_FAUCET: "",
+    OP_CONDUCTOR_OPS: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-conductor-ops:v0.0.2",
     # Proxyd
     PROXYD: "us-docker.pkg.dev/oplabs-tools-artifacts/images/proxyd:v4.14.5",
     # Sidecar


### PR DESCRIPTION
**Description**

`op-conductor-ops` is required when launching conductor instances. This PR introduces a disconnected launcher that runs a `bootstrap-cluster` command followed by a `status` command just for visibility purposes