### PR TITLE
fix: Support multiple sequencers: Pass supervisors params to conductor [29/N]

### DIFF
--- a/network_params.yaml
+++ b/network_params.yaml
@@ -39,7 +39,8 @@ optimism_package:
       batcher_params:
         extra_params: []
       conductor_params:
-        enabled: True
+        enabled: true
+        bootstrap: true
       additional_services: ["rollup-boost"]
       tx_fuzzer_params:
         enabled: true

--- a/src/conductor/input_parser.star
+++ b/src/conductor/input_parser.star
@@ -9,6 +9,7 @@ _DEFAULT_ARGS = {
     "admin": True,
     "proxy": True,
     "paused": False,
+    "bootstrap": False,
 }
 
 

--- a/src/package_io/registry.star
+++ b/src/package_io/registry.star
@@ -46,7 +46,7 @@ _DEFAULT_IMAGES = {
     OP_BESU: "ghcr.io/optimism-java/op-besu:latest",
     OP_RBUILDER: "ghcr.io/flashbots/op-rbuilder:latest",
     # CL images
-    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.4-dev.1",
+    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3",
     KONA_NODE: "ghcr.io/op-rs/kona/kona-node:latest",
     HILDR: "ghcr.io/optimism-java/hildr:latest",
     # Batching

--- a/src/package_io/registry.star
+++ b/src/package_io/registry.star
@@ -46,7 +46,7 @@ _DEFAULT_IMAGES = {
     OP_BESU: "ghcr.io/optimism-java/op-besu:latest",
     OP_RBUILDER: "ghcr.io/flashbots/op-rbuilder:latest",
     # CL images
-    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3",
+    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.4-dev.1",
     KONA_NODE: "ghcr.io/op-rs/kona/kona-node:latest",
     HILDR: "ghcr.io/optimism-java/hildr:latest",
     # Batching

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -152,6 +152,7 @@ SUBCATEGORY_PARAMS = {
         "admin",
         "proxy",
         "paused",
+        "bootstrap",
     ],
     "da_params": [
         "enabled",

--- a/src/participant_network__hack.star
+++ b/src/participant_network__hack.star
@@ -59,7 +59,7 @@ def launch_participant_network__hack(
             supervisors_params=supervisors_params,
             # Sidecar context is now deeply buried in the el_cl_launcher output
             # and we cannot dig it out without risking breaking well everything
-            # 
+            #
             # FIXME After refactoring, this should be passed in
             sidecar_context=None,
         ).context

--- a/src/participant_network__hack.star
+++ b/src/participant_network__hack.star
@@ -56,6 +56,12 @@ def launch_participant_network__hack(
                 },
             ),
             observability_helper=observability_helper,
+            supervisors_params=supervisors_params,
+            # Sidecar context is now deeply buried in the el_cl_launcher output
+            # and we cannot dig it out without risking breaking well everything
+            # 
+            # FIXME After refactoring, this should be passed in
+            sidecar_context=None,
         ).context
         if conductor_params
         else None

--- a/test/conductor/input_parser_test.star
+++ b/test/conductor/input_parser_test.star
@@ -61,6 +61,7 @@ def test_conductor_input_parser_default_args_enabled(plan):
         admin=True,
         proxy=True,
         paused=False,
+        bootstrap=False,
     )
 
     expect.eq(
@@ -109,6 +110,7 @@ def test_conductor_input_parser_custom_params(plan):
             admin=True,
             proxy=True,
             paused=False,
+            bootstrap=False,
         ),
     )
 

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -322,6 +322,7 @@ def test_l2_participant_input_parser_defaults_conductor_enabled(plan):
             admin=True,
             proxy=True,
             paused=False,
+            bootstrap=False,
         ),
     )
 


### PR DESCRIPTION
**Description**

`op-conductor` needs to know about the supervisors, hence this.

We also need to pass the `rollup-boost` context to the conductor but it's buried so deep in the `el_cl_launcher` that we'd need to go through with the full refactor to support it (sad face).

Fixes https://github.com/ethereum-optimism/optimism/issues/16366