### PR TITLE
chore: Use lighter deployment utils image

### DIFF
--- a/src/package_io/registry.star
+++ b/src/package_io/registry.star
@@ -76,7 +76,7 @@ _DEFAULT_IMAGES = {
     # Tx Fuzzer
     TX_FUZZER: "ethpandaops/tx-fuzz:master",
     # utils
-    DEPLOYMENT_UTILS: "mslipper/deployment-utils:latest",
+    DEPLOYMENT_UTILS: "badouralix/curl-jq:latest",
     # observability
     PROMETHEUS: "prom/prometheus:v3.1.0",
     GRAFANA: "grafana/grafana:11.5.0",

--- a/src/util.star
+++ b/src/util.star
@@ -1,6 +1,6 @@
 constants = import_module("./package_io/constants.star")
 
-DEPLOYMENT_UTILS_IMAGE = "mslipper/deployment-utils:latest"
+DEPLOYMENT_UTILS_IMAGE = "badouralix/curl-jq:latest"
 
 
 def read_network_config_value(plan, network_config_file, json_file, json_path):


### PR DESCRIPTION
**Description**

Small optimization - use 6 instead of 100MB image for `curl` and `jq`. This image is also used by the `ethereum-package` so we save a bit of time on removing the duplicate pulling