### PR TITLE
fix(op-faucet): set op.network.id label

### DIFF
--- a/src/faucet/op-faucet/op_faucet_launcher.star
+++ b/src/faucet/op-faucet/op_faucet_launcher.star
@@ -32,8 +32,9 @@ def launch(
     )
 
     config = _get_config(
-        image,
-        faucet_config,
+        image=image,
+        faucet_config=faucet_config,
+        network_ids=[f.ChainID for f in faucets],
     )
     plan.add_service(service_name, config)
 
@@ -41,12 +42,14 @@ def launch(
 def _get_config(
     image,
     faucet_config,
+    network_ids,
 ):
     """Get the ServiceConfig for the op-faucet service.
 
     Args:
         image (str): The image to use for the op-faucet service.
         faucet_config (artifact): The config artifact for the op-faucet service.
+        network_ids (list of str): The network IDs to use for the op-faucet service.
     """
     mount_path = "/config"
     cmd = [
@@ -66,8 +69,8 @@ def _get_config(
             ),
         },
         labels={
-            "op.kind": "faucet"
-            # TODO Add network IDs
+            "op.kind": "faucet",
+            "op.network.id": "-".join(network_ids),
         },
         files={
             mount_path: faucet_config,


### PR DESCRIPTION
This change sets the faucet labels properly, so we can use them in
service recognition downstream.