### PR TITLE
chore: Support multiple sequencers: Update ID assertions [39/N]

### DIFF
--- a/src/l2/input_parser.star
+++ b/src/l2/input_parser.star
@@ -87,7 +87,7 @@ def _parse_instance(l2_args, l2_name, l2_id_generator, registry):
     )
 
     # We make sure the L2 name is a valid name
-    _id.assert_id(l2_name)
+    _id.assert_id(id=l2_name, name="L2 name")
 
     # We filter the None values so that we can merge dicts easily
     l2_params = _DEFAULT_ARGS | _filter.remove_none(l2_args or {})

--- a/src/l2/participant/input_parser.star
+++ b/src/l2/participant/input_parser.star
@@ -87,7 +87,7 @@ def _parse_instance(
     participant_params = _DEFAULT_ARGS | _filter.remove_none(participant_args or {})
 
     # We make sure the name adheres to our standards
-    _id.assert_id(participant_name)
+    _id.assert_id(id=participant_name, name="Node on network {}".format(network_name))
 
     # Now we make sure the sequencer property is valid
     #

--- a/src/l2/participant/input_parser.star
+++ b/src/l2/participant/input_parser.star
@@ -87,7 +87,9 @@ def _parse_instance(
     participant_params = _DEFAULT_ARGS | _filter.remove_none(participant_args or {})
 
     # We make sure the name adheres to our standards
-    _id.assert_id(id=participant_name, name="Node on network {}".format(network_name))
+    _id.assert_id(
+        id=participant_name, name="Name of the node on network {}".format(network_name)
+    )
 
     # Now we make sure the sequencer property is valid
     #

--- a/src/util/id.star
+++ b/src/util/id.star
@@ -1,7 +1,20 @@
-# IDs cannot contain '-' as we use '-' to separate elements in naming conventions
-def assert_id(id):
-    if "-" in id:
-        fail("ID cannot contain '-': {}".format(id))
+# IDs, since they are being used in service names, can only contain alphanumeric characters and -
+def assert_id(id, name="ID"):
+    if not id.strip():
+        fail("{} cannot be empty or whitespace only, got '{}'".format(name, id))
+
+    # Unfortunately starlark does not support regular expressions so we'll have to do the check char by char
+    allowed = "0123456789-abcdefghijklmnopqrstuvwxyz"
+
+    for char in id.elems():
+        if not char in allowed and not char.lower() in allowed:
+            fail(
+                "{} can only contain alphanumeric characters and '-', got '{}'".format(
+                    name, id
+                )
+            )
+
+    return id
 
 
 # Returns a autoincrementing ID generator function whose first value will be the `initial` argument

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -33,8 +33,8 @@ def test_l2_input_parser_extra_attributes(plan):
 
 def test_l2_input_parser_invalid_name(plan):
     expect.fails(
-        lambda: input_parser.parse({"network-0": None}, _default_registry),
-        "ID cannot contain '-': network-0",
+        lambda: input_parser.parse({"network_0": None}, _default_registry),
+        "L2 name can only contain alphanumeric characters and '-', got 'network_0'",
     )
 
 

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -52,7 +52,7 @@ def test_l2_participant_input_parser_invalid_name(plan):
         lambda: input_parser.parse(
             {"node_0": None}, _default_network_params, _default_registry
         ),
-        "Node on network my-l2 can only contain alphanumeric characters and '-', got 'node_0'",
+        "Name of the node on network my-l2 can only contain alphanumeric characters and '-', got 'node_0'",
     )
 
 

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -50,9 +50,9 @@ def test_l2_participant_input_parser_extra_attributes(plan):
 def test_l2_participant_input_parser_invalid_name(plan):
     expect.fails(
         lambda: input_parser.parse(
-            {"node-0": None}, _default_network_params, _default_registry
+            {"node_0": None}, _default_network_params, _default_registry
         ),
-        "ID cannot contain '-': node-0",
+        "Node on network my-l2 can only contain alphanumeric characters and '-', got 'node_0'",
     )
 
 

--- a/test/util/id_test.star
+++ b/test/util/id_test.star
@@ -1,6 +1,44 @@
 _id = import_module("/src/util/id.star")
 
 
+def test_id_assert_id(plan):
+    expect.fails(
+        lambda: _id.assert_id(""), "ID cannot be empty or whitespace only, got ''"
+    )
+    expect.fails(
+        lambda: _id.assert_id("   "), "ID cannot be empty or whitespace only, got '   '"
+    )
+
+    expect.fails(
+        lambda: _id.assert_id("no_underscores"),
+        "ID can only contain alphanumeric characters and '-', got 'no_underscores'",
+    )
+    expect.fails(
+        lambda: _id.assert_id("no.periods"),
+        "ID can only contain alphanumeric characters and '-', got 'no\\.periods'",
+    )
+    expect.fails(
+        lambda: _id.assert_id("no,commas"),
+        "ID can only contain alphanumeric characters and '-', got 'no,commas'",
+    )
+    expect.fails(
+        lambda: _id.assert_id("no?weirdness"),
+        "ID can only contain alphanumeric characters and '-', got 'no\\?weirdness'",
+    )
+
+    expect.fails(
+        lambda: _id.assert_id(" ", "A name"),
+        "A name cannot be empty or whitespace only, got ' '",
+    )
+    expect.fails(
+        lambda: _id.assert_id("custom?name", "A name"),
+        "A name can only contain alphanumeric characters and '-', got 'custom\\?name'",
+    )
+
+    expect.eq(_id.assert_id("-"), "-")
+    expect.eq(_id.assert_id("abcd1234-"), "abcd1234-")
+
+
 def test_id_autoincrement_default_initial_value(plan):
     id = _id.autoincrement()
 


### PR DESCRIPTION
**Description**

With the switch to label-based parsing, the ID assertions have changed