### PR TITLE
chore: Support multiple sequencers: Input parser & launcher for blockscout [34/N]

### DIFF
--- a/.github/tests/blockscout.yaml
+++ b/.github/tests/blockscout.yaml
@@ -4,5 +4,5 @@ optimism_package:
         - el_type: op-geth
       network_params:
         name: op-rollup-one
-      additional_services:
-        - blockscout
+      blockscout_params:
+        enabled: True

--- a/README.md
+++ b/README.md
@@ -461,7 +461,6 @@ optimism_package:
       # Additional services to run alongside the network
       # Defaults to []
       # Available services:
-      # - blockscout
       # - rollup-boost
       # - da_server
       additional_services: []
@@ -483,6 +482,12 @@ optimism_package:
           - "--addr=0.0.0.0"
           - "--port=3100"
           - "--log.level=debug"
+
+      blockscout_params:
+        enabled: false
+        image: "blockscout/blockscout-optimism:6.8.0"
+        verifier_image: "ghcr.io/blockscout/smart-contract-verifier:v1.9.0"
+        
 
   challengers:
     my-challenger:
@@ -582,8 +587,8 @@ optimism_package:
     - participants:
         - el_type: op-geth
           cl_type: op-node
-      additional_services:
-        - blockscout
+      blockscout_params:
+        enabled: True
 ethereum_package:
   participants:
     - el_type: geth
@@ -642,15 +647,15 @@ optimism_package:
       network_params:
         name: op-rollup-one
         network_id: "3151909"
-      additional_services:
-        - blockscout
+      blockscout_params:
+        enabled: True
     - participants:
         - el_type: op-geth
       network_params:
         name: op-rollup-two
         network_id: "3151910"
-      additional_services:
-        - blockscout
+      blockscout_params:
+        enabled: True
 ethereum_package:
   participants:
     - el_type: geth

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -42,6 +42,8 @@ optimism_package:
         enabled: true
         bootstrap: true
       additional_services: ["rollup-boost"]
+      blockscout_params:
+        enabled: true
       tx_fuzzer_params:
         enabled: true
   op_contract_deployer_params:

--- a/src/blockscout/input_parser.star
+++ b/src/blockscout/input_parser.star
@@ -26,33 +26,33 @@ def parse(blockscout_args, network_params, registry):
     if not blockscout_params["enabled"]:
         return None
 
-    blockscout_params["database"] = struct(
-        service_name="op-blockscout-db-{}-{}".format(network_id, network_name),
+    return struct(
+        database=struct(
+            service_name="op-blockscout-db-{}-{}".format(network_id, network_name),
+        ),
+        blockscout=struct(
+            image=blockscout_params["image"] or registry.get(_registry.OP_BLOCKSCOUT),
+            service_name="op-blockscout-{}-{}".format(network_id, network_name),
+            labels={
+                "op.kind": "blockscout",
+                "op.network.id": str(network_id),
+            },
+            ports={
+                _net.HTTP_PORT_NAME: _net.port(number=4000),
+            },
+        ),
+        verifier=struct(
+            image=blockscout_params["verifier_image"]
+            or registry.get(_registry.OP_BLOCKSCOUT_VERIFIER),
+            service_name="op-blockscout-verifier-{}-{}".format(
+                network_id, network_name
+            ),
+            labels={
+                "op.kind": "blockscout-verifier",
+                "op.network.id": str(network_id),
+            },
+            ports={
+                _net.HTTP_PORT_NAME: _net.port(number=8050),
+            },
+        ),
     )
-
-    blockscout_params["blockscout"] = struct(
-        image=blockscout_params["image"] or registry.get(_registry.OP_BLOCKSCOUT),
-        service_name="op-blockscout-{}-{}".format(network_id, network_name),
-        labels={
-            "op.kind": "blockscout",
-            "op.network.id": str(network_id),
-        },
-        ports={
-            _net.HTTP_PORT_NAME: _net.port(number=4000),
-        },
-    )
-
-    blockscout_params["verifier"] = struct(
-        image=blockscout_params["verifier_image"]
-        or registry.get(_registry.OP_BLOCKSCOUT_VERIFIER),
-        service_name="op-blockscout-verifier-{}-{}".format(network_id, network_name),
-        labels={
-            "op.kind": "blockscout-verifier",
-            "op.network.id": str(network_id),
-        },
-        ports={
-            _net.HTTP_PORT_NAME: _net.port(number=8050),
-        },
-    )
-
-    return struct(**blockscout_params)

--- a/src/blockscout/input_parser.star
+++ b/src/blockscout/input_parser.star
@@ -27,35 +27,32 @@ def parse(blockscout_args, network_params, registry):
         return None
 
     blockscout_params["database"] = struct(
-        service_name = "op-blockscout-db-{}-{}".format(network_id, network_name),
+        service_name="op-blockscout-db-{}-{}".format(network_id, network_name),
     )
 
     blockscout_params["blockscout"] = struct(
-        image = blockscout_params["image"] or registry.get(
-            _registry.OP_BLOCKSCOUT
-        ),
-        service_name = "op-blockscout-{}-{}".format(network_id, network_name),
-        labels = {
+        image=blockscout_params["image"] or registry.get(_registry.OP_BLOCKSCOUT),
+        service_name="op-blockscout-{}-{}".format(network_id, network_name),
+        labels={
             "op.kind": "blockscout",
             "op.network.id": str(network_id),
         },
         ports={
             _net.HTTP_PORT_NAME: _net.port(number=4000),
-        }
+        },
     )
 
     blockscout_params["verifier"] = struct(
-        image = blockscout_params["verifier_image"] or registry.get(
-            _registry.OP_BLOCKSCOUT_VERIFIER
-        ),
-        service_name = "op-blockscout-verifier-{}-{}".format(network_id, network_name),
-        labels = {
+        image=blockscout_params["verifier_image"]
+        or registry.get(_registry.OP_BLOCKSCOUT_VERIFIER),
+        service_name="op-blockscout-verifier-{}-{}".format(network_id, network_name),
+        labels={
             "op.kind": "blockscout-verifier",
             "op.network.id": str(network_id),
         },
         ports={
             _net.HTTP_PORT_NAME: _net.port(number=8050),
-        }
+        },
     )
 
     return struct(**blockscout_params)

--- a/src/blockscout/input_parser.star
+++ b/src/blockscout/input_parser.star
@@ -1,0 +1,61 @@
+_filter = import_module("/src/util/filter.star")
+_net = import_module("/src/util/net.star")
+_registry = import_module("/src/package_io/registry.star")
+
+_DEFAULT_ARGS = {
+    "enabled": False,
+    "image": None,
+    "verifier_image": None,
+}
+
+
+def parse(blockscout_args, network_params, registry):
+    network_id = network_params.network_id
+    network_name = network_params.name
+
+    # Any extra attributes will cause an error
+    _filter.assert_keys(
+        blockscout_args or {},
+        _DEFAULT_ARGS.keys(),
+        "Invalid attributes in blockscout configuration for " + network_name + ": {}",
+    )
+
+    # We filter the None values so that we can merge dicts easily
+    blockscout_params = _DEFAULT_ARGS | _filter.remove_none(blockscout_args or {})
+
+    if not blockscout_params["enabled"]:
+        return None
+
+    blockscout_params["database"] = struct(
+        service_name = "op-blockscout-db-{}-{}".format(network_id, network_name),
+    )
+
+    blockscout_params["blockscout"] = struct(
+        image = blockscout_params["image"] or registry.get(
+            _registry.OP_BLOCKSCOUT
+        ),
+        service_name = "op-blockscout-{}-{}".format(network_id, network_name),
+        labels = {
+            "op.kind": "blockscout",
+            "op.network.id": str(network_id),
+        },
+        ports={
+            _net.HTTP_PORT_NAME: _net.port(number=4000),
+        }
+    )
+
+    blockscout_params["verifier"] = struct(
+        image = blockscout_params["verifier_image"] or registry.get(
+            _registry.OP_BLOCKSCOUT_VERIFIER
+        ),
+        service_name = "op-blockscout-verifier-{}-{}".format(network_id, network_name),
+        labels = {
+            "op.kind": "blockscout-verifier",
+            "op.network.id": str(network_id),
+        },
+        ports={
+            _net.HTTP_PORT_NAME: _net.port(number=8050),
+        }
+    )
+
+    return struct(**blockscout_params)

--- a/src/blockscout/launcher.star
+++ b/src/blockscout/launcher.star
@@ -1,19 +1,7 @@
-ethereum_package_shared_utils = import_module(
-    "github.com/ethpandaops/ethereum-package/src/shared_utils/shared_utils.star"
-)
+_postgres = import_module("github.com/kurtosis-tech/postgres-package/main.star")
 
-postgres = import_module("github.com/kurtosis-tech/postgres-package/main.star")
-
-util = import_module("../util.star")
-
-IMAGE_NAME_BLOCKSCOUT = "blockscout/blockscout-optimism:6.8.0"
-IMAGE_NAME_BLOCKSCOUT_VERIF = "ghcr.io/blockscout/smart-contract-verifier:v1.9.0"
-
-SERVICE_NAME_BLOCKSCOUT = "op-blockscout"
-
-HTTP_PORT_ID = "http"
-HTTP_PORT_NUMBER = 4000
-HTTP_PORT_NUMBER_VERIF = 8050
+_net = import_module("/src/util/net.star")
+_util = import_module("/src/util.star")
 
 BLOCKSCOUT_MIN_CPU = 100
 BLOCKSCOUT_MAX_CPU = 1000
@@ -25,64 +13,46 @@ BLOCKSCOUT_VERIF_MAX_CPU = 1000
 BLOCKSCOUT_VERIF_MIN_MEMORY = 10
 BLOCKSCOUT_VERIF_MAX_MEMORY = 1024
 
-USED_PORTS = {
-    HTTP_PORT_ID: ethereum_package_shared_utils.new_port_spec(
-        HTTP_PORT_NUMBER,
-        ethereum_package_shared_utils.TCP_PROTOCOL,
-        ethereum_package_shared_utils.HTTP_APPLICATION_PROTOCOL,
-    )
-}
 
-VERIF_USED_PORTS = {
-    HTTP_PORT_ID: ethereum_package_shared_utils.new_port_spec(
-        HTTP_PORT_NUMBER_VERIF,
-        ethereum_package_shared_utils.TCP_PROTOCOL,
-        ethereum_package_shared_utils.HTTP_APPLICATION_PROTOCOL,
-    )
-}
-
-
-def launch_blockscout(
+def launch(
     plan,
-    l2_services_suffix,
+    params,
+    network_params,
+    l2_rpc_url,
     l1_rpc_url,
-    l2_el_context,
-    l2_network_name,
     deployment_output,
-    network_id,
 ):
+    network_id = network_params.network_id
+    network_name = network_params.name
+
     rollup_filename = "rollup-{0}".format(network_id)
-    portal_address = util.read_network_config_value(
+    portal_address = _util.read_network_config_value(
         plan, deployment_output, rollup_filename, ".deposit_contract_address"
     )
-    l1_deposit_start_block = util.read_network_config_value(
+    l1_deposit_start_block = _util.read_network_config_value(
         plan, deployment_output, rollup_filename, ".genesis.l1.number"
     )
 
-    postgres_output = postgres.run(
+    postgres_output = _postgres.run(
         plan,
-        service_name="{0}-postgres{1}".format(
-            SERVICE_NAME_BLOCKSCOUT, l2_services_suffix
-        ),
+        service_name=params.database.service_name,
         database="blockscout",
         extra_configs=["max_connections=1000"],
     )
 
-    config_verif = get_config_verif()
-    verif_service_name = "{0}-verif{1}".format(
-        SERVICE_NAME_BLOCKSCOUT, l2_services_suffix
-    )
-    verif_service = plan.add_service(verif_service_name, config_verif)
+    verif_config = get_config_verif(verifier_params=params.verifier)
+    verif_service = plan.add_service(params.verifier.service_name, verif_config)
     verif_url = "http://{}:{}".format(
         verif_service.hostname, verif_service.ports["http"].number
     )
 
     config_backend = get_config_backend(
-        postgres_output,
-        l1_rpc_url,
-        l2_el_context,
-        verif_url,
-        l2_network_name,
+        blockscout_params=params.blockscout,
+        postgres_output=postgres_output,
+        l1_rpc_url=l1_rpc_url,
+        l2_rpc_url=l2_rpc_url,
+        verif_url=verif_url,
+        network_name=network_name,
         {
             "INDEXER_OPTIMISM_L1_PORTAL_CONTRACT": portal_address,
             "INDEXER_OPTIMISM_L1_DEPOSITS_START_BLOCK": l1_deposit_start_block,
@@ -93,9 +63,8 @@ def launch_blockscout(
         },
     )
     blockscout_service = plan.add_service(
-        "{0}{1}".format(SERVICE_NAME_BLOCKSCOUT, l2_services_suffix), config_backend
+        params.blockscout.service_name, config_backend
     )
-    plan.print(blockscout_service)
 
     blockscout_url = "http://{}:{}".format(
         blockscout_service.hostname, blockscout_service.ports["http"].number
@@ -104,13 +73,14 @@ def launch_blockscout(
     return blockscout_url
 
 
-def get_config_verif():
+def get_config_verif(verifier_params):
     return ServiceConfig(
-        image=IMAGE_NAME_BLOCKSCOUT_VERIF,
-        ports=VERIF_USED_PORTS,
+        image=verifier_params.image,
+        ports=_net.ports_to_port_specs(verifier_params.ports),
+        labels=verifier_params.labels,
         env_vars={
             "SMART_CONTRACT_VERIFIER__SERVER__HTTP__ADDR": "0.0.0.0:{}".format(
-                HTTP_PORT_NUMBER_VERIF
+                verifier_params.ports[_net.HTTP_PORT_NAME].number
             )
         },
         min_cpu=BLOCKSCOUT_VERIF_MIN_CPU,
@@ -121,11 +91,12 @@ def get_config_verif():
 
 
 def get_config_backend(
+    blockscout_params,
     postgres_output,
     l1_rpc_url,
-    l2_el_context,
+    l2_rpc_url,
     verif_url,
-    l2_network_name,
+    network_name,
     additional_env_vars,
 ):
     database_url = "{protocol}://{user}:{password}@{hostname}:{port}/{database}".format(
@@ -157,8 +128,9 @@ def get_config_backend(
     } | additional_env_vars
 
     return ServiceConfig(
-        image=IMAGE_NAME_BLOCKSCOUT,
-        ports=USED_PORTS,
+        image=blockscout_params.image,
+        ports=_net.ports_to_port_specs(blockscout_params.ports),
+        labels=blockscout_params.labels,
         cmd=[
             "/bin/sh",
             "-c",
@@ -166,8 +138,8 @@ def get_config_backend(
         ],
         env_vars={
             "ETHEREUM_JSONRPC_VARIANT": "geth",
-            "ETHEREUM_JSONRPC_HTTP_URL": l2_el_context.rpc_http_url,
-            "ETHEREUM_JSONRPC_TRACE_URL": l2_el_context.rpc_http_url,
+            "ETHEREUM_JSONRPC_HTTP_URL": l2_rpc_url,
+            "ETHEREUM_JSONRPC_TRACE_URL": l2_rpc_url,
             "DATABASE_URL": database_url,
             "COIN": "opETH",
             "MICROSERVICE_SC_VERIFIER_ENABLED": "true",
@@ -175,10 +147,10 @@ def get_config_backend(
             "MICROSERVICE_SC_VERIFIER_TYPE": "sc_verifier",
             "INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER": "true",
             "ECTO_USE_SSL": "false",
-            "NETWORK": l2_network_name,
-            "SUBNETWORK": l2_network_name,
+            "NETWORK": network_name,
+            "SUBNETWORK": network_name,
             "API_V2_ENABLED": "true",
-            "PORT": "{}".format(HTTP_PORT_NUMBER),
+            "PORT": "{}".format(blockscout_params.ports[_net.HTTP_PORT_NAME].number),
             "SECRET_KEY_BASE": "56NtB48ear7+wMSf0IQuWDAAazhpb31qyc7GiyspBP2vh7t5zlCsF5QDv76chXeN",
         }
         | optimism_env_vars,

--- a/src/blockscout/launcher.star
+++ b/src/blockscout/launcher.star
@@ -34,7 +34,7 @@ def launch(
     )
 
     postgres_output = _postgres.run(
-        plan,
+        plan=plan,
         service_name=params.database.service_name,
         database="blockscout",
         extra_configs=["max_connections=1000"],
@@ -53,7 +53,7 @@ def launch(
         l2_rpc_url=l2_rpc_url,
         verif_url=verif_url,
         network_name=network_name,
-        {
+        additional_env_vars={
             "INDEXER_OPTIMISM_L1_PORTAL_CONTRACT": portal_address,
             "INDEXER_OPTIMISM_L1_DEPOSITS_START_BLOCK": l1_deposit_start_block,
             "INDEXER_OPTIMISM_L1_WITHDRAWALS_START_BLOCK": l1_deposit_start_block,

--- a/src/l2.star
+++ b/src/l2.star
@@ -1,5 +1,5 @@
 participant_network = import_module("./participant_network.star")
-blockscout = import_module("./blockscout/blockscout_launcher.star")
+_blockscout_launcher = import_module("./blockscout/launcher.star")
 _da_server_launcher = import_module("./da/da-server/launcher.star")
 _tx_fuzzer_launcher = import_module("./tx-fuzzer/launcher.star")
 contract_deployer = import_module("./contracts/contract_deployer.star")
@@ -99,19 +99,19 @@ def launch_l2(
 
         plan.print("Successfully launched transaction fuzzer")
 
-    for additional_service in l2_args.additional_services:
-        if additional_service == "blockscout":
-            plan.print("Launching op-blockscout")
-            blockscout.launch_blockscout(
-                plan,
-                l2_services_suffix,
-                l1_rpc_url,
-                all_el_contexts[0],  # first l2 EL url
-                network_params.name,
-                deployment_output,
-                network_params.network_id,
-            )
-            plan.print("Successfully launched op-blockscout")
+    if l2_args.blockscout_params:
+        plan.print("Launching op-blockscout")
+
+        _blockscout_launcher.launch(
+            plan=plan,
+            params=l2_args.blockscout_params,
+            network_params=network_params,
+            l1_rpc_url=l1_rpc_url,
+            l2_rpc_url=all_el_contexts[0].rpc_http_url,
+            deployment_output=deployment_output,
+        )
+
+        plan.print("Successfully launched op-blockscout")
 
     plan.print(l2.participants)
     plan.print(

--- a/src/l2/input_parser.star
+++ b/src/l2/input_parser.star
@@ -27,6 +27,7 @@ _DEFAULT_ARGS = {
     "da_params": None,
     "proposer_params": None,
     "batcher_params": None,
+    "blockscout_params": None,
     "proxyd_params": None,
     "tx_fuzzer_params": None,
     # FIXME Make blockscout use the "enabled" pattern
@@ -134,7 +135,7 @@ def _parse_instance(l2_args, l2_name, l2_id_generator, registry):
 
     # We add the explorer params
     l2_params["blockscout_params"] = _blockscout_input_parser.parse(
-        args=input_args.get("blockscout_params"), registry=registry
+        args=l2_params["blockscout_params"], registry=registry
     )
 
     return struct(

--- a/src/l2/input_parser.star
+++ b/src/l2/input_parser.star
@@ -135,7 +135,9 @@ def _parse_instance(l2_args, l2_name, l2_id_generator, registry):
 
     # We add the explorer params
     l2_params["blockscout_params"] = _blockscout_input_parser.parse(
-        args=l2_params["blockscout_params"], registry=registry
+        blockscout_args=l2_params["blockscout_params"],
+        network_params=l2_params["network_params"],
+        registry=registry,
     )
 
     return struct(

--- a/src/l2/input_parser.star
+++ b/src/l2/input_parser.star
@@ -3,6 +3,7 @@ _id = import_module("/src/util/id.star")
 
 _l2_participant_input_parser = import_module("./participant/input_parser.star")
 _batcher_input_parser = import_module("/src/batcher/input_parser.star")
+_blockscout_input_parser = import_module("/src/blockscout/input_parser.star")
 _da_input_parser = import_module("/src/da/input_parser.star")
 _proposer_input_parser = import_module("/src/proposer/input_parser.star")
 _proxyd_input_parser = import_module("/src/proxyd/input_parser.star")
@@ -129,6 +130,11 @@ def _parse_instance(l2_args, l2_name, l2_id_generator, registry):
         da_args=l2_params["da_params"],
         network_params=l2_params["network_params"],
         registry=registry,
+    )
+
+    # We add the explorer params
+    l2_params["blockscout_params"] = _blockscout_input_parser.parse(
+        args=input_args.get("blockscout_params"), registry=registry
     )
 
     return struct(

--- a/src/l2__hack.star
+++ b/src/l2__hack.star
@@ -1,5 +1,4 @@
 participant_network__hack = import_module("./participant_network__hack.star")
-blockscout = import_module("./blockscout/blockscout_launcher.star")
 _da_server_launcher = import_module("./da/da-server/launcher.star")
 _tx_fuzzer_launcher = import_module("./tx-fuzzer/launcher.star")
 contract_deployer = import_module("./contracts/contract_deployer.star")

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -7,6 +7,7 @@ _ethereum_package_shared_utils = import_module(
 )
 
 _batcher_input_parser = import_module("/src/batcher/input_parser.star")
+_blockscout_input_parser = import_module("/src/blockscout/input_parser.star")
 _da_input_parser = import_module("/src/da/input_parser.star")
 _challenger_input_parser = import_module("/src/challenger/input_parser.star")
 _conductor_input_parser = import_module("/src/conductor/input_parser.star")
@@ -198,6 +199,7 @@ def input_parser(
                 ),
                 proxyd_params=result["proxyd_params"],
                 batcher_params=result["batcher_params"],
+                blockscout_params=result["blockscout_params"],
                 proposer_params=result["proposer_params"],
                 mev_params=result["mev_params"],
                 conductor_params=result["conductor_params"],
@@ -288,6 +290,13 @@ def parse_network_params(plan, registry, input_args):
             chain.get("batcher_params", {}),
             struct(**network_params),
             registry,
+        )
+
+        blockscout_params = _blockscout_input_parser.parse(
+            # FIXME The network_params will come from the new L2 parser once that's in. Until then they need to be converted to a struct
+            blockscout_args=chain.get("blockscout_params", {}),
+            network_params=struct(**network_params),
+            registry=registry,
         )
 
         proposer_params = _proposer_input_parser.parse(
@@ -434,6 +443,7 @@ def parse_network_params(plan, registry, input_args):
             "network_params": network_params,
             "proxyd_params": proxyd_params,
             "batcher_params": batcher_params,
+            "blockscout_params": blockscout_params,
             "proposer_params": proposer_params,
             "mev_params": mev_params,
             "conductor_params": conductor_params,

--- a/src/package_io/registry.star
+++ b/src/package_io/registry.star
@@ -88,7 +88,6 @@ _DEFAULT_IMAGES = {
     GRAFANA: "grafana/grafana:11.5.0",
     LOKI: "grafana/loki:3.3.2",
     PROMTAIL: "grafana/promtail:3.3.2",
-
     # Explorers
     OP_BLOCKSCOUT: "blockscout/blockscout-optimism:6.8.0",
     OP_BLOCKSCOUT_VERIFIER: "ghcr.io/blockscout/smart-contract-verifier:v1.9.0",

--- a/src/package_io/registry.star
+++ b/src/package_io/registry.star
@@ -37,6 +37,9 @@ GRAFANA = "grafana"
 LOKI = "loki"
 PROMTAIL = "promtail"
 
+OP_BLOCKSCOUT = "op-blockscout"
+OP_BLOCKSCOUT_VERIFIER = "op-blockscout-verifier"
+
 
 _DEFAULT_IMAGES = {
     # EL images
@@ -85,6 +88,10 @@ _DEFAULT_IMAGES = {
     GRAFANA: "grafana/grafana:11.5.0",
     LOKI: "grafana/loki:3.3.2",
     PROMTAIL: "grafana/promtail:3.3.2",
+
+    # Explorers
+    OP_BLOCKSCOUT: "blockscout/blockscout-optimism:6.8.0",
+    OP_BLOCKSCOUT_VERIFIER: "ghcr.io/blockscout/smart-contract-verifier:v1.9.0",
 }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -170,6 +170,11 @@ SUBCATEGORY_PARAMS = {
         "min_memory",
         "max_memory",
     ],
+    "blockscout_params": [
+        "enabled",
+        "image",
+        "verifier_image",
+    ],
 }
 
 OP_CONTRACT_DEPLOYER_PARAMS = [
@@ -184,7 +189,7 @@ OP_CONTRACT_DEPLOYER_OVERRIDES = [
     "vmType",
 ]
 
-ADDITIONAL_SERVICES_PARAMS = ["blockscout", "rollup-boost"]
+ADDITIONAL_SERVICES_PARAMS = ["rollup-boost"]
 
 EXTERNAL_L1_NETWORK_PARAMS = [
     "network_id",

--- a/test/blockscout/input_parser_test.star
+++ b/test/blockscout/input_parser_test.star
@@ -1,0 +1,135 @@
+_input_parser = import_module("/src/blockscout/input_parser.star")
+
+_net = import_module("/src/util/net.star")
+_registry = import_module("/src/package_io/registry.star")
+
+_default_network_params = struct(
+    network_id=1000,
+    name="my-l2",
+)
+_default_registry = _registry.Registry()
+
+
+def test_blockscout_input_parser_extra_attrbutes(plan):
+    expect.fails(
+        lambda: _input_parser.parse(
+            {"extra": None, "name": "x"},
+            _default_network_params,
+            _default_registry,
+        ),
+        "Invalid attributes in blockscout configuration for my-l2: extra,name",
+    )
+
+
+def test_blockscout_input_parser_default_args_disabled(plan):
+    expect.eq(
+        _input_parser.parse(
+            blockscout_args=None,
+            network_params=_default_network_params,
+            registry=_default_registry,
+        ),
+        None,
+    )
+
+    expect.eq(
+        _input_parser.parse(
+            {},
+            _default_network_params,
+            _default_registry,
+        ),
+        None,
+    )
+
+    expect.eq(
+        _input_parser.parse(
+            {
+                "image": None,
+                "verifier_image": None,
+            },
+            _default_network_params,
+            _default_registry,
+        ),
+        None,
+    )
+
+
+def test_blockscout_input_parser_default_args_enabled(plan):
+    _default_params = struct(
+        blockscout=struct(
+            image="blockscout/blockscout-optimism:6.8.0",
+            labels={"op.kind": "blockscout", "op.network.id": "1000"},
+            ports={_net.HTTP_PORT_NAME: _net.port(number=4000)},
+            service_name="op-blockscout-1000-my-l2",
+        ),
+        database=struct(service_name="op-blockscout-db-1000-my-l2"),
+        verifier=struct(
+            image="ghcr.io/blockscout/smart-contract-verifier:v1.9.0",
+            labels={"op.kind": "blockscout-verifier", "op.network.id": "1000"},
+            ports={_net.HTTP_PORT_NAME: _net.port(number=8050)},
+            service_name="op-blockscout-verifier-1000-my-l2",
+        ),
+    )
+
+    expect.eq(
+        _input_parser.parse(
+            {"enabled": True},
+            _default_network_params,
+            _default_registry,
+        ),
+        _default_params,
+    )
+
+    expect.eq(
+        _input_parser.parse(
+            {
+                "enabled": True,
+                "image": None,
+                "verifier_image": None,
+            },
+            _default_network_params,
+            _default_registry,
+        ),
+        _default_params,
+    )
+
+
+def test_blockscout_input_parser_custom_params(plan):
+    parsed = _input_parser.parse(
+        blockscout_args={
+            "enabled": True,
+            "image": "op-blockscout:brightest",
+            "verifier_image": "op-blockscout-verifier:smallest",
+        },
+        network_params=_default_network_params,
+        registry=_default_registry,
+    )
+
+    expect.eq(
+        parsed.blockscout.image,
+        "op-blockscout:brightest",
+    )
+
+    expect.eq(
+        parsed.verifier.image,
+        "op-blockscout-verifier:smallest",
+    )
+
+
+def test_blockscout_input_parser_custom_registry(plan):
+    registry = _registry.Registry({_registry.OP_BLOCKSCOUT: "op-blockscout:greatest", _registry.OP_BLOCKSCOUT_VERIFIER: "op-blockscout-verifier:shadiest"})
+
+    parsed = _input_parser.parse(
+        blockscout_args={"enabled": True},
+        network_params=_default_network_params,
+        registry=registry,
+    )
+    expect.eq(parsed.blockscout.image, "op-blockscout:greatest")
+    expect.eq(parsed.verifier.image, "op-blockscout-verifier:shadiest")
+
+    parsed = _input_parser.parse(
+        {"enabled": True, "image": "op-blockscout:oldest", "verifier_image": "op-blockscout-verifier:tiniest"},
+        _default_network_params,
+        registry,
+    )
+    expect.eq(parsed.blockscout.image, "op-blockscout:oldest")
+    expect.eq(parsed.verifier.image, "op-blockscout-verifier:tiniest")

--- a/test/blockscout/input_parser_test.star
+++ b/test/blockscout/input_parser_test.star
@@ -72,22 +72,22 @@ def test_blockscout_input_parser_default_args_enabled(plan):
 
     expect.eq(
         _input_parser.parse(
-            {"enabled": True},
-            _default_network_params,
-            _default_registry,
+            blockscout_args={"enabled": True},
+            network_params=_default_network_params,
+            registry=_default_registry,
         ),
         _default_params,
     )
 
     expect.eq(
         _input_parser.parse(
-            {
+            blockscout_args={
                 "enabled": True,
                 "image": None,
                 "verifier_image": None,
             },
-            _default_network_params,
-            _default_registry,
+            network_params=_default_network_params,
+            registry=_default_registry,
         ),
         _default_params,
     )

--- a/test/blockscout/input_parser_test.star
+++ b/test/blockscout/input_parser_test.star
@@ -116,7 +116,12 @@ def test_blockscout_input_parser_custom_params(plan):
 
 
 def test_blockscout_input_parser_custom_registry(plan):
-    registry = _registry.Registry({_registry.OP_BLOCKSCOUT: "op-blockscout:greatest", _registry.OP_BLOCKSCOUT_VERIFIER: "op-blockscout-verifier:shadiest"})
+    registry = _registry.Registry(
+        {
+            _registry.OP_BLOCKSCOUT: "op-blockscout:greatest",
+            _registry.OP_BLOCKSCOUT_VERIFIER: "op-blockscout-verifier:shadiest",
+        }
+    )
 
     parsed = _input_parser.parse(
         blockscout_args={"enabled": True},
@@ -127,7 +132,11 @@ def test_blockscout_input_parser_custom_registry(plan):
     expect.eq(parsed.verifier.image, "op-blockscout-verifier:shadiest")
 
     parsed = _input_parser.parse(
-        {"enabled": True, "image": "op-blockscout:oldest", "verifier_image": "op-blockscout-verifier:tiniest"},
+        {
+            "enabled": True,
+            "image": "op-blockscout:oldest",
+            "verifier_image": "op-blockscout-verifier:tiniest",
+        },
         _default_network_params,
         registry,
     )

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -127,6 +127,8 @@ def test_l2_input_parser_defaults(plan):
                 da_params=None,
                 # tx fuzzer is disabled by default
                 tx_fuzzer_params=None,
+                # Blockscout is disabled by default
+                blockscout_params=None,
                 additional_services=[],
             )
         ],
@@ -159,6 +161,8 @@ def test_l2_input_parser_defaults(plan):
                 da_params=None,
                 # tx fuzzer is disabled by default
                 tx_fuzzer_params=None,
+                # Blockscout is disabled by default
+                blockscout_params=None,
                 additional_services=[],
             )
         ],


### PR DESCRIPTION
**Description**

Moves `blockscout` config to the new format, adds an input parser and updates the launcher