### PR TITLE
fix(op-faucet): loosen expectation on network_id type

### DIFF
--- a/src/faucet/op-faucet/op_faucet_launcher.star
+++ b/src/faucet/op-faucet/op_faucet_launcher.star
@@ -70,7 +70,7 @@ def _get_config(
         },
         labels={
             "op.kind": "faucet",
-            "op.network.id": "-".join(network_ids),
+            "op.network.id": "-".join([str(network_id) for network_id in network_ids]),
         },
         files={
             mount_path: faucet_config,

--- a/test/op_faucet_launcher_test.star
+++ b/test/op_faucet_launcher_test.star
@@ -21,7 +21,7 @@ def test_launch_with_defaults(plan):
             name="l1",
         ),
         op_faucet_launcher.faucet_data(
-            chain_id="10",
+            chain_id=10,
             el_rpc="http://l2-rpc",
             private_key=constants.dev_accounts[1]["private_key"],
             name="l2",


### PR DESCRIPTION
Network IDs can be expressed as integers in the yaml descriptor.
Handle the faucet label in a more robust manner.