### PR TITLE
chore: use service names instead of ip

### DIFF
--- a/src/conductor/op-conductor/launcher.star
+++ b/src/conductor/op-conductor/launcher.star
@@ -41,10 +41,10 @@ def launch(
     service = plan.add_service(params.service_name, config)
 
     rpc_port = params.ports[_net.RPC_PORT_NAME]
-    rpc_url = _net.service_url(service.ip_address, rpc_port)
+    rpc_url = _net.service_url(params.service_name, rpc_port)
 
     consensus_port = params.ports[_net.CONSENSUS_PORT_NAME]
-    consensus_url = _net.service_url(service.ip_address, consensus_port)
+    consensus_url = _net.service_url(params.service_name, consensus_port)
 
     metrics_info = _observability.new_metrics_info(observability_helper, service)
 

--- a/src/da/da-server/launcher.star
+++ b/src/da/da-server/launcher.star
@@ -20,7 +20,7 @@ def launch(
         # FIXME This can be removed, just requires a little refactoring of the da_server_context variable
         context=struct(
             http_url=_net.service_url(
-                service.ip_address, params.ports[_net.HTTP_PORT_NAME]
+                params.service_name, params.ports[_net.HTTP_PORT_NAME]
             )
         ),
     )

--- a/src/mev/rollup-boost/launcher.star
+++ b/src/mev/rollup-boost/launcher.star
@@ -40,7 +40,7 @@ def launch(
             rpc_port_num=rpc_port.number,
             ws_port_num=WS_PORT_NUM,
             engine_rpc_port_num=rpc_port.number,
-            rpc_http_url=_net.service_url(service.ip_address, rpc_port),
+            rpc_http_url=_net.service_url(params.service_name, rpc_port),
             service_name=params.service_name,
         ),
     )
@@ -53,14 +53,14 @@ def get_service_config(
     sequencer_context,
     builder_context,
 ):
-    L2_EXECUTION_ENGINE_ENDPOINT = "http://{0}:{1}".format(
-        sequencer_context.ip_addr,
-        sequencer_context.engine_rpc_port_num,
+    L2_EXECUTION_ENGINE_ENDPOINT = _net.service_url(
+        sequencer_context.service_name,
+        _net.port(number=sequencer_context.engine_rpc_port_num),
     )
 
-    BUILDER_EXECUTION_ENGINE_ENDPOINT = "http://{0}:{1}".format(
-        builder_context.ip_addr,
-        builder_context.engine_rpc_port_num,
+    BUILDER_EXECUTION_ENGINE_ENDPOINT = _net.service_url(
+        builder_context.service_name,
+        _net.port(number=builder_context.engine_rpc_port_num),
     )
 
     ports = _net.ports_to_port_specs(params.ports)

--- a/src/tx-fuzzer/launcher.star
+++ b/src/tx-fuzzer/launcher.star
@@ -28,7 +28,7 @@ def get_service_config(
         "spam",
         "--rpc={}".format(
             _net.service_url(
-                el_context.ip_addr, _net.port(number=el_context.rpc_port_num)
+                el_context.service_name, _net.port(number=el_context.rpc_port_num)
             )
         ),
         # FIXME Should not be hardcoded

--- a/test/tx_fuzzer_launcher_test.star
+++ b/test/tx_fuzzer_launcher_test.star
@@ -54,6 +54,7 @@ def test_tx_fuzzer_launch_with_defaults(plan):
         el_context=struct(
             rpc_port_num=8888,
             ip_addr="127.0.0.1",
+            service_name="rpc-el",
         ),
         node_selectors=parsed_input_args.global_node_selectors,
     )
@@ -72,7 +73,7 @@ def test_tx_fuzzer_launch_with_defaults(plan):
         fuzzer_service_config.cmd,
         [
             "spam",
-            "--rpc={}".format("http://127.0.0.1:8888"),
+            "--rpc={}".format("http://rpc-el:8888"),
             "--sk={0}".format(constants.dev_accounts[0]["private_key"]),
         ],
     )


### PR DESCRIPTION
**Description**

We were using ip_address when communicating with other services within the kurtosis network. Whilst this is perfectly valid and it works, it makes debugging misconfigurations rather cumbersome. This PR switches to using service_name instead which contains the container name.