### PR TITLE
chore: Dynamic healthcheck  interval for conductor

### DIFF
--- a/src/conductor/input_parser.star
+++ b/src/conductor/input_parser.star
@@ -13,7 +13,7 @@ _DEFAULT_ARGS = {
     "pprof_enabled": False,
     "websocket_enabled": False,
     # Optional overrides
-    "healthcheck_interval": 2,
+    "healthcheck_interval": None,
     "healthcheck_min_peer_count": 1,
     "raft_snapshot_threshold": 1024,
     "raft_heartbeat_timeout": "900ms",
@@ -54,6 +54,13 @@ def parse(
     # Add the service name
     conductor_params["service_name"] = "op-conductor-{}-{}-{}".format(
         network_id, network_name, participant_name
+    )
+
+    # Default the healthcheck interval to the recommended value
+    conductor_params["healthcheck_interval"] = (
+        int(conductor_params["healthcheck_interval"])
+        if conductor_params["healthcheck_interval"]
+        else 2 * network_params.seconds_per_slot + 1
     )
 
     # Add ports

--- a/test/conductor/input_parser_test.star
+++ b/test/conductor/input_parser_test.star
@@ -199,7 +199,7 @@ def test_conductor_input_parser_websocket_enabled(plan):
             bootstrap=False,
             pprof_enabled=False,
             websocket_enabled=True,
-            healthcheck_interval=2,
+            healthcheck_interval=5,
             healthcheck_min_peer_count=1,
             raft_heartbeat_timeout="900ms",
             raft_lease_timeout="550ms",

--- a/test/conductor/input_parser_test.star
+++ b/test/conductor/input_parser_test.star
@@ -3,7 +3,7 @@ _input_parser = import_module("/src/conductor/input_parser.star")
 _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
-_default_network_params = struct(network_id=1000, name="my-l2")
+_default_network_params = struct(network_id=1000, name="my-l2", seconds_per_slot=2)
 _default_participant_index = 0
 _default_participant_name = "node0"
 _default_registry = _registry.Registry()
@@ -69,7 +69,7 @@ def test_conductor_input_parser_default_args_enabled(plan):
         bootstrap=False,
         pprof_enabled=False,
         websocket_enabled=False,
-        healthcheck_interval=2,
+        healthcheck_interval=5,
         healthcheck_min_peer_count=1,
         raft_heartbeat_timeout="900ms",
         raft_lease_timeout="550ms",
@@ -98,6 +98,7 @@ def test_conductor_input_parser_custom_params(plan):
         conductor_args={
             "enabled": True,
             "image": "op-conductor:brightest",
+            "healthcheck_interval": 4,
         },
         network_params=_default_network_params,
         participant_index=_default_participant_index,
@@ -129,7 +130,7 @@ def test_conductor_input_parser_custom_params(plan):
             bootstrap=False,
             pprof_enabled=False,
             websocket_enabled=False,
-            healthcheck_interval=2,
+            healthcheck_interval=4,
             healthcheck_min_peer_count=1,
             raft_heartbeat_timeout="900ms",
             raft_lease_timeout="550ms",

--- a/test/da/input_parser_test.star
+++ b/test/da/input_parser_test.star
@@ -3,10 +3,7 @@ _input_parser = import_module("/src/da/input_parser.star")
 _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
-_default_network_params = struct(
-    network_id=1000,
-    name="my-l2",
-)
+_default_network_params = struct(network_id=1000, name="my-l2", seconds_per_slot=2)
 _default_registry = _registry.Registry()
 
 

--- a/test/flashblocks/flashblocks-rpc/input_parser_test.star
+++ b/test/flashblocks/flashblocks-rpc/input_parser_test.star
@@ -1,10 +1,7 @@
 _input_parser = import_module("/src/flashblocks/flashblocks-rpc/input_parser.star")
 _registry = import_module("/src/package_io/registry.star")
 
-_default_network_params = struct(
-    network_id=1000,
-    name="my-l2",
-)
+_default_network_params = struct(network_id=1000, name="my-l2", seconds_per_slot=2)
 _default_registry = _registry.Registry()
 
 

--- a/test/flashblocks/flashblocks-web-proxy/input_parser_test.star
+++ b/test/flashblocks/flashblocks-web-proxy/input_parser_test.star
@@ -4,10 +4,7 @@ _input_parser = import_module(
 _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
-_default_network_params = struct(
-    network_id=1000,
-    name="my-l2",
-)
+_default_network_params = struct(network_id=1000, name="my-l2", seconds_per_slot=2)
 _default_registry = _registry.Registry()
 
 

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -3,10 +3,7 @@ input_parser = import_module("/src/l2/participant/input_parser.star")
 _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
-_default_network_params = struct(
-    network_id=1000,
-    name="my-l2",
-)
+_default_network_params = struct(network_id=1000, name="my-l2", seconds_per_slot=2)
 _default_registry = _registry.Registry()
 
 _shared_defaults = {
@@ -325,7 +322,7 @@ def test_l2_participant_input_parser_defaults_conductor_enabled(plan):
             bootstrap=False,
             pprof_enabled=False,
             websocket_enabled=False,
-            healthcheck_interval=2,
+            healthcheck_interval=5,
             healthcheck_min_peer_count=1,
             raft_heartbeat_timeout="900ms",
             raft_lease_timeout="550ms",

--- a/test/mev/input_parser_test.star
+++ b/test/mev/input_parser_test.star
@@ -3,7 +3,7 @@ _input_parser = import_module("/src/mev/input_parser.star")
 _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
-_default_network_params = struct(network_id=1000, name="my-l2")
+_default_network_params = struct(network_id=1000, name="my-l2", seconds_per_slot=2)
 _default_participant_index = 0
 _default_participant_name = "node0"
 _default_registry = _registry.Registry()

--- a/test/proposer/input_parser_test.star
+++ b/test/proposer/input_parser_test.star
@@ -3,10 +3,7 @@ input_parser = import_module("/src/proposer/input_parser.star")
 _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
-_default_network_params = struct(
-    network_id=1000,
-    name="my-l2",
-)
+_default_network_params = struct(network_id=1000, name="my-l2", seconds_per_slot=2)
 _default_registry = _registry.Registry()
 
 

--- a/test/proposer/op-proposer/launcher_test.star
+++ b/test/proposer/op-proposer/launcher_test.star
@@ -21,6 +21,7 @@ _default_network_params = struct(
     network="kurtosis",
     network_id=1000,
     name="network0",
+    seconds_per_slot=2,
 )
 _default_deployment_output = "{}"
 

--- a/test/proxyd/input_parser_test.star
+++ b/test/proxyd/input_parser_test.star
@@ -6,6 +6,7 @@ _registry = import_module("/src/package_io/registry.star")
 _default_network_params = struct(
     network_id=1000,
     name="my-l2",
+    seconds_per_slot=2,
 )
 _default_participants_params = [
     struct(

--- a/test/signer/input_parser_test.star
+++ b/test/signer/input_parser_test.star
@@ -3,10 +3,7 @@ _input_parser = import_module("/src/signer/input_parser.star")
 _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
-_default_network_params = struct(
-    network_id=1000,
-    name="my-l2",
-)
+_default_network_params = struct(network_id=1000, name="my-l2", seconds_per_slot=2)
 _default_registry = _registry.Registry()
 
 

--- a/test/tx_fuzzer/input_parser_test.star
+++ b/test/tx_fuzzer/input_parser_test.star
@@ -3,10 +3,7 @@ _input_parser = import_module("/src/tx-fuzzer/input_parser.star")
 _net = import_module("/src/util/net.star")
 _registry = import_module("/src/package_io/registry.star")
 
-_default_network_params = struct(
-    network_id=1000,
-    name="my-l2",
-)
+_default_network_params = struct(network_id=1000, name="my-l2", seconds_per_slot=2)
 _default_registry = _registry.Registry()
 
 


### PR DESCRIPTION
**Description**

Supplying a dynamic healthcheck interval that defaults to `2 * blocktime + 1`

Related to https://github.com/ethereum-optimism/optimism/issues/16514