### PR TITLE
feat: op-signer: Connect the signer to the proposer [8/N]

### DIFF
--- a/src/batcher/op-batcher/launcher.star
+++ b/src/batcher/op-batcher/launcher.star
@@ -140,7 +140,7 @@ def get_service_config(
             ),
             "--signer.endpoint={}".format(
                 _net.service_url(
-                    signer_context.service.ip_address,
+                    signer_context.service.hostname,
                     signer_context.service.ports[_net.HTTP_PORT_NAME],
                 )
             ),

--- a/src/l2/launcher__hack.star
+++ b/src/l2/launcher__hack.star
@@ -136,8 +136,9 @@ def launch(
         deployment_output=deployment_output,
         private_key=proposer_private_key,
         l1_config_env_vars=l1_config_env_vars,
-        log_prefix=network_log_prefix,
         observability_helper=observability_helper,
+        signer_context=signer_context,
+        log_prefix=network_log_prefix,
     )
 
     _launch_proxyd_maybe(
@@ -285,6 +286,7 @@ def _launch_proposer(
     private_key,
     l1_config_env_vars,
     observability_helper,
+    signer_context,
     log_prefix,
 ):
     plan.print(
@@ -305,10 +307,12 @@ def _launch_proposer(
         plan=plan,
         params=proposer_params,
         sequencers_params=sequencers_params,
+        deployment_output=deployment_output,
         l1_config_env_vars=l1_config_env_vars,
         gs_proposer_private_key=private_key,
         game_factory_address=game_factory_address,
         network_params=network_params,
+        signer_context=signer_context,
         observability_helper=observability_helper,
     )
 

--- a/src/proposer/op-proposer/launcher.star
+++ b/src/proposer/op-proposer/launcher.star
@@ -100,7 +100,7 @@ def get_service_config(
             ),
             "--signer.endpoint={}".format(
                 _net.service_url(
-                    signer_context.service.ip_address,
+                    signer_context.service.hostname,
                     signer_context.service.ports[_net.HTTP_PORT_NAME],
                 )
             ),

--- a/src/proposer/op-proposer/launcher.star
+++ b/src/proposer/op-proposer/launcher.star
@@ -1,48 +1,40 @@
-ethereum_package_shared_utils = import_module(
-    "github.com/ethpandaops/ethereum-package/src/shared_utils/shared_utils.star"
-)
-
-ethereum_package_constants = import_module(
+_ethereum_package_constants = import_module(
     "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
 )
 
-constants = import_module("../../package_io/constants.star")
-util = import_module("../../util.star")
-
-observability = import_module("../../observability/observability.star")
-prometheus = import_module("../../observability/prometheus/prometheus_launcher.star")
+_observability = import_module("../../observability/observability.star")
 
 _net = import_module("/src/util/net.star")
-
-#
-#  ---------------------------------- Batcher client -------------------------------------
-# The Docker container runs as the "op-proposer" user so we can't write to root
-DATA_DIRPATH_ON_SERVICE_CONTAINER = "/data/op-proposer/op-proposer-data"
+_util = import_module("../../util.star")
 
 
 def launch(
     plan,
     params,
     sequencers_params,
+    deployment_output,
     l1_config_env_vars,
     gs_proposer_private_key,
     game_factory_address,
     network_params,
     observability_helper,
+    signer_context,
 ):
     config = get_service_config(
         plan=plan,
         params=params,
         sequencers_params=sequencers_params,
+        deployment_output=deployment_output,
         l1_config_env_vars=l1_config_env_vars,
         gs_proposer_private_key=gs_proposer_private_key,
         game_factory_address=game_factory_address,
         observability_helper=observability_helper,
+        signer_context=signer_context,
     )
 
     service = plan.add_service(params.service_name, config)
 
-    observability.register_op_service_metrics_job(
+    _observability.register_op_service_metrics_job(
         observability_helper, service, network_params.network
     )
 
@@ -53,10 +45,12 @@ def get_service_config(
     plan,
     params,
     sequencers_params,
+    deployment_output,
     l1_config_env_vars,
     gs_proposer_private_key,
     game_factory_address,
     observability_helper,
+    signer_context,
 ):
     ports = _net.ports_to_port_specs(params.ports)
 
@@ -88,18 +82,43 @@ def get_service_config(
         "--wait-node-sync=true",
     ] + params.extra_params
 
+    if signer_context:
+        proposer_address = _util.read_network_config_value(
+            plan,
+            deployment_output,
+            params.service_name,
+            ".address",
+        )
+
+        cmd = cmd + [
+            "--signer.tls.ca={}".format(signer_context.credentials.ca.crt),
+            "--signer.tls.cert={}".format(
+                signer_context.credentials.hosts[params.service_name].tls.crt
+            ),
+            "--signer.tls.key={}".format(
+                signer_context.credentials.hosts[params.service_name].tls.key
+            ),
+            "--signer.endpoint={}".format(
+                _net.service_url(
+                    signer_context.service.ip_address,
+                    signer_context.service.ports[_net.HTTP_PORT_NAME],
+                )
+            ),
+            "--signer.address={}".format(proposer_address),
+        ]
+
     # apply customizations
 
     if observability_helper.enabled:
-        observability.configure_op_service_metrics(cmd, ports)
+        _observability.configure_op_service_metrics(cmd, ports)
 
     if params.pprof_enabled:
-        observability.configure_op_service_pprof(cmd, ports)
+        _observability.configure_op_service_pprof(cmd, ports)
 
     return ServiceConfig(
         image=params.image,
         ports=ports,
         cmd=cmd,
         labels=params.labels,
-        private_ip_address_placeholder=ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+        private_ip_address_placeholder=_ethereum_package_constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
     )

--- a/test/batcher/op-batcher/launcher_test.star
+++ b/test/batcher/op-batcher/launcher_test.star
@@ -193,7 +193,7 @@ def test_batcher_launcher_launch_with_signer(plan):
     # We create a mock context for the signer since things like its IP, the value references to the uploaded files etc cannot easily be injected
     signer_context = struct(
         service=struct(
-            ip_address="7.7.7.7",
+            hostname="signer-signer-signer",
             ports={
                 _net.HTTP_PORT_NAME: PortSpec(number=8545, application_protocol="http"),
             },
@@ -255,7 +255,7 @@ def test_batcher_launcher_launch_with_signer(plan):
             "--signer.tls.ca=ca.crt",
             "--signer.tls.cert=tls.crt",
             "--signer.tls.key=tls.key",
-            "--signer.endpoint=http://7.7.7.7:8545",
+            "--signer.endpoint=http://signer-signer-signer:8545",
             "--signer.address={}".format(batcher_address_mock),
             # And end here
             "--metrics.enabled",

--- a/test/proposer/op-proposer/launcher_test.star
+++ b/test/proposer/op-proposer/launcher_test.star
@@ -118,7 +118,7 @@ def test_proposer_launcher_launch_with_signer(plan):
     # We create a mock context for the signer since things like its IP, the value references to the uploaded files etc cannot easily be injected
     signer_context = struct(
         service=struct(
-            ip_address="7.7.7.7",
+            hostname="signer-signer-signer",
             ports={
                 _net.HTTP_PORT_NAME: PortSpec(number=8545, application_protocol="http"),
             },
@@ -172,7 +172,7 @@ def test_proposer_launcher_launch_with_signer(plan):
             "--signer.tls.ca=ca.crt",
             "--signer.tls.cert=tls.crt",
             "--signer.tls.key=tls.key",
-            "--signer.endpoint=http://7.7.7.7:8545",
+            "--signer.endpoint=http://signer-signer-signer:8545",
             "--signer.address=0xbac4e5",
             "--metrics.enabled",
             "--metrics.addr=0.0.0.0",

--- a/test/proposer/op-proposer/launcher_test.star
+++ b/test/proposer/op-proposer/launcher_test.star
@@ -1,0 +1,191 @@
+_input_parser = import_module("/src/package_io/input_parser.star")
+_l2_input_parser = import_module("/src/l2/input_parser.star")
+_proposer_input_parser = import_module("/src/proposer/input_parser.star")
+_op_proposer_launcher = import_module("/src/proposer/op-proposer/launcher.star")
+_op_signer_launcher = import_module("/src/signer/op-signer/launcher.star")
+_observability = import_module("/src/observability/observability.star")
+_registry = import_module("/src/package_io/registry.star")
+_selectors = import_module("/src/l2/selectors.star")
+
+_net = import_module("/src/util/net.star")
+_util = import_module("/src/util.star")
+
+_default_registry = _registry.Registry()
+_default_l1_config_env_vars = {
+    "CL_RPC_URL": "http://l1.cl.rpc",
+    "L1_RPC_URL": "http://l1.rpc",
+    "L1_WS_URL": "wss://l1.rpc",
+    "L1_RPC_KIND": "very.kind",
+}
+_default_network_params = struct(
+    network="kurtosis",
+    network_id=1000,
+    name="network0",
+)
+_default_deployment_output = "{}"
+
+
+def test_proposer_launcher_launch_without_signer(plan):
+    # We'll need the observability params from the legacy parser
+    legacy_params = _input_parser.input_parser(
+        plan=plan,
+        input_args={},
+    )
+    observability_helper = _observability.make_helper(legacy_params.observability)
+
+    l2s_params = _l2_input_parser.parse(
+        {
+            "network0": {
+                "participants": {
+                    "node0": {"sequencer": True},
+                    "node1": {"sequencer": True},
+                    "node2": {"sequencer": "node0"},
+                }
+            }
+        },
+        registry=_default_registry,
+    )
+
+    l2_params = l2s_params[0]
+    proposer_params = l2_params.proposer_params
+    sequencers_params = _selectors.get_sequencers_params(l2_params.participants)
+
+    # plan,
+    # params,
+    # sequencers_params,
+    # l1_config_env_vars,
+    # gs_proposer_private_key,
+    # game_factory_address,
+    # network_params,
+    # observability_helper,
+    # signer_context,
+
+    _op_proposer_launcher.launch(
+        plan=plan,
+        params=proposer_params,
+        sequencers_params=sequencers_params,
+        deployment_output=_default_deployment_output,
+        l1_config_env_vars=_default_l1_config_env_vars,
+        gs_proposer_private_key="0x0",
+        game_factory_address="0x1",
+        network_params=_default_network_params,
+        observability_helper=observability_helper,
+        signer_context=None,
+    )
+
+    service_config = kurtosistest.get_service_config(proposer_params.service_name)
+
+    expect.eq(
+        service_config.cmd,
+        [
+            "op-proposer",
+            "--poll-interval=12s",
+            "--rpc.port=8560",
+            "--rollup-rpc=http://op-cl-2151908-node0-op-node:8547,http://op-cl-2151908-node1-op-node:8547",
+            "--game-factory-address=0x1",
+            "--private-key=0x0",
+            "--l1-eth-rpc=http://l1.rpc",
+            "--allow-non-finalized=true",
+            "--game-type=1",
+            "--proposal-interval=10m",
+            "--wait-node-sync=true",
+            "--metrics.enabled",
+            "--metrics.addr=0.0.0.0",
+            "--metrics.port=9001",
+        ],
+    )
+
+
+def test_proposer_launcher_launch_with_signer(plan):
+    # We'll need the observability params from the legacy parser
+    legacy_params = _input_parser.input_parser(
+        plan=plan,
+        input_args={},
+    )
+    observability_helper = _observability.make_helper(legacy_params.observability)
+
+    l2s_params = _l2_input_parser.parse(
+        {
+            "network0": {
+                "participants": {
+                    "node0": {"sequencer": True},
+                    "node1": {"sequencer": True},
+                    "node2": {"sequencer": "node0"},
+                },
+                "signer_params": {
+                    "enabled": True,
+                },
+            }
+        },
+        registry=_default_registry,
+    )
+
+    l2_params = l2s_params[0]
+    proposer_params = l2_params.proposer_params
+    signer_params = l2_params.signer_params
+    sequencers_params = _selectors.get_sequencers_params(l2_params.participants)
+
+    # We create a mock context for the signer since things like its IP, the value references to the uploaded files etc cannot easily be injected
+    signer_context = struct(
+        service=struct(
+            ip_address="7.7.7.7",
+            ports={
+                _net.HTTP_PORT_NAME: PortSpec(number=8545, application_protocol="http"),
+            },
+        ),
+        credentials=struct(
+            ca=struct(crt="ca.crt"),
+            hosts={
+                proposer_params.service_name: struct(
+                    tls=struct(crt="tls.crt", key="tls.key")
+                )
+            },
+        ),
+    )
+
+    # We need to mock the proposer address that's being read from the deployment output
+    # otherwise we would be getting a random kurtosis runtime value which we cannot get hold of
+    proposer_address_mock = "0xbac4e5"
+    kurtosistest.mock(_util, "read_network_config_value").mock_return_value(
+        proposer_address_mock
+    )
+
+    _op_proposer_launcher.launch(
+        plan=plan,
+        params=proposer_params,
+        sequencers_params=sequencers_params,
+        deployment_output=_default_deployment_output,
+        l1_config_env_vars=_default_l1_config_env_vars,
+        gs_proposer_private_key="0x0",
+        game_factory_address="0x1",
+        network_params=_default_network_params,
+        observability_helper=observability_helper,
+        signer_context=signer_context,
+    )
+
+    service_config = kurtosistest.get_service_config(proposer_params.service_name)
+
+    expect.eq(
+        service_config.cmd,
+        [
+            "op-proposer",
+            "--poll-interval=12s",
+            "--rpc.port=8560",
+            "--rollup-rpc=http://op-cl-2151908-node0-op-node:8547,http://op-cl-2151908-node1-op-node:8547",
+            "--game-factory-address=0x1",
+            "--private-key=0x0",
+            "--l1-eth-rpc=http://l1.rpc",
+            "--allow-non-finalized=true",
+            "--game-type=1",
+            "--proposal-interval=10m",
+            "--wait-node-sync=true",
+            "--signer.tls.ca=ca.crt",
+            "--signer.tls.cert=tls.crt",
+            "--signer.tls.key=tls.key",
+            "--signer.endpoint=http://7.7.7.7:8545",
+            "--signer.address=0xbac4e5",
+            "--metrics.enabled",
+            "--metrics.addr=0.0.0.0",
+            "--metrics.port=9001",
+        ],
+    )

--- a/test/proposer/op-proposer/launcher_test.star
+++ b/test/proposer/op-proposer/launcher_test.star
@@ -50,16 +50,6 @@ def test_proposer_launcher_launch_without_signer(plan):
     proposer_params = l2_params.proposer_params
     sequencers_params = _selectors.get_sequencers_params(l2_params.participants)
 
-    # plan,
-    # params,
-    # sequencers_params,
-    # l1_config_env_vars,
-    # gs_proposer_private_key,
-    # game_factory_address,
-    # network_params,
-    # observability_helper,
-    # signer_context,
-
     _op_proposer_launcher.launch(
         plan=plan,
         params=proposer_params,


### PR DESCRIPTION
**Description**

Connects the now running signer service to the proposer. Some small unused clutter from the proposer launcher has been removed as well.

Related to https://github.com/ethereum-optimism/platforms-team/issues/581