### PR TITLE
chore: Add a script that checks block progression for test enclaves

### DIFF
--- a/.github/scripts/kurtosis-check-block-progression.sh
+++ b/.github/scripts/kurtosis-check-block-progression.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# 
+# 
+# This is a test script used mostly in the CI pipeline
+# 
+# It will search for all EL clients in a specified kurtosis enclave
+# and will check whether their blocks advance in a reasonable amount of time
+# 
+# Usage:
+# 
+# ./kurtosis-check-enclave-block-creation.sh <ENCLAVE_NAME> [TARGET_BLOCK_NUMBER] [NUMBER_OF_NAPS]
+# 
+# 
+
+# Just so that we don't repeat ourselves
+ENCLAVES_API_URL=http://127.0.0.1:9779/api/enclaves
+
+# We pass the enclave name and the target block as script arguments
+ENCLAVE_NAME=$1
+if [ -z "$ENCLAVE_NAME" ]; then
+    echo "Please specify the enclave name as the first parameter"
+    exit 1
+fi
+
+# We default the target block to a good round 50
+TARGET_BLOCK=$2
+if [ -z "$TARGET_BLOCK" ]; then
+    TARGET_BLOCK=50
+fi
+
+# The number of sleeps the script will take
+NUM_NAPS=$3
+if [ -z "$NUM_NAPS" ]; then
+    NUM_NAPS=100
+fi
+
+echo "Checking whether EL clients in enclave $ENCLAVE_NAME reach target block $TARGET_BLOCK in reasonable time ($NUM_NAPS of 5s)"
+
+# Get the enclave UUID from the API
+# 
+# The API reponse is a JSON object with UUIDs as keys. To get the UUID we need to find a value
+# with a matching "name" property.
+# 
+# The "| values" at the end of the jq transformation will convert null to an empty string
+ENCLAVE_ID=$(curl -s $ENCLAVES_API_URL | jq -r 'to_entries | map(select(.value.name == "'$ENCLAVE_NAME'")) | .[0].key | values')
+
+# Make sure we got something
+if [ -z "$ENCLAVE_ID" ]; then
+    echo "No enclave found for enclave $ENCLAVE_NAME"
+    exit 1
+fi
+
+echo "Got enclave UUID: $ENCLAVE_ID"
+
+# Now get all the EL client services
+# 
+# We assume the convention is to name them op-el-xxx
+ENCLAVE_SERVICES=$(curl -s $ENCLAVES_API_URL/$ENCLAVE_ID/services)
+ENCLAVE_EL_SERVICES=$(echo $ENCLAVE_SERVICES | jq -r 'to_entries | map(select(.key | startswith("op-el-"))) | map(.value)')
+
+# Now get the EL client names and RPC ports and arrange them into single-line space-delimited strings
+# 
+# This is useful for bash iteration below
+ENCLAVE_EL_SERVICE_NAMES=$(echo $ENCLAVE_EL_SERVICES | jq -r 'map(.name) | join(" ")')
+ENCLAVE_EL_SERVICE_RPC_PORTS=$(echo $ENCLAVE_EL_SERVICES | jq -r 'map(.public_ports.rpc.number) | join(" ")')
+
+# Make sure we got something
+if [ -z "$ENCLAVE_EL_SERVICE_NAMES" ]; then
+    echo "No EL clients found for enclave $ENCLAVE_NAME"
+    exit 1
+fi
+
+echo "Got enclave EL services: $ENCLAVE_EL_SERVICE_NAMES"
+echo "Got enclave EL RPC ports: $ENCLAVE_EL_SERVICE_RPC_PORTS"
+
+# Convert the lists into bash arrays
+ENCLAVE_EL_SERVICE_NAMES_ARRAY=($ENCLAVE_EL_SERVICE_NAMES)
+ENCLAVE_EL_SERVICE_RPC_PORTS_ARRAY=($ENCLAVE_EL_SERVICE_RPC_PORTS)
+
+# Now check that the clients advance
+for STEP in $(seq 1 $NUM_NAPS); do
+    echo "Check $STEP/$NUM_NAPS"
+    
+    # Iterate over the names/RPC ports arrays
+    for I in "${!ENCLAVE_EL_SERVICE_NAMES_ARRAY[@]}"; do
+        SERVICE_NAME=${ENCLAVE_EL_SERVICE_NAMES_ARRAY[$I]}
+        SERVICE_RPC_PORT=${ENCLAVE_EL_SERVICE_RPC_PORTS_ARRAY[$I]}
+        SERVICE_RPC_URL="http://127.0.0.1:$SERVICE_RPC_PORT"
+
+        BLOCK_NUMBER=$(cast bn --rpc-url $SERVICE_RPC_URL)
+        echo "  Got block for $SERVICE_NAME: $BLOCK_NUMBER"
+
+        # Check whether we reached the target block
+        if [ "$BLOCK_NUMBER" -gt "$TARGET_BLOCK" ]; then
+            echo "  Target block $TARGET_BLOCK reached for $SERVICE_NAME"
+            
+            # If so, we remove the service from the array
+            unset ENCLAVE_EL_SERVICE_NAMES_ARRAY[$I]
+            unset ENCLAVE_EL_SERVICE_RPC_PORTS_ARRAY[$I]
+        fi
+    done
+
+    # Since we used unset, we need to reindex the arrays, we need to remove any gaps left behind
+    ENCLAVE_EL_SERVICE_NAMES_ARRAY=("${ENCLAVE_EL_SERVICE_NAMES_ARRAY[@]}")
+    ENCLAVE_EL_SERVICE_RPC_PORTS_ARRAY=("${ENCLAVE_EL_SERVICE_RPC_PORTS_ARRAY[@]}")
+
+    # Now we check whether the arrays are empty
+    # 
+    # This means all target blocks have been reached and we can exit fine
+    if [ ${#ENCLAVE_EL_SERVICE_NAMES_ARRAY[@]} -eq 0 ]; then
+        echo "All target blocks have been reached. Exiting."
+        exit 0
+    fi
+
+    sleep 5
+done
+
+echo "Target blocks have not been reached for the following services:"
+
+for I in "${!ENCLAVE_EL_SERVICE_NAMES_ARRAY[@]}"; do
+    SERVICE_NAME=${ENCLAVE_EL_SERVICE_NAMES_ARRAY[$I]}
+
+    echo "  $SERVICE_NAME"
+done
+
+exit 1

--- a/.github/scripts/kurtosis-dump-logs.sh
+++ b/.github/scripts/kurtosis-dump-logs.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# 
+# 
+# This is a log script used mostly in the CI pipeline
+# 
+# It will search for all OP clients in a specified kurtosis enclave
+# and will dump their logs in a CI-friendly manner
+# 
+# Usage:
+# 
+# ./kurtosis-dump-logs.sh <ENCLAVE_NAME>
+# 
+# 
+
+# Just so that we don't repeat ourselves
+ENCLAVES_API_URL=http://127.0.0.1:9779/api/enclaves
+
+# We pass the enclave name and the target block as script arguments
+ENCLAVE_NAME=$1
+if [ -z "$ENCLAVE_NAME" ]; then
+    echo "Please specify the enclave name as the first parameter"
+    exit 1
+fi
+
+echo "Dumping logs of the OP services for enclave $ENCLAVE_NAME"
+
+# Get the enclave UUID from the API
+# 
+# The | values at the end of the j1 transformation will convert null to an empty string
+ENCLAVE_ID=$(curl -s $ENCLAVES_API_URL | jq -r 'to_entries | map(select(.value.name == "'$ENCLAVE_NAME'")) | .[0].key | values')
+
+# Make sure we got something
+if [ -z "$ENCLAVE_ID" ]; then
+    echo "No enclave found for enclave $ENCLAVE_NAME"
+    exit 1
+fi
+
+echo "Got enclave UUID: $ENCLAVE_ID"
+
+# Now get all the service names
+ENCLAVE_SERVICES=$(curl -s $ENCLAVES_API_URL/$ENCLAVE_ID/services)
+ENCLAVE_SERVICES_NAMES=$(echo $ENCLAVE_SERVICES | jq -r 'keys_unsorted | join(" ")')
+
+# Make sure we got something
+if [ -z "$ENCLAVE_SERVICES_NAMES" ]; then
+    echo "No clients found for enclave $ENCLAVE_NAME"
+    exit 0
+fi
+
+echo "Got enclave services: $ENCLAVE_SERVICES_NAMES"
+
+# Convert the list into a bash array
+ENCLAVE_SERVICE_NAMES_ARRAY=($ENCLAVE_SERVICES_NAMES)
+
+# Iterate over the names/RPC ports arrays
+for SERVICE_NAME in "${ENCLAVE_SERVICE_NAMES_ARRAY[@]}"; do
+    # We use the github actions grouping to get a nicer output
+    echo "::group::$SERVICE_NAME"
+    kurtosis service logs -a $ENCLAVE_NAME $SERVICE_NAME
+    echo "::endgroup::"
+done

--- a/.github/workflows/actions/run-kurtosis-docker/action.yaml
+++ b/.github/workflows/actions/run-kurtosis-docker/action.yaml
@@ -7,9 +7,6 @@ inputs:
   enclave:
     description: "Kurtosis enclave name"
     default: "devnet"
-  artifact-key:
-    description: "Unique key for logs artifact upload"
-    default: ""
 
 runs:
   using: "composite"
@@ -32,9 +29,15 @@ runs:
       if: ${{ always() }}
       run: kurtosis dump ./.kurtosis-dump
 
+    - name: Create log artifact key
+      if: ${{ always() }}
+      shell: bash
+      id: create-artifact-key
+      run: echo "artifact-key=$(echo "${{ inputs.args-file || 'no-args' }}" | tr '/.' '__')" >> $GITHUB_OUTPUT
+
     - name: Store kurtosis logs
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
-        name: kurtosis-dump-${{ inputs.enclave }}${{ inputs.artifact-key && format('-{0}', inputs.artifact-key) || '' }}
+        name: kurtosis-dump-${{ inputs.enclave }}-${{ steps.create-artifact-key.outputs.artifact-key }}
         path: ./.kurtosis-dump/enclaves/

--- a/.github/workflows/actions/run-kurtosis-docker/action.yaml
+++ b/.github/workflows/actions/run-kurtosis-docker/action.yaml
@@ -7,6 +7,9 @@ inputs:
   enclave:
     description: "Kurtosis enclave name"
     default: "devnet"
+  artifact-key:
+    description: "Unique key for logs artifact upload"
+    default: ""
 
 runs:
   using: "composite"
@@ -15,14 +18,23 @@ runs:
       shell: bash
       run: kurtosis run . ${{ inputs.args-file && format('--args-file={0}', inputs.args-file) || '' }} --enclave=${{ inputs.enclave }} --verbosity detailed
 
-    - name: Dump kurtosis logs
+    - name: Assert that clients advance
       shell: bash
-      if: ${{ failure() }}
+      run: ./.github/scripts/kurtosis-check-block-progression.sh ${{ inputs.enclave }}
+
+    - name: Dump kurtosis logs to console
+      shell: bash
+      if: ${{ always() }}
+      run: ./.github/scripts/kurtosis-dump-logs.sh ${{ inputs.enclave }}
+
+    - name: Dump kurtosis logs to artifacts
+      shell: bash
+      if: ${{ always() }}
       run: kurtosis dump ./.kurtosis-dump
 
     - name: Store kurtosis logs
-      if: ${{ failure() }}
+      if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
-        name: kurtosis-logs
+        name: kurtosis-dump-${{ inputs.enclave }}${{ inputs.artifact-key && format('-{0}', inputs.artifact-key) || '' }}
         path: ./.kurtosis-dump/enclaves/

--- a/.github/workflows/actions/setup-environment/action.yaml
+++ b/.github/workflows/actions/setup-environment/action.yaml
@@ -1,0 +1,13 @@
+name: Setup environment
+description: Sets up the environment for CI pipelines
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install mise
+      uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
+      with:
+        version: v1.3.2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,9 +26,9 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        
+      - name: Setup environment
+        uses: ./.github/workflows/actions/setup-environment
 
       - name: Run Starlark
         run: kurtosis run ${{ github.workspace }} --verbosity detailed --args-file ${{ matrix.file_name }} || echo "TEST_FAILED=true" >> $GITHUB_ENV
@@ -60,8 +60,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - name: Setup environment
+        uses: ./.github/workflows/actions/setup-environment
 
       - name: Deploy L1
         run: kurtosis run --enclave test --args-file ./.github/tests/external-l1/ethereum.yaml github.com/ethpandaops/ethereum-package

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - name: Setup environment
+        uses: ./.github/workflows/actions/setup-environment
       
       - name: Run kurtosis
         uses: ./.github/workflows/actions/run-kurtosis-docker
@@ -37,8 +37,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - name: Setup environment
+        uses: ./.github/workflows/actions/setup-environment
 
       - name: Run kurtosis
         uses: ./.github/workflows/actions/run-kurtosis-docker
@@ -55,8 +55,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - name: Setup environment
+        uses: ./.github/workflows/actions/setup-environment
 
       - name: Run lint
         run: just lint
@@ -68,8 +68,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - name: Setup environment
+        uses: ./.github/workflows/actions/setup-environment
 
       - name: Run unit tests
         run: just test


### PR DESCRIPTION
Based on [my PR to `op-reth`](https://github.com/ethereum-optimism/op-reth/pull/57)

**Description**

- Adds a smoke test that checks the block progression of the network under test
- Adds a helper script that dumps logs formatted for github UI (using the collapsible groups)
- Always stores log artifacts - there seem to be cases when the pipeline is green yet something somewhere did not go well (currently investigating two issues where this happened)
- Encapsulate setup action into its own composite action not to duplicate code all over the place. Unfortunately, since the workflow needs to have the repo code in order to run this action, we cannot smack the checkout there as well