### PR TITLE
feat: Add operatorFeeVaultRecipient to intent_chain

### DIFF
--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -176,6 +176,9 @@ def _build_chain_intent(
             "sequencerFeeVaultRecipient": read_chain_cmd(
                 "sequencerFeeVaultRecipient", chain_id
             ),
+            "operatorFeeVaultRecipient": read_chain_cmd(
+                "operatorFeeVaultRecipient", chain_id
+            ),
             "roles": {
                 "batcher": read_chain_cmd("batcher", chain_id),
                 "challenger": read_chain_cmd("challenger", chain_id),

--- a/static_files/scripts/fund.sh
+++ b/static_files/scripts/fund.sh
@@ -10,7 +10,7 @@ nonce=$(cast nonce "$addr")
 deployer_addr=$(cast wallet address "$DEPLOYER_PRIVATE_KEY")
 
 mnemonic="test test test test test test test test test test test junk"
-roles=("l2ProxyAdmin" "l1ProxyAdmin" "baseFeeVaultRecipient" "l1FeeVaultRecipient" "sequencerFeeVaultRecipient" "systemConfigOwner")
+roles=("l2ProxyAdmin" "l1ProxyAdmin" "baseFeeVaultRecipient" "l1FeeVaultRecipient" "sequencerFeeVaultRecipient" "operatorFeeVaultRecipient" "systemConfigOwner")
 funded_roles=("proposer" "batcher" "sequencer" "challenger")
 
 IFS=',';read -r -a chain_ids <<< "$1"


### PR DESCRIPTION
Th current optimism-package for optimism 1.16.2 raises the error(`chain has a fee vault set to zero address`) due to it doesnt' contain `operatorFeeVaultRecipient`.

```bash
2025/11/16 11:44:13 Error: error deploying environment: error deploying kurtosis package: execution error: An error occurred executing instruction (number 49) at github.com/yoshidan/optimism-package/src/contracts/contract_deployer.star[389:37]:                                                                                                                                        
run_sh(name="op-deployer-apply", run="op-deployer apply --l1-rpc-url $L1_RPC_URL --private-key $PRIVATE_KEY --workdir /network-data && op-deployer inspect genesis --workdir /network-data --outfile /network-data/genesis-2151908.json 2151908 && op-deployer inspect rollup --workdir /network-data --outfile /network-data/rollup-2151908.json 2151908", image="op-deployer:23d8cc8b91d1", files={"/contracts-d26c7ac6c44f47999754b2983c7d20c38ebda4dbe080bd77633b379b1c6d88c5": "contracts-d26c7ac6c44f47999754b2983c7d20c38ebda4dbe080bd77633b379b1c6d88c5", "/network-data": "op-deployer-configs"}, store=[StoreSpec(src="/network-data", name="op-deployer-configs")], env_vars={"CL_RPC_URL": "http://{{kurtosis:87ad44291d02453faabaee39c70aea80:ip_address.runtime_value}}:4000", "DEPLOYER_CACHE_DIR": "/var/cache/op-deployer", "L1_BLOCK_TIME": "6", "L1_CHAIN_ID": "3151908", "L1_RPC_KIND": "standard", "L1_RPC_URL": "http://{{kurtosis:85f7a552808e495499e2741b11a21c07:ip_address.runtime_value}}:8545", "L1_WS_URL": "ws://{{kurtosis:85f7a552808e495499e2741b11a21c07:ip_address.runtime_value}}:8546", "PRIVATE_KEY": "eaba42282ad33c8ef2524f07277c03a776d98ae19f581990ce75becb7cfa1c23", "WEB3_RPC_URL": "http://{{kurtosis:85f7a552808e495499e2741b11a21c07:ip_address.runtime_value}}:8545"}, description="Apply L2 contract deployments")               
 --- at /home/circleci/project/core/server/api_container/server/startosis_engine/startosis_executor.go:164 (sendErrorAndFail) ---                                                             
Caused by: Run sh returned exit code '1' that is not part of the acceptable status codes '[0]', with output:                                                                                  
  "Application failed: failed to validate intent-type=custom: chain has a fee vault set to zero address: chainId=0x000000000000000000000000000000000000000000000000000000000020d5e4\n"        
 --- at /home/circleci/project/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go:368 (RunShCapabilities.Execute) --- 
```

Optimism 1.16.2 requires `operatorFeeVaultRecipient`.

https://github.com/ethereum-optimism/optimism/blob/1b8c541060f0d323a7023fbc68fbbc8daf674340/op-deployer/pkg/deployer/state/chain_intent.go#L122

