### PR TITLE
feat: op-signer: Necessary script adjustments [5/N]

### DIFF
--- a/src/signer/op-signer/scripts/convert-private-key.sh
+++ b/src/signer/op-signer/scripts/convert-private-key.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+# Get private key from the script arguments
+if [ $# -ne 1 ]; then
+    echo "Error: Private key argument is required."
+    exit 1
+fi
+
+# We grab the private key from the arguments
+PRIVATE_KEY="$1"; shift
+
+# We convert it to ASCII
+PRIVATE_KEY_ASCII=$(echo -n "$PRIVATE_KEY" | xxd -r -p)
+
+# And pad it 
+PRIVATE_KEY_PREFIX="\\x30\\x2e\\x02\\x01\\x01\\x04\\x20"
+PRIVATE_KEY_SUFFIX="\\xa0\\x07\\x06\\x05\\x2b\\x81\\x04\\x00\\x0a"
+PRIVATE_KEY_WRAPPED="${PRIVATE_KEY_PREFIX}${PRIVATE_KEY_ASCII}${PRIVATE_KEY_SUFFIX}"
+
+# And finally we create the EC encoded private key
+printf "%b" "$PRIVATE_KEY_WRAPPED" | openssl ec -inform DER -outform PEM


### PR DESCRIPTION
**Description**

In this PR, the script for generating local credentials is adjusted to fit our usecase (unnecessary indirection is removed & file permissions are adjusted).

Additionally, [an inline script from the original PR](https://github.com/ethpandaops/optimism-package/pull/207/files#diff-8952ca36c0cbca2168c99c185e468d02357daaab464a93cd7bf58bf8f3b90eb0R136) is moved into a shell script - this script converts a HEX private key to a PEM file. This is necessary since `op-signer` requires private keys (that we have in the deployment output in HEX) to be converted to PEM files