### PR TITLE
feat(OPCM): OPCM.migrate [1/N]

### DIFF
--- a/main.star
+++ b/main.star
@@ -315,7 +315,7 @@ def _launch_opcm_migrate_maybe(
     deployment_output,
 ):
     if l2_params.migration_params:
-        log_prefix = "L2 network {}".format(l2_params.name)
+        log_prefix = "L2 network {}".format(l2_params.network_params.name)
 
         plan.print("{}: Running interop migration".format(log_prefix))
 

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -50,6 +50,8 @@ optimism_package:
         enabled: true
       tx_fuzzer_params:
         enabled: true
+      migration_params:
+        enabled: true
   op_contract_deployer_params:
     image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.4.0-rc.2
     l1_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-02024c5a26c16fc1a5c716fff1c46b5bf7f23890d431bb554ddbad60971211d4.tar.gz

--- a/src/contracts/artifacts.star
+++ b/src/contracts/artifacts.star
@@ -1,0 +1,49 @@
+def normalize_locator(locator):
+    """Transform artifact locator from 'artifact://NAME' format to (name, file_path) pair.
+
+    If the locator doesn't use the artifact:// format, returns (None, original_locator).
+
+    Args:
+        locator: The original artifact locator string
+
+    Returns:
+        tuple: (artifact_name, normalized_locator, mount_point)
+    """
+    if locator and locator.startswith("artifact://"):
+        artifact_name = locator[len("artifact://") :]
+        mount_point = "/{0}".format(artifact_name)
+        return (artifact_name, "file://{0}".format(mount_point), mount_point)
+    return (None, locator, None)
+
+
+def normalize_locators(plan, l1_locator, l2_locator):
+    """Normalize artifact locators with specific mount points.
+
+    Args:
+        plan: The plan object
+        l1_locator: The L1 artifact locator
+        l2_locator: The L2 artifact locator
+
+    Returns:
+        tuple: (l1_artifacts_locator, l2_artifacts_locator, extra_files)
+    """
+    (
+        l1_artifact_name,
+        l1_artifacts_locator,
+        l1_mount_point,
+    ) = normalize_locator(l1_locator)
+    (
+        l2_artifact_name,
+        l2_artifacts_locator,
+        l2_mount_point,
+    ) = normalize_locator(l2_locator)
+
+    extra_files = {}
+    if l1_mount_point:
+        extra_files[l1_mount_point] = plan.get_files_artifact(name=l1_artifact_name)
+    if (
+        l2_mount_point and l2_mount_point not in extra_files
+    ):  # shortcut if both are the same
+        extra_files[l2_mount_point] = plan.get_files_artifact(name=l2_artifact_name)
+
+    return l1_artifacts_locator, l2_artifacts_locator, extra_files

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -1,12 +1,7 @@
-ENVRC_PATH = "/workspace/optimism/.envrc"
-FACTORY_DEPLOYER_ADDRESS = "0x3fAB184622Dc19b6109349B94811493BF2a45362"
-FACTORY_ADDRESS = "0x4e59b44847b379578588920cA78FbF26c0B4956C"
-# raw tx data for deploying Create2Factory contract to L1
-FACTORY_DEPLOYER_CODE = "0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222"
-
 FUND_SCRIPT_FILEPATH = "../../static_files/scripts"
 
 utils = import_module("../util.star")
+_artifacts = import_module("./artifacts.star")
 _filter = import_module("../util/filter.star")
 
 ethereum_package_genesis_constants = import_module(
@@ -18,57 +13,6 @@ CANNED_VALUES = {
     "eip1559DenominatorCanyon": 250,
     "eip1559Elasticity": 6,
 }
-
-
-def _normalize_artifacts_locator(locator):
-    """Transform artifact locator from 'artifact://NAME' format to (name, file_path) pair.
-
-    If the locator doesn't use the artifact:// format, returns (None, original_locator).
-
-    Args:
-        locator: The original artifact locator string
-
-    Returns:
-        tuple: (artifact_name, normalized_locator, mount_point)
-    """
-    if locator and locator.startswith("artifact://"):
-        artifact_name = locator[len("artifact://") :]
-        mount_point = "/{0}".format(artifact_name)
-        return (artifact_name, "file://{0}".format(mount_point), mount_point)
-    return (None, locator, None)
-
-
-def _normalize_artifacts_locators(plan, l1_locator, l2_locator):
-    """Normalize artifact locators with specific mount points.
-
-    Args:
-        plan: The plan object
-        l1_locator: The L1 artifact locator
-        l2_locator: The L2 artifact locator
-
-    Returns:
-        tuple: (l1_artifacts_locator, l2_artifacts_locator, extra_files)
-    """
-    (
-        l1_artifact_name,
-        l1_artifacts_locator,
-        l1_mount_point,
-    ) = _normalize_artifacts_locator(l1_locator)
-    (
-        l2_artifact_name,
-        l2_artifacts_locator,
-        l2_mount_point,
-    ) = _normalize_artifacts_locator(l2_locator)
-
-    extra_files = {}
-    if l1_mount_point:
-        extra_files[l1_mount_point] = plan.get_files_artifact(name=l1_artifact_name)
-    if (
-        l2_mount_point and l2_mount_point not in extra_files
-    ):  # shortcut if both are the same
-        extra_files[l2_mount_point] = plan.get_files_artifact(name=l2_artifact_name)
-
-    return l1_artifacts_locator, l2_artifacts_locator, extra_files
 
 
 def deploy_contracts(
@@ -105,7 +49,7 @@ def deploy_contracts(
         l1_artifacts_locator,
         l2_artifacts_locator,
         contracts_extra_files,
-    ) = _normalize_artifacts_locators(
+    ) = _artifacts.normalize_locators(
         plan,
         optimism_args.op_contract_deployer_params.l1_artifacts_locator,
         optimism_args.op_contract_deployer_params.l2_artifacts_locator,

--- a/src/contracts/opcm_migrator.star
+++ b/src/contracts/opcm_migrator.star
@@ -1,4 +1,5 @@
 utils = import_module("../util.star")
+_artifacts = import_module("./artifacts.star")
 _filter = import_module("../util/filter.star")
 
 ethereum_package_genesis_constants = import_module(
@@ -21,7 +22,7 @@ def launch(
     # Some of the input for the migrate call are coming from the original deployment output
     # so we'll need to jq them out
     #
-    # You can refer to read_chain_cmd function in contract_deployer
+    # You can refer to read_chain_cmd function in contract_deployer or read_network_config_value in the challenger launcher
     #
     # FIXME
 

--- a/src/contracts/opcm_migrator.star
+++ b/src/contracts/opcm_migrator.star
@@ -14,6 +14,7 @@ def launch(
     network_id,
     l1_config_env_vars,
     op_contract_deployer_params,
+    migration_params,
 ):
     # Normalize the L2 artifacts locator
     l2_artifacts_locator = _artifacts.normalize_locator(
@@ -64,21 +65,20 @@ def launch(
             "DEPLOYER_CACHE_DIR": "/op-deployer/cache",
             "DEPLOYER_PRIVATE_KEY": priv_key,
             "DEPLOYER_ARTIFACTS_LOCATOR": l2_artifacts_locator,
-            "DEPLOYER_PROXY_ADMIN_OWNER": "FIXME",  # Coming from the deployment output
             "DEPLOYER_OPCM_IMPL_ADDRESS": "FIXME",  # Coming from the deployment output
-            "DEPLOYER_PERMISSIONED": "FIXME",  # Coming from the args file
-            "DEPLOYER_STARTING_ANCHOR_ROOT": "FIXME",  # Coming from the args file
-            "DEPLOYER_STARTING_ANCHOR_L2_SEQUENCE_NUMBER": "FIXME",  # Coming from the args file
+            "DEPLOYER_PERMISSIONED": migration_params.permissionless,  # This is a bit of a mindfuck since the flag in the go code is called permissionless but the env variable is permissioned
+            "DEPLOYER_STARTING_ANCHOR_ROOT": migration_params.starting_anchor_root,
+            "DEPLOYER_STARTING_ANCHOR_L2_SEQUENCE_NUMBER": migration_params.starting_anchor_l2_sequence_number,
             "DEPLOYER_PROPOSER_ADDRESS": "FIXME",  # Coming from the deployment output
             "DEPLOYER_CHALLENGER_ADDRESS": "FIXME",  # Coming from the deployment output
-            "DEPLOYER_DISPUTE_MAX_GAME_DEPTH": "FIXME",  # Coming from the args file
-            "DEPLOYER_DISPUTE_SPLIT_DEPTH": "FIXME",  # Coming from the args file
-            "DEPLOYER_INITIAL_BOND": "FIXME",  # Coming from the args file
-            "DEPLOYER_DISPUTE_CLOCK_EXTENSION": "FIXME",  # Coming from the args file
-            "DEPLOYER_DISPUTE_MAX_CLOCK_DURATION": "FIXME",  # Coming from the args file
+            "DEPLOYER_DISPUTE_MAX_GAME_DEPTH": migration_params.dispute_max_game_depth,
+            "DEPLOYER_DISPUTE_SPLIT_DEPTH": migration_params.dispute_split_depth,
+            "DEPLOYER_DISPUTE_MAX_CLOCK_DURATION": migration_params.dispute_max_clock_duration,
+            "DEPLOYER_DISPUTE_CLOCK_EXTENSION": migration_params.dispute_clock_extension,
+            "DEPLOYER_DISPUTE_ABSOLUTE_PRESTATE": migration_params.dispute_absolute_prestate,
+            "DEPLOYER_INITIAL_BOND": migration_params.initial_bond,
             "DEPLOYER_SYSTEM_CONFIG_PROXY_ADDRESS": system_config_proxy_address,
             "DEPLOYER_OP_CHAIN_PROXY_ADMIN_ADDRESS": proxy_admin_address,
-            "DEPLOYER_DISPUTE_ABSOLUTE_PRESTATE": "FIXME",  # Coming from the args file
             "L1_RPC_URL": l1_config_env_vars["L1_RPC_URL"],
         },
         run="op-deployer manage migrate > /op-deployer/output.json",

--- a/src/contracts/opcm_migrator.star
+++ b/src/contracts/opcm_migrator.star
@@ -50,7 +50,6 @@ def launch(
         name="op-deployer-opcm-migrate",
         description="Run OPCM.migrate",
         image=op_contract_deployer_params.image,
-        env_vars=l1_config_env_vars,
         files={
             # We need to supply the original op-deployer deployment output since we'll need some of the addresses
             "/op-deployer/data": deployment_output,

--- a/src/contracts/opcm_migrator.star
+++ b/src/contracts/opcm_migrator.star
@@ -1,0 +1,77 @@
+utils = import_module("../util.star")
+_filter = import_module("../util/filter.star")
+
+ethereum_package_genesis_constants = import_module(
+    "github.com/ethpandaops/ethereum-package/src/prelaunch_data_generator/genesis_constants/genesis_constants.star"
+)
+
+
+def launch(
+    plan,
+    priv_key,
+    deployment_output,
+    l1_config_env_vars,
+    op_contract_deployer_params,
+):
+    # Normalize the L2 artifacts locator
+    l2_artifacts_locator = _artifacts.normalize_locator(
+        locator=op_contract_deployer_params.l2_artifacts_locator
+    )
+
+    # Some of the input for the migrate call are coming from the original deployment output
+    # so we'll need to jq them out
+    #
+    # You can refer to read_chain_cmd function in contract_deployer
+    #
+    # FIXME
+
+    # We'll run the OPCM.migrate and collect its output
+    opcm_migrate = plan.run_sh(
+        name="op-deployer-opcm-migrate",
+        description="Run OPCM.migrate",
+        image=op_contract_deployer_params.image,
+        env_vars=l1_config_env_vars,
+        files={
+            # We need to supply the original op-deployer deployment output since we'll need some of the addresses
+            "/op-deployer/data": deployment_output,
+            "/op-deployer/cache": Directory(persistent_key="cachedir"),
+        },
+        store=[
+            # We will be piping the output of the migration into a json file so we'll store that file
+            StoreSpec(src="/op-deployer/opcm.migrate.json"),
+        ],
+        env_vars={
+            # We supply the command args as env variables (just because we can use a nice dict instead of string interpolation)
+            "DEPLOYER_CACHE_DIR": "/op-deployer/cache",
+            "DEPLOYER_PRIVATE_KEY": priv_key,
+            "DEPLOYER_ARTIFACTS_LOCATOR": l2_artifacts_locator,
+            "DEPLOYER_PROXY_ADMIN_OWNER": "FIXME",  # Coming from the deployment output
+            "DEPLOYER_OPCM_IMPL_ADDRESS": "FIXME",  # Coming from the deployment output
+            "DEPLOYER_PERMISSIONED": "FIXME",  # Coming from the args file
+            "DEPLOYER_STARTING_ANCHOR_ROOT": "FIXME",  # Coming from the args file
+            "DEPLOYER_STARTING_ANCHOR_L2_SEQUENCE_NUMBER": "FIXME",  # Coming from the args file
+            "DEPLOYER_PROPOSER_ADDRESS": "FIXME",  # Coming from the deployment output
+            "DEPLOYER_CHALLENGER_ADDRESS": "FIXME",  # Coming from the deployment output
+            "DEPLOYER_DISPUTE_MAX_GAME_DEPTH": "FIXME",  # Coming from the args file
+            "DEPLOYER_DISPUTE_SPLIT_DEPTH": "FIXME",  # Coming from the args file
+            "DEPLOYER_INITIAL_BOND": "FIXME",  # Coming from the args file
+            "DEPLOYER_DISPUTE_CLOCK_EXTENSION": "FIXME",  # Coming from the args file
+            "DEPLOYER_DISPUTE_MAX_CLOCK_DURATION": "FIXME",  # Coming from the args file
+            "DEPLOYER_SYSTEM_CONFIG_PROXY_ADDRESS": "FIXME",  # Coming from the args file
+            "DEPLOYER_OP_CHAIN_PROXY_ADMIN_ADDRESS": "FIXME",  # Coming from the args file
+            "DEPLOYER_DISPUTE_ABSOLUTE_PRESTATE": "FIXME",  # Coming from the args file
+            "L1_RPC_URL": l1_config_env_vars["L1_RPC_URL"],
+        },
+        run="op-deployer manage migrate > /op-deployer/output.json",
+    )
+
+    # Now we have to update the deployment output with the migration output
+    # since the migration has redeployed the dispute game factory
+    #
+    # For this we again jq the dispute game factory address out of the migration output
+    # and then we update the deployment output with it. We then return the updated deployment output
+    # as the output of this function.
+    #
+    # This is done using the store=[] argument for the plan.run_sh function
+    #
+    # FIXME

--- a/src/contracts/opcm_migrator.star
+++ b/src/contracts/opcm_migrator.star
@@ -1,4 +1,4 @@
-utils = import_module("../util.star")
+_util = import_module("../util.star")
 _artifacts = import_module("./artifacts.star")
 _filter = import_module("../util/filter.star")
 
@@ -27,20 +27,20 @@ def launch(
     #
     # FIXME
 
-    proxy_admin_address = util.read_network_config_value(
+    proxy_admin_address = _util.read_network_config_value(
         plan,
         deployment_output,
         "state",
         '.opChainDeployments[] | select(.id=="{0}") | .ProxyAdmin'.format(
-            util.to_hex_chain_id(network_id)
+            _util.to_hex_chain_id(network_id)
         ),
     )
-    system_config_proxy_address = util.read_network_config_value(
+    system_config_proxy_address = _util.read_network_config_value(
         plan,
         deployment_output,
         "state",
         '.opChainDeployments[] | select(.id=="{0}") | .SystemConfigProxy'.format(
-            util.to_hex_chain_id(network_id)
+            _util.to_hex_chain_id(network_id)
         ),
     )
 

--- a/src/contracts/opcm_migrator.star
+++ b/src/contracts/opcm_migrator.star
@@ -9,7 +9,7 @@ ethereum_package_genesis_constants = import_module(
 
 def launch(
     plan,
-    priv_key,
+    l1_priv_key,
     deployment_output,
     network_id,
     l1_config_env_vars,
@@ -63,7 +63,7 @@ def launch(
         env_vars={
             # We supply the command args as env variables (just because we can use a nice dict instead of string interpolation)
             "DEPLOYER_CACHE_DIR": "/op-deployer/cache",
-            "DEPLOYER_PRIVATE_KEY": priv_key,
+            "DEPLOYER_PRIVATE_KEY": l1_priv_key,
             "DEPLOYER_ARTIFACTS_LOCATOR": l2_artifacts_locator,
             "DEPLOYER_OPCM_IMPL_ADDRESS": "FIXME",  # Coming from the deployment output
             "DEPLOYER_PERMISSIONED": migration_params.permissionless,  # This is a bit of a mindfuck since the flag in the go code is called permissionless but the env variable is permissioned

--- a/src/contracts/opcm_migrator.star
+++ b/src/contracts/opcm_migrator.star
@@ -11,6 +11,7 @@ def launch(
     plan,
     priv_key,
     deployment_output,
+    network_id,
     l1_config_env_vars,
     op_contract_deployer_params,
 ):
@@ -25,6 +26,23 @@ def launch(
     # You can refer to read_chain_cmd function in contract_deployer or read_network_config_value in the challenger launcher
     #
     # FIXME
+
+    proxy_admin_address = util.read_network_config_value(
+        plan,
+        deployment_output,
+        "state",
+        '.opChainDeployments[] | select(.id=="{0}") | .ProxyAdmin'.format(
+            util.to_hex_chain_id(network_id)
+        ),
+    )
+    system_config_proxy_address = util.read_network_config_value(
+        plan,
+        deployment_output,
+        "state",
+        '.opChainDeployments[] | select(.id=="{0}") | .SystemConfigProxy'.format(
+            util.to_hex_chain_id(network_id)
+        ),
+    )
 
     # We'll run the OPCM.migrate and collect its output
     opcm_migrate = plan.run_sh(
@@ -58,8 +76,8 @@ def launch(
             "DEPLOYER_INITIAL_BOND": "FIXME",  # Coming from the args file
             "DEPLOYER_DISPUTE_CLOCK_EXTENSION": "FIXME",  # Coming from the args file
             "DEPLOYER_DISPUTE_MAX_CLOCK_DURATION": "FIXME",  # Coming from the args file
-            "DEPLOYER_SYSTEM_CONFIG_PROXY_ADDRESS": "FIXME",  # Coming from the args file
-            "DEPLOYER_OP_CHAIN_PROXY_ADMIN_ADDRESS": "FIXME",  # Coming from the args file
+            "DEPLOYER_SYSTEM_CONFIG_PROXY_ADDRESS": system_config_proxy_address,
+            "DEPLOYER_OP_CHAIN_PROXY_ADMIN_ADDRESS": proxy_admin_address,
             "DEPLOYER_DISPUTE_ABSOLUTE_PRESTATE": "FIXME",  # Coming from the args file
             "L1_RPC_URL": l1_config_env_vars["L1_RPC_URL"],
         },

--- a/src/l2/input_parser.star
+++ b/src/l2/input_parser.star
@@ -23,6 +23,7 @@ _DEFAULT_NETWORK_PARAMS = {
 
 _DEFAULT_MIGRATION_PARAMS = {
     "enabled": False,
+    "permissionless": False,
     "starting_anchor_root": None,
     "starting_anchor_l2_sequence_number": None,
     "dispute_max_game_depth": None,

--- a/src/l2/launcher.star
+++ b/src/l2/launcher.star
@@ -180,6 +180,7 @@ def launch(
         da=da,
     )
 
+
 def _launch_opcm_migrate_maybe(plan, migration_params, deployment_output, log_prefix):
     if migration_params:
         plan.print("{}: Running interop migration".format(log_prefix))

--- a/src/l2/launcher.star
+++ b/src/l2/launcher.star
@@ -166,35 +166,12 @@ def launch(
             )
         )
 
-    deployment_output = _launch_opcm_migrate_maybe(
-        plan=plan,
-        migration_params=params.migration_params,
-        deployment_output=deployment_output,
-        log_prefix=network_log_prefix,
-    )
-
     return struct(
         name=network_params.name,
         network_id=network_params.network_id,
         participants=participants,
         da=da,
     )
-
-
-def _launch_opcm_migrate_maybe(plan, migration_params, deployment_output, log_prefix):
-    if migration_params:
-        plan.print("{}: Running interop migration".format(log_prefix))
-
-        deployment_output = _opcm_migration_launcher.launch(
-            plan=plan,
-            params=migration_params,
-        )
-
-        plan.print("{}: Successfully ran interop migration".format(log_prefix))
-
-        return deployment_output
-
-    return deployment_output
 
 
 def _launch_da_maybe(plan, da_params, log_prefix):

--- a/src/l2/launcher.star
+++ b/src/l2/launcher.star
@@ -166,12 +166,34 @@ def launch(
             )
         )
 
+    deployment_output = _launch_opcm_migrate_maybe(
+        plan=plan,
+        migration_params=params.migration_params,
+        deployment_output=deployment_output,
+        log_prefix=network_log_prefix,
+    )
+
     return struct(
         name=network_params.name,
         network_id=network_params.network_id,
         participants=participants,
         da=da,
     )
+
+def _launch_opcm_migrate_maybe(plan, migration_params, deployment_output, log_prefix):
+    if migration_params:
+        plan.print("{}: Running interop migration".format(log_prefix))
+
+        deployment_output = _opcm_migration_launcher.launch(
+            plan=plan,
+            params=migration_params,
+        )
+
+        plan.print("{}: Successfully ran interop migration".format(log_prefix))
+
+        return deployment_output
+
+    return deployment_output
 
 
 def _launch_da_maybe(plan, da_params, log_prefix):

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -231,6 +231,7 @@ def test_l2_input_parser_tx_fuzzer_defaults(plan):
 def test_l2_input_parser_migration_defaults(plan):
     _default__migration_params = struct(
         enabled=True,
+        permissionless=False,
         starting_anchor_root=None,
         starting_anchor_l2_sequence_number=None,
         dispute_max_game_depth=None,

--- a/test/l2/input_parser_test.star
+++ b/test/l2/input_parser_test.star
@@ -132,6 +132,8 @@ def test_l2_input_parser_defaults(plan):
                 tx_fuzzer_params=None,
                 # Blockscout is disabled by default
                 blockscout_params=None,
+                # OPCM.migrate is disabled by default
+                migration_params=None,
             )
         ],
     )
@@ -165,6 +167,8 @@ def test_l2_input_parser_defaults(plan):
                 tx_fuzzer_params=None,
                 # Blockscout is disabled by default
                 blockscout_params=None,
+                # OPCM.migrate is disabled by default
+                migration_params=None,
             )
         ],
     )
@@ -199,7 +203,7 @@ def test_l2_input_parser_da_defaults(plan):
     expect.eq(parsed[0].da_params, _default_da_params)
 
 
-def test_l2_input_parser_tz_fuzzer_defaults(plan):
+def test_l2_input_parser_tx_fuzzer_defaults(plan):
     _default_tx_fuzzer_params = struct(
         enabled=True,
         extra_params=[],
@@ -222,6 +226,31 @@ def test_l2_input_parser_tz_fuzzer_defaults(plan):
         _default_registry,
     )
     expect.eq(parsed[0].tx_fuzzer_params, _default_tx_fuzzer_params)
+
+
+def test_l2_input_parser_migration_defaults(plan):
+    _default__migration_params = struct(
+        enabled=True,
+        starting_anchor_root=None,
+        starting_anchor_l2_sequence_number=None,
+        dispute_max_game_depth=None,
+        dispute_split_depth=None,
+        dispute_max_clock_duration=None,
+        dispute_clock_extension=None,
+        dispute_absolute_prestate=None,
+        initial_bond=None,
+    )
+
+    parsed = input_parser.parse(
+        {
+            "network1": {
+                "participants": {"node0": {}},
+                "migration_params": {"enabled": True},
+            }
+        },
+        _default_registry,
+    )
+    expect.eq(parsed[0].migration_params, _default__migration_params)
 
 
 def test_l2_input_parser_auto_network_id(plan):


### PR DESCRIPTION
**Description**

Stub of the OPCM.migrate functionality. This depends on the `manage migrate` command introduced [here](https://github.com/ethereum-optimism/optimism/pull/16710/files)

- Since there is a new `op-deployer` command needed to run this, old versions of the deployer will not be compatible with this functionality
- The deployer code is one of the areas left untouched still and contains a lot of code that is now sub-standard. In the interest of keeping this brief we will not be refactoring the code:
  - `registry` should used for docker images
  - `# zhwrd: this mess is temporary until we implement json reading for op-deployer intent file` should be left untouched
  - we'll also not be touching any input parsing if it has not been migrated to the new system yet (we'll just try to live with it unfortunately)

On the migration side, my original idea was to basically update `deployment_output` with the new `DisputeGameFactoryAddress` BUT it might be easier to:

- Grab that address from the result of the `op-deployer manage migrate` call (you should be able to do this by piping the result through `jq`)
- Return that value from `opcm_migrator::launch`
- Add a new parameter called `dispute_game_factory_address` or smth in proposer and challenger
- Make its default value be the value from the `deployment_output` (i.e. the `util.read_network_config_value` line in the launcher)
- If the user enables the migration, simply pass the return value from `opcm_migrator::launch` to this parameter (I say simply but it will require a couple lines of code)

⚠️ ⚠️ ⚠️ **There is some weirdness regarding the addresses and challengers already in the code, and it might blow up in your face**⚠️ ⚠️ ⚠️  

Challengers are not per-L2 components yet they require the dispute game factory address (DGFA for short) that is a per-L2 value. At the moment, they will pick the first DGFA from the list of chains. I hope you now see where I am going with this - it is definitely possible to misconfigure this (e.g. you migrate one chain but not the other, you are now left with diverging addresses).

**It's been just marked as dangerous and left untreated. If it does explode, warn the authorities and stakeholders A$AP - this is one of those things that could result in a series of 46 PRs required to get the conductor support.**