### PR TITLE
chore: chore: Support multiple sequencers: Missing labels [38/N]

### DIFF
--- a/src/challenger/input_parser.star
+++ b/src/challenger/input_parser.star
@@ -62,6 +62,11 @@ def _parse_instance(challenger_args, challenger_name, l2s_params):
         "-".join([str(p) for p in challenger_params["participants"]]),
     )
 
+    challenger_params["labels"] = {
+        "op.kind": "challenger",
+        "op.network.id": ",".join([str(network_id) for network_id in network_ids]),
+    }
+
     # Now we make sure to cover the prestate arg combinations
     #
     # First we check we only have one of them defined

--- a/src/challenger/op-challenger/launcher.star
+++ b/src/challenger/op-challenger/launcher.star
@@ -215,6 +215,7 @@ def get_challenger_config(
         cmd=cmd,
         entrypoint=["op-challenger"],
         files=files,
+        labels=params.labels,
         private_ip_address_placeholder=ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
         ports=ports,
     )

--- a/src/conductor/input_parser.star
+++ b/src/conductor/input_parser.star
@@ -13,7 +13,9 @@ _DEFAULT_ARGS = {
 }
 
 
-def parse(conductor_args, network_params, participant_name, registry):
+def parse(
+    conductor_args, network_params, participant_name, participant_index, registry
+):
     network_id = network_params.network_id
     network_name = network_params.name
 
@@ -55,6 +57,7 @@ def parse(conductor_args, network_params, participant_name, registry):
     conductor_params["labels"] = {
         "op.kind": "conductor",
         "op.network.id": str(network_id),
+        "op.network.participant.index": str(participant_index),
         "op.network.participant.name": participant_name,
         "op.conductor.type": "op-conductor",
     }

--- a/src/faucet/op-faucet/op_faucet_launcher.star
+++ b/src/faucet/op-faucet/op_faucet_launcher.star
@@ -65,6 +65,10 @@ def _get_config(
                 application_protocol="http",
             ),
         },
+        labels={
+            "op.kind": "faucet"
+            # TODO Add network IDs
+        },
         files={
             mount_path: faucet_config,
         },

--- a/src/l2/participant/cl/input_parser.star
+++ b/src/l2/participant/cl/input_parser.star
@@ -26,21 +26,39 @@ _IMAGE_IDS = {
 }
 
 
-def parse(args, participant_name, network_params, registry):
-    return _parse(args, participant_name, network_params, registry, "cl")
+def parse(cl_args, participant_name, participant_index, network_params, registry):
+    return _parse(
+        cl_args=cl_args,
+        participant_name=participant_name,
+        participant_index=participant_index,
+        network_params=network_params,
+        registry=registry,
+        cl_kind="cl",
+    )
 
 
-def parse_builder(args, participant_name, network_params, registry):
-    return _parse(args, participant_name, network_params, registry, "clbuilder")
+def parse_builder(
+    cl_args, participant_name, participant_index, network_params, registry
+):
+    return _parse(
+        cl_args=cl_args,
+        participant_name=participant_name,
+        participant_index=participant_index,
+        network_params=network_params,
+        registry=registry,
+        cl_kind="clbuilder",
+    )
 
 
-def _parse(args, participant_name, network_params, registry, cl_kind):
+def _parse(
+    cl_args, participant_name, participant_index, network_params, registry, cl_kind
+):
     network_id = network_params.network_id
     network_name = network_params.name
 
     # Any extra attributes will cause an error
     _filter.assert_keys(
-        args or {},
+        cl_args or {},
         _DEFAULT_ARGS.keys(),
         "Invalid attributes in CL configuration for "
         + participant_name
@@ -51,7 +69,7 @@ def _parse(args, participant_name, network_params, registry, cl_kind):
 
     # We filter the None values so that we can merge dicts easily
     # and merge the config with the defaults
-    cl_params = _DEFAULT_ARGS | _filter.remove_none(args or {})
+    cl_params = _DEFAULT_ARGS | _filter.remove_none(cl_args or {})
 
     # We default the image to the one in the registry
     #
@@ -69,6 +87,7 @@ def _parse(args, participant_name, network_params, registry, cl_kind):
     cl_params["labels"] = {
         "op.kind": cl_kind,
         "op.network.id": str(network_id),
+        "op.network.participant.index": str(participant_index),
         "op.network.participant.name": participant_name,
         "op.cl.type": cl_params["type"],
     }

--- a/src/l2/participant/el/input_parser.star
+++ b/src/l2/participant/el/input_parser.star
@@ -32,29 +32,41 @@ _IMAGE_IDS = {
 }
 
 
-def parse(el_args, participant_name, network_params, registry):
+def parse(el_args, participant_name, participant_index, network_params, registry):
     return _parse(
         el_args=el_args,
         default_args=_DEFAULT_ARGS,
         participant_name=participant_name,
+        participant_index=participant_index,
         network_params=network_params,
         registry=registry,
         el_kind="el",
     )
 
 
-def parse_builder(el_args, participant_name, network_params, registry):
+def parse_builder(
+    el_args, participant_name, participant_index, network_params, registry
+):
     return _parse(
         el_args=el_args,
         default_args=_DEFAULT_BUILDER_ARGS,
         participant_name=participant_name,
+        participant_index=participant_index,
         network_params=network_params,
         registry=registry,
         el_kind="elbuilder",
     )
 
 
-def _parse(el_args, default_args, participant_name, network_params, registry, el_kind):
+def _parse(
+    el_args,
+    default_args,
+    participant_name,
+    participant_index,
+    network_params,
+    registry,
+    el_kind,
+):
     network_id = network_params.network_id
     network_name = network_params.name
 
@@ -89,6 +101,7 @@ def _parse(el_args, default_args, participant_name, network_params, registry, el
     el_params["labels"] = {
         "op.kind": el_kind,
         "op.network.id": str(network_id),
+        "op.network.participant.index": str(participant_index),
         "op.network.participant.name": participant_name,
         "op.el.type": el_params["type"],
     }

--- a/src/l2/participant/input_parser.star
+++ b/src/l2/participant/input_parser.star
@@ -138,6 +138,7 @@ def _parse_instance(
         conductor_args=participant_params["conductor_params"],
         network_params=network_params,
         participant_name=participant_name,
+        participant_index=participant_index,
         registry=registry,
     )
 

--- a/src/l2/participant/input_parser.star
+++ b/src/l2/participant/input_parser.star
@@ -21,10 +21,16 @@ _DEFAULT_ARGS = {
 
 
 def parse(args, network_params, registry):
+    participant_index_generator = _id.autoincrement(initial=0)
+
     participants_params = _filter.remove_none(
         [
             _parse_instance(
-                participant_args or {}, participant_name, network_params, registry
+                participant_args=participant_args or {},
+                participant_name=participant_name,
+                participant_index_generator=participant_index_generator,
+                network_params=network_params,
+                registry=registry,
             )
             for participant_name, participant_args in (args or {}).items()
         ]
@@ -50,9 +56,21 @@ def parse(args, network_params, registry):
     return participants_params
 
 
-def _parse_instance(participant_args, participant_name, network_params, registry):
+def _parse_instance(
+    participant_args,
+    participant_name,
+    participant_index_generator,
+    network_params,
+    registry,
+):
     network_id = network_params.network_id
     network_name = network_params.name
+
+    # To bridge the legacy list format to the new dictionary format for participants,
+    # we introduce an index label
+    #
+    # This will be added to the EL/CL labels so that the optimism devent SDK can extract the legacy node index
+    participant_index = participant_index_generator()
 
     # Any extra attributes will cause an error
     _filter.assert_keys(
@@ -108,6 +126,7 @@ def _parse_instance(participant_args, participant_name, network_params, registry
         mev_args=participant_params["mev_params"],
         network_params=network_params,
         participant_name=participant_name,
+        participant_index=participant_index,
         registry=registry,
     )
 
@@ -124,18 +143,35 @@ def _parse_instance(participant_args, participant_name, network_params, registry
 
     return struct(
         el=_el_input_parser.parse(
-            participant_params["el"], participant_name, network_params, registry
+            el_args=participant_params["el"],
+            participant_name=participant_name,
+            participant_index=participant_index,
+            network_params=network_params,
+            registry=registry,
         ),
         el_builder=_el_input_parser.parse_builder(
-            participant_params["el_builder"], participant_name, network_params, registry
+            el_args=participant_params["el_builder"],
+            participant_name=participant_name,
+            participant_index=participant_index,
+            network_params=network_params,
+            registry=registry,
         ),
         cl=_cl_input_parser.parse(
-            participant_params["cl"], participant_name, network_params, registry
+            cl_args=participant_params["cl"],
+            participant_name=participant_name,
+            participant_index=participant_index,
+            network_params=network_params,
+            registry=registry,
         ),
         cl_builder=_cl_input_parser.parse_builder(
-            participant_params["cl_builder"], participant_name, network_params, registry
+            cl_args=participant_params["cl_builder"],
+            participant_name=participant_name,
+            participant_index=participant_index,
+            network_params=network_params,
+            registry=registry,
         ),
         name=participant_name,
+        index=participant_index,
         sequencer=sequencer,
         mev_params=mev_params,
         conductor_params=conductor_params,

--- a/src/mev/input_parser.star
+++ b/src/mev/input_parser.star
@@ -15,7 +15,7 @@ _IMAGE_IDS = {
 }
 
 
-def parse(mev_args, network_params, participant_name, registry):
+def parse(mev_args, network_params, participant_name, participant_index, registry):
     network_id = network_params.network_id
     network_name = network_params.name
 
@@ -53,6 +53,7 @@ def parse(mev_args, network_params, participant_name, registry):
         "op.kind": "mev",
         "op.network.id": str(network_id),
         "op.mev.type": mev_params["type"],
+        "op.network.participant.index": str(participant_index),
         "op.network.participant.name": participant_name,
     }
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -330,6 +330,9 @@ def parse_network_params(plan, registry, input_args):
             # FIXME At the moment the "name" of the sequencer is just its index in the array
             # so we pass 0 as the name
             participant_name="0",
+            # FIXME At the moment the index of the sequencer is just its index in the array
+            # so we pass 0 as the index
+            participant_index=0,
             registry=registry,
         )
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -315,6 +315,9 @@ def parse_network_params(plan, registry, input_args):
             # FIXME At the moment the "name" of the sequencer is just its index in the array
             # so we pass 0 as the name
             participant_name="0",
+            # FIXME At the moment the index of the sequencer is just its index in the array
+            # so we pass 0 as the index
+            participant_index=0,
             registry=registry,
         )
 

--- a/src/proxyd/launcher.star
+++ b/src/proxyd/launcher.star
@@ -98,6 +98,7 @@ def get_service_config(
         image=params.image,
         ports=ports,
         cmd=cmd,
+        labels=params.labels,
         files={
             _CONFIG_DIRPATH_ON_SERVICE: config_artifact_name,
         },

--- a/src/proxyd/launcher.star
+++ b/src/proxyd/launcher.star
@@ -98,7 +98,6 @@ def get_service_config(
         image=params.image,
         ports=ports,
         cmd=cmd,
-        labels=params.labels,
         files={
             _CONFIG_DIRPATH_ON_SERVICE: config_artifact_name,
         },

--- a/src/supervisor/input_parser.star
+++ b/src/supervisor/input_parser.star
@@ -86,6 +86,12 @@ def _parse_instance(supervisor_args, supervisor_name, superchains, registry):
         )
     }
 
+    supervisor_params["labels"] = {
+        "op.kind": "supervisor",
+        "op.supervisor.type": supervisor_params["type"],
+        "op.supervisor.superchain": superchain.name,
+    }
+
     return struct(**supervisor_params)
 
 

--- a/src/supervisor/kona-supervisor/launcher.star
+++ b/src/supervisor/kona-supervisor/launcher.star
@@ -70,6 +70,7 @@ def _get_config(
     return ServiceConfig(
         image=params.image,
         ports=ports,
+        labels=params.labels,
         files={
             DATA_DIR: params.superchain.dependency_set.name,
             _ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: deployment_output,

--- a/src/supervisor/op-supervisor/launcher.star
+++ b/src/supervisor/op-supervisor/launcher.star
@@ -69,6 +69,7 @@ def _get_config(
     return ServiceConfig(
         image=params.image,
         ports=ports,
+        labels=params.labels,
         files={
             DATA_DIR: params.superchain.dependency_set.name,
             _ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: deployment_output,

--- a/test/challenger/input_parser_test.star
+++ b/test/challenger/input_parser_test.star
@@ -39,6 +39,7 @@ def test_challenger_input_parser_default_args(plan):
         service_name="op-challenger-challenger-1000-2000",
         enabled=True,
         image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-challenger:develop",
+        labels={"op.kind": "challenger", "op.network.id": "1000,2000"},
         extra_params=[],
         participants=[1000, 2000],
         cannon_prestate_path="",

--- a/test/conductor/input_parser_test.star
+++ b/test/conductor/input_parser_test.star
@@ -4,6 +4,7 @@ _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
 _default_network_params = struct(network_id=1000, name="my-l2")
+_default_participant_index = 0
 _default_participant_name = "node0"
 _default_registry = _registry.Registry()
 
@@ -11,10 +12,11 @@ _default_registry = _registry.Registry()
 def test_conductor_input_parser_extra_attributes(plan):
     expect.fails(
         lambda: _input_parser.parse(
-            {"extra": None, "name": "x"},
-            _default_network_params,
-            _default_participant_name,
-            _default_registry,
+            conductor_args={"extra": None, "name": "x"},
+            network_params=_default_network_params,
+            participant_index=_default_participant_index,
+            participant_name=_default_participant_name,
+            registry=_default_registry,
         ),
         "Invalid attributes in conductor configuration for node0 on network my-l2: extra,name",
     )
@@ -23,20 +25,22 @@ def test_conductor_input_parser_extra_attributes(plan):
 def test_conductor_input_parser_default_args(plan):
     expect.eq(
         _input_parser.parse(
-            None,
-            _default_network_params,
-            _default_participant_name,
-            _default_registry,
+            conductor_args=None,
+            network_params=_default_network_params,
+            participant_index=_default_participant_index,
+            participant_name=_default_participant_name,
+            registry=_default_registry,
         ),
         None,
     )
 
     expect.eq(
         _input_parser.parse(
-            {},
-            _default_network_params,
-            _default_participant_name,
-            _default_registry,
+            conductor_args={},
+            network_params=_default_network_params,
+            participant_index=_default_participant_index,
+            participant_name=_default_participant_name,
+            registry=_default_registry,
         ),
         None,
     )
@@ -50,6 +54,7 @@ def test_conductor_input_parser_default_args_enabled(plan):
         labels={
             "op.kind": "conductor",
             "op.network.id": "1000",
+            "op.network.participant.index": "0",
             "op.network.participant.name": "node0",
             "op.conductor.type": "op-conductor",
         },
@@ -66,14 +71,15 @@ def test_conductor_input_parser_default_args_enabled(plan):
 
     expect.eq(
         _input_parser.parse(
-            {
+            conductor_args={
                 "enabled": True,
                 "image": None,
                 "extra_params": None,
             },
-            _default_network_params,
-            _default_participant_name,
-            _default_registry,
+            network_params=_default_network_params,
+            participant_index=_default_participant_index,
+            participant_name=_default_participant_name,
+            registry=_default_registry,
         ),
         _default_params,
     )
@@ -81,13 +87,14 @@ def test_conductor_input_parser_default_args_enabled(plan):
 
 def test_conductor_input_parser_custom_params(plan):
     parsed = _input_parser.parse(
-        {
+        conductor_args={
             "enabled": True,
             "image": "op-conductor:brightest",
         },
-        _default_network_params,
-        _default_participant_name,
-        _default_registry,
+        network_params=_default_network_params,
+        participant_index=_default_participant_index,
+        participant_name=_default_participant_name,
+        registry=_default_registry,
     )
 
     expect.eq(
@@ -99,6 +106,7 @@ def test_conductor_input_parser_custom_params(plan):
             labels={
                 "op.kind": "conductor",
                 "op.network.id": "1000",
+                "op.network.participant.index": "0",
                 "op.network.participant.name": "node0",
                 "op.conductor.type": "op-conductor",
             },
@@ -119,17 +127,19 @@ def test_conductor_input_parser_custom_registry(plan):
     registry = _registry.Registry({_registry.OP_CONDUCTOR: "conductor:greatest"})
 
     parsed = _input_parser.parse(
-        {"enabled": True},
-        _default_network_params,
-        _default_participant_name,
-        registry,
+        conductor_args={"enabled": True},
+        network_params=_default_network_params,
+        participant_index=_default_participant_index,
+        participant_name=_default_participant_name,
+        registry=registry,
     )
     expect.eq(parsed.image, "conductor:greatest")
 
     parsed = _input_parser.parse(
-        {"enabled": True, "image": "conductor:oldest"},
-        _default_network_params,
-        _default_participant_name,
-        registry,
+        conductor_args={"enabled": True, "image": "conductor:oldest"},
+        network_params=_default_network_params,
+        participant_index=_default_participant_index,
+        participant_name=_default_participant_name,
+        registry=registry,
     )
     expect.eq(parsed.image, "conductor:oldest")

--- a/test/l2/participant/cl/launcher_test.star
+++ b/test/l2/participant/cl/launcher_test.star
@@ -385,6 +385,7 @@ def test_l2_participant_cl_launcher_incompatible_conductor(plan):
 
     conductor_params = _conductor_input_parser.parse(
         conductor_args={"enabled": True},
+        participant_index=0,
         participant_name=participant_params.name,
         network_params=l2_params.network_params,
         registry=_default_registry,

--- a/test/l2/participant/cl/launcher_test.star
+++ b/test/l2/participant/cl/launcher_test.star
@@ -104,6 +104,7 @@ def test_l2_participant_cl_launcher_hildr(plan):
         {
             "op.kind": "cl",
             "op.network.id": "2151908",
+            "op.network.participant.index": "0",
             "op.network.participant.name": "node0",
             "op.cl.type": "hildr",
         },
@@ -227,6 +228,7 @@ def test_l2_participant_cl_launcher_kona_node(plan):
         {
             "op.kind": "cl",
             "op.network.id": "2151908",
+            "op.network.participant.index": "0",
             "op.network.participant.name": "node0",
             "op.cl.type": "kona-node",
         },
@@ -334,6 +336,7 @@ def test_l2_participant_cl_launcher_op_node(plan):
         {
             "op.kind": "cl",
             "op.network.id": "2151908",
+            "op.network.participant.index": "0",
             "op.network.participant.name": "node0",
             "op.cl.type": "op-node",
         },

--- a/test/l2/participant/el/launcher_test.star
+++ b/test/l2/participant/el/launcher_test.star
@@ -112,6 +112,7 @@ def test_l2_participant_el_launcher_op_besu(plan):
         {
             "op.kind": "el",
             "op.network.id": "2151908",
+            "op.network.participant.index": "0",
             "op.network.participant.name": "node0",
             "op.el.type": "op-besu",
         },
@@ -188,6 +189,7 @@ def test_l2_participant_el_launcher_op_erigon(plan):
         {
             "op.kind": "el",
             "op.network.id": "2151908",
+            "op.network.participant.index": "0",
             "op.network.participant.name": "node0",
             "op.el.type": "op-erigon",
         },
@@ -264,6 +266,7 @@ def test_l2_participant_el_launcher_op_geth(plan):
         {
             "op.kind": "el",
             "op.network.id": "2151908",
+            "op.network.participant.index": "0",
             "op.network.participant.name": "node0",
             "op.el.type": "op-geth",
         },
@@ -359,6 +362,7 @@ def test_l2_participant_el_launcher_op_nethermind(plan):
         {
             "op.kind": "el",
             "op.network.id": "2151908",
+            "op.network.participant.index": "0",
             "op.network.participant.name": "node0",
             "op.el.type": "op-nethermind",
         },
@@ -456,6 +460,7 @@ def test_l2_participant_el_launcher_op_rbuilder(plan):
         {
             "op.kind": "elbuilder",
             "op.network.id": "2151908",
+            "op.network.participant.index": "0",
             "op.network.participant.name": "node0",
             "op.el.type": "op-rbuilder",
         },
@@ -554,6 +559,7 @@ def test_l2_participant_el_launcher_op_reth(plan):
         {
             "op.kind": "el",
             "op.network.id": "2151908",
+            "op.network.participant.index": "0",
             "op.network.participant.name": "node0",
             "op.el.type": "op-reth",
         },

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -73,6 +73,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     labels={
                         "op.kind": "cl",
                         "op.network.id": "1000",
+                        "op.network.participant.index": "0",
                         "op.network.participant.name": "node0",
                         "op.cl.type": "op-node",
                     },
@@ -93,6 +94,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     labels={
                         "op.kind": "clbuilder",
                         "op.network.id": "1000",
+                        "op.network.participant.index": "0",
                         "op.network.participant.name": "node0",
                         "op.cl.type": "op-node",
                     },
@@ -113,6 +115,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     labels={
                         "op.kind": "el",
                         "op.network.id": "1000",
+                        "op.network.participant.index": "0",
                         "op.network.participant.name": "node0",
                         "op.el.type": "op-geth",
                     },
@@ -135,6 +138,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     labels={
                         "op.kind": "elbuilder",
                         "op.network.id": "1000",
+                        "op.network.participant.index": "0",
                         "op.network.participant.name": "node0",
                         "op.el.type": "op-geth",
                     },
@@ -157,6 +161,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     labels={
                         "op.kind": "mev",
                         "op.network.id": "1000",
+                        "op.network.participant.index": "0",
                         "op.network.participant.name": "node0",
                         "op.mev.type": "rollup-boost",
                     },
@@ -179,6 +184,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     labels={
                         "op.kind": "cl",
                         "op.network.id": "1000",
+                        "op.network.participant.index": "1",
                         "op.network.participant.name": "node1",
                         "op.cl.type": "op-node",
                     },
@@ -199,6 +205,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     labels={
                         "op.kind": "clbuilder",
                         "op.network.id": "1000",
+                        "op.network.participant.index": "1",
                         "op.network.participant.name": "node1",
                         "op.cl.type": "op-node",
                     },
@@ -219,6 +226,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     labels={
                         "op.kind": "el",
                         "op.network.id": "1000",
+                        "op.network.participant.index": "1",
                         "op.network.participant.name": "node1",
                         "op.el.type": "op-geth",
                     },
@@ -241,6 +249,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     labels={
                         "op.kind": "elbuilder",
                         "op.network.id": "1000",
+                        "op.network.participant.index": "1",
                         "op.network.participant.name": "node1",
                         "op.el.type": "op-geth",
                     },
@@ -263,6 +272,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     labels={
                         "op.kind": "mev",
                         "op.network.id": "1000",
+                        "op.network.participant.index": "1",
                         "op.network.participant.name": "node1",
                         "op.mev.type": "rollup-boost",
                     },

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -322,6 +322,7 @@ def test_l2_participant_input_parser_defaults_conductor_enabled(plan):
             labels={
                 "op.kind": "conductor",
                 "op.network.id": "1000",
+                "op.network.participant.index": "0",
                 "op.network.participant.name": "node0",
                 "op.conductor.type": "op-conductor",
             },

--- a/test/mev/input_parser_test.star
+++ b/test/mev/input_parser_test.star
@@ -128,6 +128,7 @@ def test_mev_input_parser_custom_params(plan):
             labels={
                 "op.kind": "mev",
                 "op.network.id": "1000",
+                "op.network.participant.index": "0",
                 "op.network.participant.name": "node0",
                 "op.mev.type": "rollup-boost",
             },

--- a/test/mev/input_parser_test.star
+++ b/test/mev/input_parser_test.star
@@ -4,6 +4,7 @@ _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
 _default_network_params = struct(network_id=1000, name="my-l2")
+_default_participant_index = 0
 _default_participant_name = "node0"
 _default_registry = _registry.Registry()
 
@@ -11,10 +12,11 @@ _default_registry = _registry.Registry()
 def test_mev_input_parser_extra_attributes(plan):
     expect.fails(
         lambda: _input_parser.parse(
-            {"extra": None, "name": "x"},
-            _default_network_params,
-            _default_participant_name,
-            _default_registry,
+            mev_args={"extra": None, "name": "x"},
+            network_params=_default_network_params,
+            participant_index=_default_participant_index,
+            participant_name=_default_participant_name,
+            registry=_default_registry,
         ),
         "Invalid attributes in MEV configuration for node0 on network my-l2: extra,name",
     )
@@ -23,20 +25,22 @@ def test_mev_input_parser_extra_attributes(plan):
 def test_mev_input_parser_invalid_builder_params(plan):
     expect.fails(
         lambda: _input_parser.parse(
-            {"builder_port": "7"},
-            _default_network_params,
-            _default_participant_name,
-            _default_registry,
+            mev_args={"builder_port": "7"},
+            network_params=_default_network_params,
+            participant_index=_default_participant_index,
+            participant_name=_default_participant_name,
+            registry=_default_registry,
         ),
         "Missing builder_host in MEV configuration for node0 on network my-l2",
     )
 
     expect.fails(
         lambda: _input_parser.parse(
-            {"builder_host": "localhost"},
-            _default_network_params,
-            _default_participant_name,
-            _default_registry,
+            mev_args={"builder_host": "localhost"},
+            network_params=_default_network_params,
+            participant_index=_default_participant_index,
+            participant_name=_default_participant_name,
+            registry=_default_registry,
         ),
         "Missing builder_port in MEV configuration for node0 on network my-l2",
     )
@@ -52,6 +56,7 @@ def test_mev_input_parser_default_args(plan):
         labels={
             "op.kind": "mev",
             "op.network.id": "1000",
+            "op.network.participant.index": "0",
             "op.network.participant.name": "node0",
             "op.mev.type": "rollup-boost",
         },
@@ -62,35 +67,38 @@ def test_mev_input_parser_default_args(plan):
 
     expect.eq(
         _input_parser.parse(
-            None,
-            _default_network_params,
-            _default_participant_name,
-            _default_registry,
+            mev_args=None,
+            network_params=_default_network_params,
+            participant_index=_default_participant_index,
+            participant_name=_default_participant_name,
+            registry=_default_registry,
         ),
         _default_params,
     )
 
     expect.eq(
         _input_parser.parse(
-            {},
-            _default_network_params,
-            _default_participant_name,
-            _default_registry,
+            mev_args={},
+            network_params=_default_network_params,
+            participant_index=_default_participant_index,
+            participant_name=_default_participant_name,
+            registry=_default_registry,
         ),
         _default_params,
     )
 
     expect.eq(
         _input_parser.parse(
-            {
+            mev_args={
                 "image": None,
                 "type": None,
                 "builder_host": None,
                 "builder_port": None,
             },
-            _default_network_params,
-            _default_participant_name,
-            _default_registry,
+            network_params=_default_network_params,
+            participant_index=_default_participant_index,
+            participant_name=_default_participant_name,
+            registry=_default_registry,
         ),
         _default_params,
     )
@@ -98,14 +106,15 @@ def test_mev_input_parser_default_args(plan):
 
 def test_mev_input_parser_custom_params(plan):
     parsed = _input_parser.parse(
-        {
+        mev_args={
             "image": "op-rollup-boost:brightest",
             "builder_host": "localhost",
             "builder_port": 8080,
         },
-        _default_network_params,
-        _default_participant_name,
-        _default_registry,
+        network_params=_default_network_params,
+        participant_index=_default_participant_index,
+        participant_name=_default_participant_name,
+        registry=_default_registry,
     )
 
     expect.eq(
@@ -133,17 +142,19 @@ def test_mev_input_parser_custom_registry(plan):
     registry = _registry.Registry({_registry.ROLLUP_BOOST: "rollup-boost:greatest"})
 
     parsed = _input_parser.parse(
-        {},
-        _default_network_params,
-        _default_participant_name,
-        registry,
+        mev_args={},
+        network_params=_default_network_params,
+        participant_index=_default_participant_index,
+        participant_name=_default_participant_name,
+        registry=registry,
     )
     expect.eq(parsed.image, "rollup-boost:greatest")
 
     parsed = _input_parser.parse(
-        {"image": "rollup-boost:oldest"},
-        _default_network_params,
-        _default_participant_name,
-        registry,
+        mev_args={"image": "rollup-boost:oldest"},
+        network_params=_default_network_params,
+        participant_index=_default_participant_index,
+        participant_name=_default_participant_name,
+        registry=registry,
     )
     expect.eq(parsed.image, "rollup-boost:oldest")

--- a/test/supervisor/input_parser_test.star
+++ b/test/supervisor/input_parser_test.star
@@ -87,6 +87,11 @@ def test_supervisor_input_parser_default_args(plan):
                 enabled=True,
                 extra_params=[],
                 image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-supervisor:develop",
+                labels={
+                    "op.kind": "supervisor",
+                    "op.supervisor.type": "op-supervisor",
+                    "op.supervisor.superchain": "superchain0",
+                },
                 name="supervisor0",
                 ports={
                     "rpc": _net.port(


### PR DESCRIPTION
**Description**

This PR adds missing and new labels to OP services:

- `op.network.participant.index` label to EL, CL, conductor and MEV to emulate the legacy
- Labels for challenger
- Labels for faucet
